### PR TITLE
Subtitle Fix

### DIFF
--- a/Community/Tdarr_Plugin_d5d3_iiDrakeii_FFMPEG_NVENC_Tiered_MKV.js
+++ b/Community/Tdarr_Plugin_d5d3_iiDrakeii_FFMPEG_NVENC_Tiered_MKV.js
@@ -101,7 +101,7 @@ function plugin(file) {
 //mitigate errors due to embeded pictures	  
 	  	  try {
   if ((file.ffProbeData.streams[i].codec_name.toLowerCase() == "png" || file.ffProbeData.streams[i].codec_name.toLowerCase() == "bmp" || file.ffProbeData.streams[i].codec_name.toLowerCase() == "mjpeg") && file.ffProbeData.streams[i].codec_type.toLowerCase() == "video" ) {
-	map = `-map 0:v:0 -map 0:a -map 0:s`
+	map = `-map 0:v:0 -map 0:a -map 0:s?`
     }
 	  }
 	  catch (err) { }


### PR DESCRIPTION
Added fix for subtitles per https://discordapp.com/channels/623392507828371476/626268797472604160/695001638628360212

Fixes error:
`
Stream map '0:s' matches no streams.
To ignore this, add a trailing '?' to the map.
`