### PR TITLE
Migz Plugins

### DIFF
--- a/Community/Tdarr_Plugin_MC93_Migz1FFMPEG_CPU.js
+++ b/Community/Tdarr_Plugin_MC93_Migz1FFMPEG_CPU.js
@@ -5,8 +5,8 @@ function details() {
     Name: "Migz-Transcode Using CPU & FFMPEG",
     Type: "Video",
     Operation: "Transcode",
-    Description: `Files not in H265 will be transcoded into H265 using CPU with ffmpeg, settings are dependant on file bitrate, working by the logic that H265 can support the same ammount of data at half the bitrate of H264. \n\n`,
-    Version: "1.6",
+    Description: `Files not in H265 will be transcoded into H265 using CPU with ffmpeg, settings are dependant on file bitrate, working by the logic that H265 can support the same ammount of data at half the bitrate of H264. \n This plugin will  skip any files that are in the VP9 codec as these are already at a comparable compression level to H265.\n\n`,
+    Version: "1.7",
     Link:
       "https://github.com/HaveAGitGat/Tdarr_Plugins/blob/master/Community/Tdarr_Plugin_MC93_Migz1FFMPEG_CPU.js",
     Tags: "pre-processing,ffmpeg,video only,configurable,h265",
@@ -169,21 +169,21 @@ function plugin(file, librarySettings, inputs) {
           if (file.ffProbeData.streams[i].codec_name == "mjpeg" || file.ffProbeData.streams[i].codec_name == "png") {
             extraArguments += `-map -v:${videoIdx} `;
         }
-      // Check if codec of stream is hevc AND check if file.container matches inputs.container. If so nothing for plugin to do.
+      // Check if codec of stream is hevc or vp9 AND check if file.container matches inputs.container. If so nothing for plugin to do.
       if (
-        file.ffProbeData.streams[i].codec_name == "hevc" &&
+        file.ffProbeData.streams[i].codec_name == "hevc" || file.ffProbeData.streams[i].codec_name == "vp9" &&
         file.container == inputs.container
       ) {
         response.processFile = false;
-        response.infoLog += `☑File is already hevc & in ${inputs.container}. \n`;
+        response.infoLog += `☑File is already hevc or vp9 & in ${inputs.container}. \n`;
         return response;
       }
-      // Check if codec of stream is hevc AND check if file.container does NOT match inputs.container. If so remux file.
+      // Check if codec of stream is hevc or vp9 AND check if file.container does NOT match inputs.container. If so remux file.
       if (
-        file.ffProbeData.streams[i].codec_name == "hevc" &&
+        file.ffProbeData.streams[i].codec_name == "hevc" || file.ffProbeData.streams[i].codec_name == "vp9" &&
         file.container != "${inputs.container}"
       ) {
-        response.infoLog += `☒File is hevc but is not in ${inputs.container} container. Remuxing. \n`;
+        response.infoLog += `☒File is hevc or vp9 but is not in ${inputs.container} container. Remuxing. \n`;
         response.preset = `, -map 0 -c copy ${extraArguments}`;
         response.processFile = true;
         return response;
@@ -205,7 +205,7 @@ function plugin(file, librarySettings, inputs) {
 
   response.preset += `,-map 0 -c:v libx265 ${bitrateSettings} -c:a copy -c:s copy -max_muxing_queue_size 9999 ${extraArguments}`;
   response.processFile = true;
-  response.infoLog += `☒File is not hevc. Transcoding. \n`;
+  response.infoLog += `☒File is not hevc or vp9. Transcoding. \n`;
   return response;
 }
 module.exports.details = details;


### PR DESCRIPTION
1) Bug fix for CleanTitle where if the title of an audio/substeam didn't exist it would exit that loop but not increment the Id of the track. Was causing the plugin to loop in some cases.

2) Modify both FFMPEG plugins to treat VP9 codec in a similiar way to HEVC. I.e if a file is already in VP9 codec don't transcode it to HEVC as VP9 is already heavily compressed in a similiar way to HEVC. Plugin itself still outputs files as HEVC