### PR TITLE
#156

### DIFF
--- a/Community/Tdarr_Plugin_b39x_the1poet_surround_sound_to_ac3.js
+++ b/Community/Tdarr_Plugin_b39x_the1poet_surround_sound_to_ac3.js
@@ -48,7 +48,7 @@ function plugin(file) {
 
       try {
         if (
-          file.ffProbeData.streams[i].channels >= 6 &&
+          file.ffProbeData.streams[i].channels == 6 &&
           file.ffProbeData.streams[i].codec_name !== "ac3" &&
           file.ffProbeData.streams[i].codec_type.toLowerCase() == "audio"
         ) {


### PR DESCRIPTION
Since FFMPEG does not support converting 7.1 to AC3 the plugin was previously downmixing 7.1 audio to 5.1. Since I'm also running Tdarr_Plugin_MC93_Migz5ConvertAudio to downmix tracks anyway, this caused me to end up with duplicate 5.1 tracks in all of my videos. This update does not fix the fundamental issue of ffmpeg not converting 7.1 to AC3, instead it just makes the plugin ignore audio streams with >6 channels since ffmpeg can't convert them to AC3 anyway. Combined with Tdarr_Plugin_MC93_Migz5ConvertAudio, this should allow users to have stereo and 5.1 audio streams encoded in AC3 while keeping the original 7.1 stream.