### PR TITLE
Migz Plugins - Fixes

### DIFF
--- a/Community/Tdarr_Plugin_MC93_Migz1FFMPEG.js
+++ b/Community/Tdarr_Plugin_MC93_Migz1FFMPEG.js
@@ -48,7 +48,7 @@ function plugin(file, librarySettings, inputs) {
     preset: "",
     handBrakeMode: false,
     FFmpegMode: true,
-    reQueueAfter: false,
+    reQueueAfter: true,
     infoLog: "",
   };
 

--- a/Community/Tdarr_Plugin_MC93_Migz1FFMPEG.js
+++ b/Community/Tdarr_Plugin_MC93_Migz1FFMPEG.js
@@ -108,7 +108,7 @@ function plugin(file, librarySettings, inputs) {
 
   // Check if file is MKV, if so then add extra argument to drop data. MKV does not support data streams.
   if (inputs.container == "mkv") {
-    extraArguments += "-map -0:d ";
+    extraArguments += `-map -0:d `;
   }
 
   // Check if 10bit variable is true.

--- a/Community/Tdarr_Plugin_MC93_Migz1FFMPEG.js
+++ b/Community/Tdarr_Plugin_MC93_Migz1FFMPEG.js
@@ -48,7 +48,7 @@ function plugin(file, librarySettings, inputs) {
     preset: "",
     handBrakeMode: false,
     FFmpegMode: true,
-    reQueueAfter: true,
+    reQueueAfter: false,
     infoLog: "",
   };
 
@@ -60,11 +60,6 @@ function plugin(file, librarySettings, inputs) {
     return response;
   } else {
     response.container = "." + inputs.container;
-  }
-
-  // Check if file is MKV, if so then add extra argument to drop data. MKV does not support data streams.
-  if (inputs.container == "mkv") {
-    extraArguments += "-map -0:d ";
   }
 
   // Check if file is a video. If it isn't then exit plugin.
@@ -109,6 +104,11 @@ function plugin(file, librarySettings, inputs) {
       response.infoLog += `☑Current bitrate is below configured bitrate cutoff of ${inputs.bitrate_cutoff}. Nothing to do, cancelling plugin. \n`;
       return response;
     }
+  }
+
+  // Check if file is MKV, if so then add extra argument to drop data. MKV does not support data streams.
+  if (inputs.container == "mkv") {
+    extraArguments += "-map -0:d ";
   }
 
   // Check if 10bit variable is true.

--- a/Community/Tdarr_Plugin_MC93_Migz1FFMPEG_CPU.js
+++ b/Community/Tdarr_Plugin_MC93_Migz1FFMPEG_CPU.js
@@ -48,7 +48,7 @@ function plugin(file, librarySettings, inputs) {
     preset: "",
     handBrakeMode: false,
     FFmpegMode: true,
-    reQueueAfter: false,
+    reQueueAfter: true,
     infoLog: "",
   };
 

--- a/Community/Tdarr_Plugin_MC93_Migz1FFMPEG_CPU.js
+++ b/Community/Tdarr_Plugin_MC93_Migz1FFMPEG_CPU.js
@@ -108,7 +108,7 @@ function plugin(file, librarySettings, inputs) {
 
   // Check if file is MKV, if so then add extra argument to drop data. MKV does not support data streams.
   if (inputs.container == "mkv") {
-    extraArguments += "-map -0:d ";
+    extraArguments += `-map -0:d `;
   }
 
   // Check if 10bit variable is true.

--- a/Community/Tdarr_Plugin_MC93_Migz1FFMPEG_CPU.js
+++ b/Community/Tdarr_Plugin_MC93_Migz1FFMPEG_CPU.js
@@ -48,7 +48,7 @@ function plugin(file, librarySettings, inputs) {
     preset: "",
     handBrakeMode: false,
     FFmpegMode: true,
-    reQueueAfter: true,
+    reQueueAfter: false,
     infoLog: "",
   };
 
@@ -60,11 +60,6 @@ function plugin(file, librarySettings, inputs) {
     return response;
   } else {
     response.container = "." + inputs.container;
-  }
-
-  // Check if file is MKV, if so then add extra argument to drop data. MKV does not support data streams.
-  if (inputs.container == "mkv") {
-    extraArguments += "-map -0:d ";
   }
 
   // Check if file is a video. If it isn't then exit plugin.
@@ -109,6 +104,11 @@ function plugin(file, librarySettings, inputs) {
       response.infoLog += `☑Current bitrate is below configured bitrate cutoff of ${inputs.bitrate_cutoff}. Nothing to do, cancelling plugin. \n`;
       return response;
     }
+  }
+
+  // Check if file is MKV, if so then add extra argument to drop data. MKV does not support data streams.
+  if (inputs.container == "mkv") {
+    extraArguments += "-map -0:d ";
   }
 
   // Check if 10bit variable is true.

--- a/Community/Tdarr_Plugin_MC93_Migz4CleanSubs.js
+++ b/Community/Tdarr_Plugin_MC93_Migz4CleanSubs.js
@@ -109,7 +109,7 @@ function plugin(file, librarySettings, inputs) {
           file.ffProbeData.streams[i].tags.title.toLowerCase().includes("sdh"))
       ) {
         ffmpegCommandInsert += `-map -0:s:${subtitleIdx} `;
-        response.infoLog += `☒Subtitle stream detected as being Commentary or Description, removing. Subtitle stream 0:s:${SubtitleIdx} - ${file.ffProbeData.streams[i].tags.title}. \n`;
+        response.infoLog += `☒Subtitle stream detected as being Commentary or Description, removing. Subtitle stream 0:s:${subtitleIdx} - ${file.ffProbeData.streams[i].tags.title}. \n`;
         convert = true;
       }
     } catch (err) {}


### PR DESCRIPTION
Change both ffmpeg plugins reQueueAfter to false. These plugins should not need to be requeued and worked on again.

Move mkv data stream check to after extraArguments var creation so that it works as intended.
Updated mkv data check from "" to `` for consistency.

Correct typo in CleanSubs plugin. Thanks zzeneg for spotting this.