### PR TITLE
Update Tdarr_Plugin_MC93_Migz1FFMPEG_CPU.js

### DIFF
--- a/Community/Tdarr_Plugin_MC93_Migz1FFMPEG_CPU.js
+++ b/Community/Tdarr_Plugin_MC93_Migz1FFMPEG_CPU.js
@@ -65,7 +65,7 @@ function plugin(file, librarySettings, inputs) {
   };
 
   // Check if inputs.container has been configured. If it hasn't then exit plugin.
-  if (inputs.container == "") {
+  if (!inputs || inputs.container == "") {
     response.infoLog +=
       "☒Container has not been configured within plugin settings, please configure required options. Skipping this plugin. \n";
     response.processFile = false;


### PR DESCRIPTION
if `inputs` isn't defined, then `inputs.container` causes a plugin error that is not caught by the `if (inputs.container == "")`

this change checks the `inputs` first and if not defined, allows the plugin to be skipped properly.