### PR TITLE
Update Tdarr_Plugin_x7ac_Remove_Closed_Captions.js

### DIFF
--- a/Community/Tdarr_Plugin_x7ac_Remove_Closed_Captions.js
+++ b/Community/Tdarr_Plugin_x7ac_Remove_Closed_Captions.js
@@ -1,15 +1,15 @@
 function details() {
   return {
-    id: 'Tdarr_Plugin_WS_Remove_Closed_Captions',
+    id: 'Tdarr_Plugin_x7ac_Remove_Closed_Captions',
     Stage: 'Pre-processing',
     Name: 'Remove burned closed captions',
     Type: 'Video',
     Operation: 'Remux',
     Description:
-      '[Contains built-in filter] If detected, closed captions (XDS,608,708) will be removed. Derived from x7ac Closed Captions plugin.',
-    Version: "1.00",
+      '[Contains built-in filter] If detected, closed captions (XDS,608,708) will be removed from streams.',
+    Version: '1.01',
     Link:
-      'https://github.com/HaveAGitGat/Tdarr_Plugins/blob/master/Community/',
+      'https://github.com/HaveAGitGat/Tdarr_Plugins/blob/master/Community/Tdarr_Plugin_x7ac_Remove_Closed_Captions.js',
     Tags: 'pre-processing,ffmpeg,subtitle only',
   };
 }

--- a/Community/Tdarr_Plugin_x7ac_Remove_Closed_Captions.js
+++ b/Community/Tdarr_Plugin_x7ac_Remove_Closed_Captions.js
@@ -18,18 +18,16 @@ function plugin(file) {
   const response = {
     processFile: false,
     preset: ',-map 0 -codec copy -bsf:v "filter_units=remove_types=6"',
-    container: '.' + file.container,
+    container: '.${file.container}',
     handBrakeMode: false,
     FFmpegMode: true,
     reQueueAfter: true,
     infoLog: '',
   };
-
   if (file.fileMedium !== 'video') {
     response.infoLog += '☒File is not video \n';
     return response;
   }
-
   // Check if Closed Captions are set at file level
   if (file.hasClosedCaptions) {
     response.processFile = true;
@@ -37,14 +35,15 @@ function plugin(file) {
     return response;
   }
   // If not, check for Closed Captions in the streams
-  for (const stream in file.ffProbeData.streams) {
+  var streams = file.ffProbeData.streams;
+  for (const stream in streams) {
     if (stream.closed_captions) {
       response.processFile = true;
+      break;
     }
   }
-
-  response.infoLog += response.processFile?'☒This file has burnt closed captions \n':'☑Closed captions have not been detected on this file \n';
-  
+  response.infoLog += response.processFile ? '☒This file has burnt closed captions \n' :
+  '☑Closed captions have not been detected on this file \n';
   return response;
 }
 module.exports.details = details;

--- a/Community/Tdarr_Plugin_x7ac_Remove_Closed_Captions.js
+++ b/Community/Tdarr_Plugin_x7ac_Remove_Closed_Captions.js
@@ -43,7 +43,7 @@ function plugin(file) {
     }
   }
   response.infoLog += response.processFile ? '☒This file has burnt closed captions \n' :
-  '☑Closed captions have not been detected on this file \n';
+    '☑Closed captions have not been detected on this file \n';
   return response;
 }
 module.exports.details = details;

--- a/Community/Tdarr_Plugin_x7ac_Remove_Closed_Captions.js
+++ b/Community/Tdarr_Plugin_x7ac_Remove_Closed_Captions.js
@@ -43,12 +43,9 @@ function plugin(file) {
     }
   }
 
-  response.infoLog +=
-  response.processFile ? '☒This file has burnt closed captions \n'
-  : '☑Closed captions have not been detected on this file \n';
+  response.infoLog += response.processFile?'☒This file has burnt closed captions \n':'☑Closed captions have not been detected on this file \n';
   
   return response;
 }
-
 module.exports.details = details;
 module.exports.plugin = plugin;

