### PR TITLE
Account for Null Value in Bitrate

### DIFF
--- a/Community/Tdarr_Plugin_d5d3_iiDrakeii_FFMPEG_NVENC_Tiered_MKV.js
+++ b/Community/Tdarr_Plugin_d5d3_iiDrakeii_FFMPEG_NVENC_Tiered_MKV.js
@@ -81,7 +81,7 @@ function plugin(file) {
 //codec will be checked so it can be transcoded correctly
   if (file.video_resolution === "480p" || file.video_resolution === "576p" ) {
 	bitratecheck = 1000000;
-    if(bitrateprobe < bitratecheck) {
+    if(bitratecheck != null && bitrateprobe < bitratecheck) {
 	  bitratetarget = parseInt((bitrateprobe * .8) / 1024); // Lower Bitrate to 60% of original and convert to KB
 	  bitratemax = bitratetarget + 500;	// Set max bitrate to 6MB Higher	
     }
@@ -97,7 +97,7 @@ function plugin(file) {
 //codec will be checked so it can be transcoded correctly
   if(file.video_resolution === "720p") {
 	bitratecheck = 2000000;
-    if(bitrateprobe < bitratecheck) {
+    if(bitratecheck != null && bitrateprobe < bitratecheck) {
 	  bitratetarget = parseInt((bitrateprobe * .8) / 1024); // Lower Bitrate to 60% of original and convert to KB
 	  bitratemax = bitratetarget + 2000;	// Set max bitrate to 6MB Higher	
     }
@@ -113,7 +113,7 @@ function plugin(file) {
 //codec will be checked so it can be transcoded correctly
   if(file.video_resolution === "1080p") {
 	bitratecheck = 2500000;
-    if(bitrateprobe < bitratecheck) {
+    if(bitratecheck != null && bitrateprobe < bitratecheck) {
 	  bitratetarget = parseInt((bitrateprobe * .8) / 1024); // Lower Bitrate to 60% of original and convert to KB
 	  bitratemax = bitratetarget + 2500;	// Set max bitrate to 6MB Higher	
     }
@@ -129,7 +129,7 @@ function plugin(file) {
 //codec will be checked so it can be transcoded correctly
   if(file.video_resolution === "4KUHD") {
 	bitratecheck = 14000000;
-    if(bitrateprobe < bitratecheck) {
+    if(bitratecheck != null && bitrateprobe < bitratecheck) {
 	  bitratetarget = parseInt((bitrateprobe * .7) / 1024); // Lower Bitrate to 60% of original and convert to KB
 	  bitratemax = bitratetarget + 6000;	// Set max bitrate to 6MB Higher	
     }


### PR DESCRIPTION
Added does not equal null as modifier to lower then default to avoid 0 bitrate being input as a value.