### PR TITLE
Update Tdarr_Plugin_henk_Add_Specific_Audio_Codec.js

### DIFF
--- a/Community/Tdarr_Plugin_henk_Add_Specific_Audio_Codec.js
+++ b/Community/Tdarr_Plugin_henk_Add_Specific_Audio_Codec.js
@@ -64,7 +64,7 @@ function plugin(file, librarySettings, inputs) {
 
   for (let i = 0; i < file.ffProbeData.streams.length; i += 1) {
     const currStream = file.ffProbeData.streams[i];
-    if (currStream.tags.COPYRIGHT) {
+  if (currStream.codec_type.toLowerCase() === 'audio'  && currStream.codec_name === inputs.output_codec  ) {
       if (currStream.tags.COPYRIGHT === 'henk_asac') {
         killPlugin = true;
       }

--- a/Community/Tdarr_Plugin_henk_Add_Specific_Audio_Codec.js
+++ b/Community/Tdarr_Plugin_henk_Add_Specific_Audio_Codec.js
@@ -64,7 +64,7 @@ function plugin(file, librarySettings, inputs) {
 
   for (let i = 0; i < file.ffProbeData.streams.length; i += 1) {
     const currStream = file.ffProbeData.streams[i];
-  if (currStream.codec_type.toLowerCase() === 'audio'  && currStream.codec_name === inputs.output_codec  ) {
+    if (currStream.codec_type.toLowerCase() === 'audio' && currStream.codec_name === inputs.output_codec) {
       if (currStream.tags.COPYRIGHT === 'henk_asac') {
         killPlugin = true;
       }


### PR DESCRIPTION
Solves an issue where the plugin errors out on datatreams that do not have a copyright tag. It now only scans audio streams.
In addition, improved the routine, by checking if the desired output codex is already processed (not any audio stream)