### PR TITLE
Migz Plugins: Bug Fixes

### DIFF
--- a/Community/Tdarr_Plugin_MC93_Migz2CleanTitle.js
+++ b/Community/Tdarr_Plugin_MC93_Migz2CleanTitle.js
@@ -6,14 +6,13 @@ function details() {
     Type: "Video",
 	Operation: "Clean",
     Description: `[TESTING]This plugin removes video title metadata if it exists. \n\n`,
-    Version: "1.00",
+    Version: "1.10",
     Link: ""
   }
 }
 
 function plugin(file) {
   var response = {
-
      processFile : false,
      preset : '',
      container: '.' + file.container,
@@ -35,18 +34,24 @@ function plugin(file) {
     return response
   }
   
-  if(file.meta.Title != undefined ){
-	  ffmpegCommandInsert += ` -metadata title="" `
-	  convert = true
-  }
+  try {
+    if (typeof file.meta.Title != 'undefined' ){
+	    ffmpegCommandInsert += ` -metadata title="" `
+		response.infoLog += "1"
+	    convert = true
+    }
+  } catch (err) { }
   
   for (var i = 0; i < file.ffProbeData.streams.length; i++) {
         if (file.ffProbeData.streams[i].codec_type.toLowerCase() == "video") {
-		    if (file.ffProbeData.streams[i].tags.title != undefined) {
-			    ffmpegCommandInsert += ` -metadata:s:v:${videoIdx} title="" `
-	  	        convert = true
-            }
-			videoIdx++
+		    try {
+		         if (typeof file.ffProbeData.streams[i].tags.title != 'undefined') {
+			     ffmpegCommandInsert += ` -metadata:s:v:${videoIdx} title="" `
+				 response.infoLog += "2"
+	  	         convert = true
+                }
+			} catch (err) { }
+     		videoIdx++
 		}
     }
   


### PR DESCRIPTION
1) Fixed bug with Migz1FFMPEG where sometimes duration was not available, get duration from stream 0, if duration still not available then exit plugin.

2) Fixed bug with Migz1FFMPEG where it would fail if using mkv and source has a data stream (mkv does not support data streams).

3) Fixed bug with Migz2CleanTitle where if title info did not exist at all it would fail rather then skip.