### PR TITLE
Say use v3 api key in tooltip.

### DIFF
--- a/Community/Tdarr_Plugin_henk_Keep_Native_Lang_Plus_Eng.js
+++ b/Community/Tdarr_Plugin_henk_Keep_Native_Lang_Plus_Eng.js
@@ -32,7 +32,7 @@ const details = () => ({
     },
     {
       name: 'api_key',
-      tooltip: 'Input your TMDB api key here. (https://www.themoviedb.org/)',
+      tooltip: 'Input your TMDB api (v3) key here. (https://www.themoviedb.org/)',
     },
     {
       name: 'radarr_api_key',


### PR DESCRIPTION
On TMDB api page there is a choice between v3 or v4 api key, specify wich one to use in tooltip, had to figure that one by trial and error.