### PR TITLE
Update Tdarr_Plugin_henk_Add_Specific_Audio_Codec.js

### DIFF
--- a/Community/Tdarr_Plugin_henk_Add_Specific_Audio_Codec.js
+++ b/Community/Tdarr_Plugin_henk_Add_Specific_Audio_Codec.js
@@ -64,8 +64,8 @@ function plugin(file, librarySettings, inputs) {
 
   for (let i = 0; i < file.ffProbeData.streams.length; i += 1) {
     const currStream = file.ffProbeData.streams[i];
-    if (currStream.tags.COPYRIGHT) {
-      if (currStream.tags.COPYRIGHT === 'henk_asac') {
+    if (currStream.codec_type.toLowerCase() === 'audio' && currStream.tags.copyright) {
+      if (currStream.tags.copyright === 'henk_asac') {
         killPlugin = true;
       }
     }

--- a/Community/Tdarr_Plugin_henk_Add_Specific_Audio_Codec.js
+++ b/Community/Tdarr_Plugin_henk_Add_Specific_Audio_Codec.js
@@ -64,8 +64,8 @@ function plugin(file, librarySettings, inputs) {
 
   for (let i = 0; i < file.ffProbeData.streams.length; i += 1) {
     const currStream = file.ffProbeData.streams[i];
-    if (currStream.codec_type.toLowerCase() === 'audio' && currStream.tags.copyright) {
-      if (currStream.tags.copyright === 'henk_asac') {
+    if (currStream.codec_type.toLowerCase() === 'audio' &&  currStream.codec_name === inputs.output_codec) {
+      if (currStream.tags.COPYRIGHT === 'henk_asac') {
         killPlugin = true;
       }
     }


### PR DESCRIPTION
fixed. as in some datastreams reading the copyright property resulted in an error: ☒Plugin error! TypeError: Cannot read property 'COPYRIGHT' of undefined
It's only needed to read the copyright tag in audiostreams. This solves the issue