### PR TITLE
Migz Plugins Update

### DIFF
--- a/Community/Tdarr_Plugin_MC93_Migz1FFMPEG.js
+++ b/Community/Tdarr_Plugin_MC93_Migz1FFMPEG.js
@@ -7,10 +7,10 @@ function details() {
     Type: 'Video',
     Operation: 'Transcode',
     Description: `Files not in H265 will be transcoded into H265 using Nvidia GPU with ffmpeg.
-                  \\n Settings are dependant on file bitrate
-                  \\n Working by the logic that H265 can support the same ammount of data at half the bitrate of H264.
-                  \\n NVDEC & NVENC compatable GPU required.
-                  \\n This plugin will skip any files that are in the VP9 codec. \n\n`,
+                  Settings are dependant on file bitrate
+                  Working by the logic that H265 can support the same ammount of data at half the bitrate of H264.
+                  NVDEC & NVENC compatable GPU required.
+                  This plugin will skip any files that are in the VP9 codec.`,
     Version: '3.0',
     Link: 'https://github.com/HaveAGitGat/Tdarr_Plugins/blob/master/Community/Tdarr_Plugin_MC93_Migz1FFMPEG.js',
     Tags: 'pre-processing,ffmpeg,video only,nvenc h265,configurable',

--- a/Community/Tdarr_Plugin_MC93_Migz1FFMPEG_CPU.js
+++ b/Community/Tdarr_Plugin_MC93_Migz1FFMPEG_CPU.js
@@ -6,10 +6,10 @@ function details() {
     Name: 'Migz-Transcode Using CPU & FFMPEG',
     Type: 'Video',
     Operation: 'Transcode',
-    Description: `Files not in H265 will be transcoded into H265 using Nvidia GPU with ffmpeg.
-                  \\n Settings are dependant on file bitrate
-                  \\n Working by the logic that H265 can support the same ammount of data at half the bitrate of H264.
-                  \\n This plugin will skip any files that are in the VP9 codec. \n\n`,
+    Description: `Files not in H265 will be transcoded into H265 using CPU with ffmpeg.
+                Settings are dependant on file bitrate
+				Working by the logic that H265 can support the same ammount of data at half the bitrate of H264.
+				This plugin will  skip any files that are in the VP9 codec.`,
     Version: '1.9',
     Link: 'https://github.com/HaveAGitGat/Tdarr_Plugins/blob/master/Community/Tdarr_Plugin_MC93_Migz1FFMPEG_CPU.js',
     Tags: 'pre-processing,ffmpeg,video only,configurable,h265',

--- a/Community/Tdarr_Plugin_MC93_Migz1FFMPEG_CPU.js
+++ b/Community/Tdarr_Plugin_MC93_Migz1FFMPEG_CPU.js
@@ -8,8 +8,8 @@ function details() {
     Operation: 'Transcode',
     Description: `Files not in H265 will be transcoded into H265 using CPU with ffmpeg.
                 Settings are dependant on file bitrate
-				Working by the logic that H265 can support the same ammount of data at half the bitrate of H264.
-				This plugin will  skip any files that are in the VP9 codec.`,
+                Working by the logic that H265 can support the same ammount of data at half the bitrate of H264.
+                This plugin will  skip any files that are in the VP9 codec.`,
     Version: '1.9',
     Link: 'https://github.com/HaveAGitGat/Tdarr_Plugins/blob/master/Community/Tdarr_Plugin_MC93_Migz1FFMPEG_CPU.js',
     Tags: 'pre-processing,ffmpeg,video only,configurable,h265',


### PR DESCRIPTION
Just a small description field only update, no changes to how the plugins themselves actually work.

1) Update CPU plugin description as it mentions using a GPU which is incorrect.

2) Update CPU & GPU plugins to remove `\n` and `\\n` from the description fields as the description field doesn't seem to use these as new lines and were instead displaying as text.