### PR TITLE
Tdarr_Plugin_lmg1_Reorder_Streams plugin

### DIFF
--- a/Community/Tdarr_Plugin_lmg1_Reorder_Streams.js
+++ b/Community/Tdarr_Plugin_lmg1_Reorder_Streams.js
@@ -1,6 +1,3 @@
-
-
-
 function details() {
 
   return {

--- a/Community/Tdarr_Plugin_lmg1_Reorder_Streams.js
+++ b/Community/Tdarr_Plugin_lmg1_Reorder_Streams.js
@@ -1,0 +1,69 @@
+
+
+
+function details() {
+
+  return {
+    id: "Tdarr_Plugin_lmg1_Reorder_Streams",
+    Name: "Tdarr_Plugin_lmg1_Reorder_Streams ",
+    Type: "Video",
+    Description: `This plugin will move the video stream to the front so Tdarr will recognize the codec correctly.\n\n`,
+    Version: "1.00",
+    Link: "https://github.com/luigi311/Tdarr_Plugin_lmg1_Reorder_Streams"
+  }
+
+}
+
+function plugin(file) {
+
+  //Must return this object
+
+  var response = {
+
+    processFile : false,
+    preset : '',
+    container : '.mp4',
+    handBrakeMode : false,
+    FFmpegMode : false,
+    reQueueAfter : false,
+    infoLog : '',
+
+  }
+
+  if (file.fileMedium !== "video") {
+
+    console.log("File is not video")
+
+    response.infoLog += " File is not video\n"
+    response.processFile = false;
+
+    return response
+
+  } else {
+
+    response.FFmpegMode = true
+    response.container = '.' + file.container
+
+    if(file.ffProbeData.streams[0].codec_type != 'video') {
+
+      response.infoLog += "Video is not in the first stream"
+      response.preset = ',-map 0:v? -map 0:a? -map 0:s? -map 0:d? -map 0:t? -c copy'
+      response.reQueueAfter = false;
+      response.processFile = true;
+
+      return response
+
+    } else {
+
+      response.infoLog += "File has video in first stream\n"
+
+    }
+
+    response.infoLog += " File meets conditions!\n"
+    return response
+
+  }
+}
+
+module.exports.details = details;
+module.exports.plugin = plugin;


### PR DESCRIPTION
This plugin will reorder the media streams if the first stream is not the video stream. This will fix the issue with Tdarr showing the codec as something like aac for videos and causing things to be transcoded if they do not have too. This will keep everything that is in the file and just reorder it. This should be applied prior to everything to make sure that Tdarr is reading the right video codec for its next checks.