### PR TITLE
Update Tdarr_Plugin_MC93_Migz3CleanAudio.js

### DIFF
--- a/Community/Tdarr_Plugin_MC93_Migz3CleanAudio.js
+++ b/Community/Tdarr_Plugin_MC93_Migz3CleanAudio.js
@@ -23,7 +23,7 @@ function details() {
                eng,und
 
                \\nExample:\\n
-               eng,und,jap`,
+               eng,und,jpn`,
     },
     {
       name: 'commentary',


### PR DESCRIPTION
Change jap to jpn in example to avoid people using the wrong language identifier for Japanese language tracks.