### PR TITLE
Fixing Typo in Log Message for AC3 Plugin

### DIFF
--- a/Community/Tdarr_Plugin_b39x_the1poet_surround_sound_to_ac3.js
+++ b/Community/Tdarr_Plugin_b39x_the1poet_surround_sound_to_ac3.js
@@ -67,10 +67,10 @@ function plugin(file) {
       response.handBrakeMode = false;
       response.FFmpegMode = true;
       response.reQueueAfter = true;
-      response.infoLog += "☒ File has surround audio which is not in ac3! \n";
+      response.infoLog += "☒ File has surround audio which is NOT in ac3! \n";
       return response;
     } else {
-      response.infoLog += "☑ All surround audio streams are in aac! \n";
+      response.infoLog += "☑ All surround audio streams are in ac3! \n";
     }
 
     response.infoLog += "☑File meets conditions! \n";


### PR DESCRIPTION
If the audio is AC3 the log says "ll surround audio streams are in aac! " which is wrong, and confuses me when looking at log.

Updated to show correct info.