### PR TITLE
Fixed a typo causing NaN bitrates

### DIFF
--- a/Community/Tdarr_Plugin_JB69_JBHEVCQSV_MinimalFile.js
+++ b/Community/Tdarr_Plugin_JB69_JBHEVCQSV_MinimalFile.js
@@ -761,7 +761,7 @@ function findMediaInfoItem(file, index) {
 			currMIOrder = file.mediaInfo.track[i].ID - 1;
 		}
 
-		if (currMIOrder == index|| currMIOrder == "0-" + index) {
+		if (currMIOrder == index || currMIOrder == "0-" + index) {
 			return i;
 		}
 	}


### PR DESCRIPTION
Fixed a typo (missing space) causing the script to not read the video and audio bitrate for some files resulting in a larger file after processing.