### PR TITLE
HQ Anime/Hand Drawn Animation Plugin

### DIFF
--- a/Community/Tdarr_Plugin_r002_rootuser_FFMPEG_HQ_HEVC_MKV_Animation.js
+++ b/Community/Tdarr_Plugin_r002_rootuser_FFMPEG_HQ_HEVC_MKV_Animation.js
@@ -1,0 +1,66 @@
+function details() {
+  return {
+    id: "Tdarr_Plugin_r002_rootuser_FFMPEG_HQ_HEVC_MKV_Animation",
+    Stage: "Pre-processing",
+    Name: "FFMPEG HQ 10-bit HEVC MKV for Animation",
+    Type: "Video",
+    Operation:"Transcode",
+    Description: `High Quality FFMPEG transcoding settings for Animation. Converts all audio to AAC 512K. Preserves track names, metadata and attachments/fonts. Proper use of x265-params. CRF 18. Preset medium. 10-Bit Video encoding. Skips h.265 encoded videos. The output container is mkv. \n\n`,
+    Version: "1.1",
+    Link: "",
+    Tags:"pre-processing,ffmpeg,h265,aac,10bit,"
+  }
+}
+ 
+function plugin(file) {
+  var transcode = 0; //if this var changes to 1 the file will be transcoded
+ 
+//default values that will be returned
+  var response = {
+    processFile: false,
+    preset: '',
+    container: '.mkv',
+    handBrakeMode: false,
+    FFmpegMode: true,
+    reQueueAfter: true,
+    infoLog: ''
+  }
+ 
+//check if the file is a video, if not the function will be stopped immediately
+  if (file.fileMedium !== "video") {
+    response.processFile = false
+    response.infoLog += "☒File is not a video! \n"
+    return response
+  } else {
+    response.infoLog += "☑File is a video! \n"
+  }
+ 
+//check if the file is already hevc, it will not be transcoded if true and the function will be stopped immediately
+  if (file.ffProbeData.streams[0].codec_name == 'hevc') {
+    response.processFile = false
+    response.infoLog += "☑File is already in hevc! \n"
+    return response
+  }
+
+//Transcoding options
+  {
+    response.preset = ',-map 0 -c:s copy -movflags use_metadata_tags -c:a aac -b:a 512k -c:v:0 libx265 -preset medium -x265-params crf=18:tune=animation:qcomp=0.7:aq-strength=1.1 -pix_fmt yuv420p10le -f matroska'
+    transcode = 1;
+  }
+
+//check if the file is eligible for transcoding
+//if true the neccessary response values will be changed
+  if (transcode == 1) {
+    response.processFile = true;
+    response.FFmpegMode = true
+    response.reQueueAfter = true;
+    response.infoLog += `☒File is ${file.video_resolution} but is not hevc!\n`
+    response.infoLog += `☒File will be transcoded!\n`
+  }
+ 
+  return response
+}
+ 
+module.exports.details = details;
+ 
+module.exports.plugin = plugin;

--- a/Community/Tdarr_Plugin_r002_rootuser_FFMPEG_HQ_HEVC_MKV_Animation.js
+++ b/Community/Tdarr_Plugin_r002_rootuser_FFMPEG_HQ_HEVC_MKV_Animation.js
@@ -5,10 +5,10 @@ function details() {
     Name: "FFMPEG HQ 10-bit HEVC MKV for Animation",
     Type: "Video",
     Operation:"Transcode",
-    Description: `High Quality FFMPEG transcoding settings for Animation. Converts all audio to AAC 512K. Preserves track names, metadata and attachments/fonts. Proper use of x265-params. CRF 18. Preset medium. 10-Bit Video encoding. Skips h.265 encoded videos. The output container is mkv. \n\n`,
+    Description: `[Contains built-in filter] High Quality FFMPEG transcoding settings for Animation. Converts all audio to AAC 512K. Preserves track names, metadata and attachments/fonts. Proper use of x265-params. CRF 18. Preset medium. 10-Bit Video encoding. Skips h.265 encoded videos. The output container is mkv. \n\n`,
     Version: "1.1",
     Link: "",
-    Tags:"pre-processing,ffmpeg,h265,aac,10bit,"
+    Tags:"pre-processing,ffmpeg,h265,aac,10bit,anime,"
   }
 }
  


### PR DESCRIPTION
Specifically tuned for use with Animation, primarily Anime with English subtitles.  Preserves Subtitles; Metadata; Attachments; Fonts and Styling.  CRF 18 to keep as much quality as reasonable, while keeping file sizes low.  Audio converted to AAC 512K for compatibility.  Have used `x265-params`, as it seems the source script I used failed to do so, and the variables were not being read properly.  Medium preset, need a reasonably fast CPU/Server.  10-Bit video output to help curb banding.