### PR TITLE
Fix subs re-queue bug in therealshadoh plugins

### DIFF
--- a/Community/Tdarr_Plugin_z0ab_TheRealShadoh_FFmpeg_Subs_H264_Medium.js
+++ b/Community/Tdarr_Plugin_z0ab_TheRealShadoh_FFmpeg_Subs_H264_Medium.js
@@ -122,7 +122,7 @@ function plugin(file) {
       response.FFmpegMode = true
       return response
      }else{
-      response.infoLog += "☑File has no title metadata"
+      response.infoLog += "☑File has no title metadata \n"
      }
 
      if(!jsonString.includes("aac")){

--- a/Community/Tdarr_Plugin_z0ab_TheRealShadoh_FFmpeg_Subs_H264_Medium.js
+++ b/Community/Tdarr_Plugin_z0ab_TheRealShadoh_FFmpeg_Subs_H264_Medium.js
@@ -53,11 +53,9 @@ function plugin(file) {
      for (var i = 0; i < file.ffProbeData.streams.length; i++) {
 
        try {
-
-         if(file.ffProbeData.streams[i].codec_type.toLowerCase() == "subtitle"){
-
+         let streamData = file.ffProbeData.streams[i];
+         if(streamData.codec_type.toLowerCase() == "subtitle" && streamData.codec_name != "mov_text"){
            hasSubs = true
-
          }
        } catch (err) { }
      }
@@ -140,15 +138,14 @@ function plugin(file) {
 
      if(hasSubs){
 
-      response.infoLog += "☒File has subs \n"
+      response.infoLog += "☒File has incompatible subs \n"
       response.preset = ', -map 0:v -map 0:s? -map 0:a -c:v copy -c:a copy -c:s mov_text'
-      response.reQueueAfter = true;
       response.processFile = true;
       response.FFmpegMode = true
       return response
 
      }else{
-      response.infoLog += "☑File has no subs \n"
+      response.infoLog += "☑File has no/compatible subs \n"
      }
 
      response.infoLog += "☑File meets conditions! \n"


### PR DESCRIPTION
This fixes a previously mentioned https://github.com/HaveAGitGat/Tdarr_Plugins/pull/27 bug where files with sub's would endlessly re-queue under these plugins.

The plugin now only sets the subs to be converted if they're not `mov_text` and if not sets them to `mov_text`

I've only done it for one of the plugins for now but if everyone is happy with the changes I'll do the same to the others :) 