--- a/Community/Tdarr_Plugin_x7ac_Remove_Closed_Captions.js
+++ b/Community/Tdarr_Plugin_x7ac_Remove_Closed_Captions.js
@@ -1,16 +1,16 @@
 function details() {
   return {
-    id: "Tdarr_Plugin_x7ac_Remove_Closed_Captions",
-    Stage: "Pre-processing",
-    Name: "Remove closed captions",
-    Type: "Video",
-    Operation: "Remux",
+    id: 'Tdarr_Plugin_WS_Remove_Closed_Captions',
+    Stage: 'Pre-processing',
+    Name: 'Remove burned closed captions',
+    Type: 'Video',
+    Operation: 'Remux',
     Description:
-      "[Contains built-in filter] If detected, closed captions (XDS,608,708) will be removed.",
+      '[Contains built-in filter] If detected, closed captions (XDS,608,708) will be removed. Derived from x7ac Closed Captions plugin.',
     Version: "1.00",
     Link:
-      "https://github.com/HaveAGitGat/Tdarr_Plugins/blob/master/Community/Tdarr_Plugin_x7ac_Remove_Closed_Captions.js",
-    Tags: "pre-processing,ffmpeg,subtitle only",
+      'https://github.com/HaveAGitGat/Tdarr_Plugins/blob/master/Community/',
+    Tags: 'pre-processing,ffmpeg,subtitle only',
   };
 }
 
