### PR TITLE
Migz Plugins Update

### DIFF
--- a/Community/Tdarr_Plugin_MC93_Migz1FFMPEG_CPU.js
+++ b/Community/Tdarr_Plugin_MC93_Migz1FFMPEG_CPU.js
@@ -6,7 +6,7 @@ function details() {
     Type: "Video",
     Operation: "Transcode",
     Description: `Files not in H265 will be transcoded into H265 using CPU with ffmpeg, settings are dependant on file bitrate, working by the logic that H265 can support the same ammount of data at half the bitrate of H264. \n\n`,
-    Version: "1.4",
+    Version: "1.5",
     Link:
       "https://github.com/HaveAGitGat/Tdarr_Plugins/blob/master/Community/Tdarr_Plugin_MC93_Migz1FFMPEG_CPU.js",
     Tags: "pre-processing,ffmpeg,video only,configurable,h265",
@@ -41,8 +41,8 @@ function details() {
       {
         name: "force_conform",
         tooltip: `Make the file conform to output containers requirements.
-                \\n Drop hdmv_pgs_subtitle/eia_608/subrip subtitles for MP4.
-                \\n Drop data streams and mov_text/eia_608 subtitles for MKV.
+                \\n Drop hdmv_pgs_subtitle/eia_608/subrip/timed_id3 for MP4.
+                \\n Drop data streams/mov_text/eia_608/timed_id3 for MKV.
                 \\n Default is false.
   	            \\nExample:\\n
   	            true
@@ -127,7 +127,9 @@ function plugin(file, librarySettings, inputs) {
                 file.ffProbeData.streams[i].codec_name
                 .toLowerCase() == "mov_text" ||
                 file.ffProbeData.streams[i].codec_name
-                .toLowerCase() == "eia_608"
+                .toLowerCase() == "eia_608" ||
+                file.ffProbeData.streams[i].codec_name
+                .toLowerCase() == "timed_id3"
             ) {
                 extraArguments += `-map -0:${i} `;
             }
@@ -141,7 +143,9 @@ function plugin(file, librarySettings, inputs) {
                 file.ffProbeData.streams[i].codec_name
                 .toLowerCase() == "eia_608" ||
                 file.ffProbeData.streams[i].codec_name
-                .toLowerCase() == "subrip"
+                .toLowerCase() == "subrip" ||
+                file.ffProbeData.streams[i].codec_name
+                .toLowerCase() == "timed_id3"
             ) {
                 extraArguments += `-map -0:${i} `;
             }
@@ -197,7 +201,7 @@ function plugin(file, librarySettings, inputs) {
     (duration * 0.0075)
   )} \n Bitrate settings: \nTarget = ${targetBitrate} \nMinimum = ${minimumBitrate} \nMaximum = ${maximumBitrate} \n`;
 
-  response.preset += `,-map 0 -c:v libx265 ${bitrateSettings} -c:a copy -c:s copy -max_muxing_queue_size 4096 ${extraArguments}`;
+  response.preset += `,-map 0 -c:v libx265 ${bitrateSettings} -c:a copy -c:s copy -max_muxing_queue_size 9999 ${extraArguments}`;
   response.processFile = true;
   response.infoLog += `☒File is not hevc. Transcoding. \n`;
   return response;

--- a/Community/Tdarr_Plugin_MC93_Migz2CleanTitle.js
+++ b/Community/Tdarr_Plugin_MC93_Migz2CleanTitle.js
@@ -6,7 +6,7 @@ function details() {
     Type: "Video",
     Operation: "Clean",
     Description: `This plugin removes title metadata from video/audio/subtitles, if it exists. Video checking is mandatory, audio and subtitles are optional.\n\n`,
-    Version: "1.2",
+    Version: "1.3",
     Link:
       "https://github.com/HaveAGitGat/Tdarr_Plugins/blob/master/Community/Tdarr_Plugin_MC93_Migz2CleanTitle.js",
     Tags: "pre-processing,ffmpeg,configurable",
@@ -113,7 +113,7 @@ function plugin(file, librarySettings, inputs) {
   // Convert file if convert variable is set to true.
   if (convert == true) {
     response.infoLog += "☒File has title metadata. Removing \n";
-    response.preset = `,${ffmpegCommandInsert} -c copy -map 0 -max_muxing_queue_size 4096`;
+    response.preset = `,${ffmpegCommandInsert} -c copy -map 0 -max_muxing_queue_size 9999`;
     response.reQueueAfter = true;
     response.processFile = true;
   } else {

--- a/Community/Tdarr_Plugin_MC93_Migz3CleanAudio.js
+++ b/Community/Tdarr_Plugin_MC93_Migz3CleanAudio.js
@@ -6,7 +6,7 @@ function details() {
     Type: "Audio",
     Operation: "Clean",
     Description: `This plugin keeps only specified language audio tracks & can tags those that have an unknown language. \n\n`,
-    Version: "2.2",
+    Version: "2.3",
     Link:
       "https://github.com/HaveAGitGat/Tdarr_Plugins/blob/master/Community/Tdarr_Plugin_MC93_Migz3CleanAudio.js",
     Tags: "pre-processing,ffmpeg,audio only,configurable",
@@ -207,7 +207,7 @@ function plugin(file, librarySettings, inputs) {
   // Convert file if convert variable is set to true.
   if (convert === true) {
     response.processFile = true;
-    response.preset = `, -map 0 ${ffmpegCommandInsert} -c copy -max_muxing_queue_size 4096`;
+    response.preset = `, -map 0 ${ffmpegCommandInsert} -c copy -max_muxing_queue_size 9999`;
     response.container = "." + file.container;
     response.reQueueAfter = true;
   } else {

--- a/Community/Tdarr_Plugin_MC93_Migz4CleanSubs.js
+++ b/Community/Tdarr_Plugin_MC93_Migz4CleanSubs.js
@@ -6,7 +6,7 @@ function details() {
     Type: "subtitles",
     Operation: "Clean",
     Description: `This plugin keeps only specified language subtitle tracks & can tag those that have an unknown language. \n\n`,
-    Version: "2.2",
+    Version: "2.3",
     Link:
       "https://github.com/HaveAGitGat/Tdarr_Plugins/blob/master/Community/Tdarr_Plugin_MC93_Migz4CleanSubs.js",
     Tags: "pre-processing,ffmpeg,subtitle only,configurable",
@@ -158,7 +158,7 @@ function plugin(file, librarySettings, inputs) {
   // Convert file if convert variable is set to true.
   if (convert === true) {
     response.processFile = true;
-    response.preset = `, -map 0 ${ffmpegCommandInsert} -c copy -max_muxing_queue_size 4096`;
+    response.preset = `, -map 0 ${ffmpegCommandInsert} -c copy -max_muxing_queue_size 9999`;
     response.container = "." + file.container;
     response.reQueueAfter = true;
   } else {

--- a/Community/Tdarr_Plugin_MC93_Migz5ConvertAudio.js
+++ b/Community/Tdarr_Plugin_MC93_Migz5ConvertAudio.js
@@ -6,7 +6,7 @@ function details() {
     Type: "Audio",
     Operation: "Transcode",
     Description: `This plugin can convert any 2.0 audio track/s to AAC and can create downmixed audio tracks. \n\n`,
-    Version: "2.1",
+    Version: "2.2",
     Link: "",
     Tags: "pre-processing,ffmpeg,audio only,configurable",
     Inputs: [
@@ -140,7 +140,7 @@ function plugin(file, librarySettings, inputs) {
   // Convert file if convert variable is set to true.
   if (convert == true) {
     response.processFile = true;
-    response.preset = `, -map 0 -c:v copy -c:a copy ${ffmpegCommandInsert} -strict -2 -c:s copy -max_muxing_queue_size 4096 `;
+    response.preset = `, -map 0 -c:v copy -c:a copy ${ffmpegCommandInsert} -strict -2 -c:s copy -max_muxing_queue_size 9999 `;
   } else {
     response.infoLog += "☑File contains all required audio formats. \n";
     response.processFile = false;

--- a/Community/Tdarr_Plugin_MC93_Migz6OrderStreams.js
+++ b/Community/Tdarr_Plugin_MC93_Migz6OrderStreams.js
@@ -6,7 +6,7 @@ function details() {
     Type: "Streams",
     Operation: "Order",
     Description: `Orders streams into Video first, then Audio (2ch, 6ch, 8ch) and finally Subtitles. \n\n`,
-    Version: "1.1",
+    Version: "1.2",
     Link:
       "https://github.com/HaveAGitGat/Tdarr_Plugins/blob/master/Community/Tdarr_Plugin_MC93_Migz6OrderStreams.js",
     Tags: "pre-processing,ffmpeg,",
@@ -173,7 +173,7 @@ function plugin(file) {
   // Convert file if convert variable is set to true.
   if (convert == true) {
     response.processFile = true;
-    response.preset = `,${ffmpegCommandInsert} -c copy -max_muxing_queue_size 4096`;
+    response.preset = `,${ffmpegCommandInsert} -c copy -max_muxing_queue_size 9999`;
     response.reQueueAfter = true;
     response.infoLog +=
       "☒ Streams are out of order, reorganizing streams. Video, Audio, Subtitles. \n";

--- a/Community/Tdarr_Plugin_MC93_MigzImageRemoval.js
+++ b/Community/Tdarr_Plugin_MC93_MigzImageRemoval.js
@@ -6,7 +6,7 @@ function details() {
     Type: "Video",
     Operation: "Clean",
     Description: `Identify any unwanted image formats in the file and remove those streams. MJPEG & PNG \n\n`,
-    Version: "1.1",
+    Version: "1.2",
     Link:
       "https://github.com/HaveAGitGat/Tdarr_Plugins/blob/master/Community/Tdarr_Plugin_MC93_MigzImageRemoval.js",
     Tags: "pre-processing,ffmpeg,video only",
@@ -55,7 +55,7 @@ function plugin(file, librarySettings, inputs) {
 
   // Convert file if convert variable is set to true.
   if (convert === true) {
-    response.preset += `,-map 0 -c copy -max_muxing_queue_size 4096 ${extraArguments}`;
+    response.preset += `,-map 0 -c copy -max_muxing_queue_size 9999 ${extraArguments}`;
     response.infoLog += `☒File has image format stream, removing. \n`;
     response.processFile = true;
   } else {


### PR DESCRIPTION
1) Add input to enable bframes. - ffmpegGPU plugin

2) Add timed_id3 has codec type to remove for mkv/mp4 if force_conform is enabled. - Both ffmpeg plugins

3) max_muxing_queue_size change to 9999 as this number is still too low in some cases.