@@ -18,25 +18,25 @@ function plugin(file) {
   const response = {
     processFile: false,
     preset: ',-map 0 -codec copy -bsf:v "filter_units=remove_types=6"',
-    container: "." + file.container,
+    container: '.' + file.container,
     handBrakeMode: false,
     FFmpegMode: true,
     reQueueAfter: true,
-    infoLog: "",
+    infoLog: '',
   };
 
-  if (file.fileMedium !== "video") {
-    response.infoLog += "☒File is not video \n";
+  if (file.fileMedium !== 'video') {
+    response.infoLog += '☒File is not video \n';
     return response;
   }
 
-  //Check if Closed Captions are set at file level
+  // Check if Closed Captions are set at file level
   if (file.hasClosedCaptions) {
     response.processFile = true;
     response.infoLog += '☒This file has closed captions \n';
     return response;
   }
-  //If not, check for Closed Captions in the streams
+  // If not, check for Closed Captions in the streams
   for (const stream in file.ffProbeData.streams) {
     if (stream.closed_captions) {
       response.processFile = true;

--- a/Community/Tdarr_Plugin_x7ac_Remove_Closed_Captions.js
+++ b/Community/Tdarr_Plugin_x7ac_Remove_Closed_Captions.js
@@ -17,7 +17,7 @@ function details() {
 function plugin(file) {
   const response = {
     processFile: false,
-    preset: `,-map 0 -codec copy -bsf:v "filter_units=remove_types=6"`,
+    preset: `,-map 0 -codec copy -bsf:v 'filter_units=remove_types=6'`,
     container: '.${file.container}',
     handBrakeMode: false,
     FFmpegMode: true,
@@ -35,7 +35,7 @@ function plugin(file) {
     return response;
   }
   // If not, check for Closed Captions in the streams
-  var streams = file.ffProbeData.streams;
+  const streams = file.ffProbeData.streams;
   for (const stream in streams) {
     if (stream.closed_captions) {
       response.processFile = true;

--- a/Community/Tdarr_Plugin_x7ac_Remove_Closed_Captions.js
+++ b/Community/Tdarr_Plugin_x7ac_Remove_Closed_Captions.js
@@ -17,7 +17,7 @@ function details() {
 function plugin(file) {
   const response = {
     processFile: false,
-    preset: ',-map 0 -codec copy -bsf:v "filter_units=remove_types=6"',
+    preset: `,-map 0 -codec copy -bsf:v "filter_units=remove_types=6"`,
     container: '.${file.container}',
     handBrakeMode: false,
     FFmpegMode: true,

--- a/Community/Tdarr_Plugin_x7ac_Remove_Closed_Captions.js
+++ b/Community/Tdarr_Plugin_x7ac_Remove_Closed_Captions.js
@@ -17,8 +17,8 @@ function details() {
 function plugin(file) {
   const response = {
     processFile: false,
-    preset: `,-map 0 -codec copy -bsf:v 'filter_units=remove_types=6'`,
-    container: '.${file.container}',
+    preset: ',-map 0 -codec copy -bsf:v \"filter_units=remove_types=6\"',
+    container: `.${file.container}`,
     handBrakeMode: false,
     FFmpegMode: true,
     reQueueAfter: true,
@@ -35,15 +35,15 @@ function plugin(file) {
     return response;
   }
   // If not, check for Closed Captions in the streams
-  const streams = file.ffProbeData.streams;
+  const {streams} = file.ffProbeData;
   for (const stream in streams) {
     if (stream.closed_captions) {
       response.processFile = true;
       break;
     }
   }
-  response.infoLog += response.processFile ? '☒This file has burnt closed captions \n' :
-    '☑Closed captions have not been detected on this file \n';
+  response.infoLog += response.processFile ? '☒This file has burnt closed captions \n' 
+    : '☑Closed captions have not been detected on this file \n';
   return response;
 }
 module.exports.details = details;

--- a/Community/Tdarr_Plugin_x7ac_Remove_Closed_Captions.js
+++ b/Community/Tdarr_Plugin_x7ac_Remove_Closed_Captions.js
@@ -1,4 +1,3 @@
-/* eslint-disable */
 function details() {
   return {
     id: "Tdarr_Plugin_x7ac_Remove_Closed_Captions",
@@ -16,46 +15,39 @@ function details() {
 }
 
 function plugin(file) {
-  //Must return this object
-
-  var response = {
+  const response = {
     processFile: false,
-    preset: "",
-    container: ".mp4",
+    preset: ',-map 0 -codec copy -bsf:v "filter_units=remove_types=6"',
+    container: "." + file.container,
     handBrakeMode: false,
-    FFmpegMode: false,
+    FFmpegMode: true,
     reQueueAfter: true,
     infoLog: "",
   };
 
   if (file.fileMedium !== "video") {
-    console.log("File is not video");
-
     response.infoLog += "☒File is not video \n";
-    response.processFile = false;
-
     return response;
-  } else {
-    if (file.hasClosedCaptions === true) {
-      response = {
-        processFile: true,
-        preset: ',-map 0 -codec copy -bsf:v "filter_units=remove_types=6"',
-        container: "." + file.container,
-        handBrakeMode: false,
-        FFmpegMode: true,
-        reQueueAfter: true,
-        infoLog: "☒This file has closed captions \n",
-      };
+  }
 
-      return response;
-    } else {
-      response.infoLog +=
-        "☑Closed captions have not been detected on this file \n";
-      response.processFile = false;
-
-      return response;
+  //Check if Closed Captions are set at file level
+  if (file.hasClosedCaptions) {
+    response.processFile = true;
+    response.infoLog += '☒This file has closed captions \n';
+    return response;
+  }
+  //If not, check for Closed Captions in the streams
+  for (const stream in file.ffProbeData.streams) {
+    if (stream.closed_captions) {
+      response.processFile = true;
     }
   }
+
+  response.infoLog +=
+  response.processFile ? '☒This file has burnt closed captions \n'
+  : '☑Closed captions have not been detected on this file \n';
+  
+  return response;
 }
 
 module.exports.details = details;

--- a/Community/Tdarr_Plugin_x7ac_Remove_Closed_Captions.js
+++ b/Community/Tdarr_Plugin_x7ac_Remove_Closed_Captions.js
@@ -17,6 +17,7 @@ function details() {
 function plugin(file) {
   const response = {
     processFile: false,
+    // eslint-disable-next-line no-useless-escape
     preset: ',-map 0 -codec copy -bsf:v \"filter_units=remove_types=6\"',
     container: `.${file.container}`,
     handBrakeMode: false,
@@ -35,14 +36,14 @@ function plugin(file) {
     return response;
   }
   // If not, check for Closed Captions in the streams
-  const {streams} = file.ffProbeData;
-  for (const stream in streams) {
+  const { streams } = file.ffProbeData;
+  streams.forEach((stream) => {
     if (stream.closed_captions) {
       response.processFile = true;
-      break;
     }
-  }
-  response.infoLog += response.processFile ? '☒This file has burnt closed captions \n' 
+  });
+
+  response.infoLog += response.processFile ? '☒This file has burnt closed captions \n'
     : '☑Closed captions have not been detected on this file \n';
   return response;
 }


### PR DESCRIPTION
**This is my first Pull Request. If something is off, let me know.

I added a little logic to loop through the streams to find Closed Captions burned into the video stream, which Plex detects (and cannot play) but this plugin did not.

The ffProbeData from my files say the following:
```
{
(...)
"hasClosedCaptions": false,              <<<<<<<<<<<<<<<
  "container": "mkv",
  "ffProbeRead": "success",
  "ffProbeData": {
    "streams": [
      {
        "index": 0,
        "codec_name": "h264",
        "codec_long_name": "H.264 / AVC / MPEG-4 AVC / MPEG-4 part 10",
        "profile": "High",
        "codec_type": "video",
       (...)
        "closed_captions": 1,           <<<<<<<<<<<<<<<
       (...)
     }
}
```

So now the plugin checks both places.

Credits to @supersnellehenk for a great code optimization. :)