### PR TITLE
Update migz audio/subtitle cleaners to slightly improve logging

### DIFF
--- a/Community/Tdarr_Plugin_MC93_Migz3CleanAudio.js
+++ b/Community/Tdarr_Plugin_MC93_Migz3CleanAudio.js
@@ -190,8 +190,8 @@ const plugin = (file, librarySettings, inputs, otherArguments) => {
             .includes('und')
         ) {
           ffmpegCommandInsert += `-metadata:s:a:${audioIdx} language=${inputs.tag_language} `;
-          response.infoLog +=
-            `☒Audio stream 0:a:${audioIdx} detected as having no language, tagging as ${inputs.tag_language}. \n`;
+          response.infoLog
+            += `☒Audio stream 0:a:${audioIdx} detected as having no language, tagging as ${inputs.tag_language}. \n`;
           convert = true;
         }
       } catch (err) {
@@ -203,16 +203,16 @@ const plugin = (file, librarySettings, inputs, otherArguments) => {
       // No catch error here otherwise it would never detect the metadata as missing.
       if (typeof file.ffProbeData.streams[i].tags === 'undefined') {
         ffmpegCommandInsert += `-metadata:s:a:${audioIdx} language=${inputs.tag_language} `;
-        response.infoLog +=
-          `☒Audio stream 0:a:${audioIdx} detected as having no language, tagging as ${inputs.tag_language}. \n`;
+        response.infoLog
+          += `☒Audio stream 0:a:${audioIdx} detected as having no language, tagging as ${inputs.tag_language}. \n`;
         convert = true;
       } else if (typeof file.ffProbeData.streams[i].tags.language === 'undefined') {
         // Checks if the tags.language metadata is completely missing.
         // If so this would cause playback to show language as "undefined".
         // No catch error here otherwise it would never detect the metadata as missing.
         ffmpegCommandInsert += `-metadata:s:a:${audioIdx} language=${inputs.tag_language} `;
-        response.infoLog +=
-          `☒Audio stream 0:a:${audioIdx} detected as having no language, tagging as ${inputs.tag_language}. \n`;
+        response.infoLog
+          += `☒Audio stream 0:a:${audioIdx} detected as having no language, tagging as ${inputs.tag_language}. \n`;
         convert = true;
       }
     }

--- a/Community/Tdarr_Plugin_MC93_Migz3CleanAudio.js
+++ b/Community/Tdarr_Plugin_MC93_Migz3CleanAudio.js
@@ -139,7 +139,7 @@ const plugin = (file, librarySettings, inputs, otherArguments) => {
       ) {
         audioStreamsRemoved += 1;
         ffmpegCommandInsert += `-map -0:a:${audioIdx} `;
-        response.infoLog += `☒Audio stream detected as being unwanted, removing. Audio stream 0:a:${audioIdx} \n`;
+        response.infoLog += `☒Audio stream 0:a:${audioIdx} has unwanted language tag ${file.ffProbeData.streams[i].tags.language.toLowerCase()}, removing. \n`;
         convert = true;
       }
     } catch (err) {
@@ -165,7 +165,7 @@ const plugin = (file, librarySettings, inputs, otherArguments) => {
       ) {
         audioStreamsRemoved += 1;
         ffmpegCommandInsert += `-map -0:a:${audioIdx} `;
-        response.infoLog += `☒Audio stream detected as being descriptive, removing. Stream 0:a:${audioIdx} \n`;
+        response.infoLog += `☒Audio stream 0:a:${audioIdx} detected as being descriptive, removing. \n`;
         convert = true;
       }
     } catch (err) {
@@ -188,7 +188,7 @@ const plugin = (file, librarySettings, inputs, otherArguments) => {
             .includes('und')
         ) {
           ffmpegCommandInsert += `-metadata:s:a:${audioIdx} language=${inputs.tag_language} `;
-          response.infoLog += `☒Audio stream detected as having no language, tagging as ${inputs.tag_language}. \n`;
+          response.infoLog += `☒Audio stream 0:a:${audioIdx} detected as having no language, tagging as ${inputs.tag_language}. \n`;
           convert = true;
         }
       } catch (err) {
@@ -200,14 +200,14 @@ const plugin = (file, librarySettings, inputs, otherArguments) => {
       // No catch error here otherwise it would never detect the metadata as missing.
       if (typeof file.ffProbeData.streams[i].tags === 'undefined') {
         ffmpegCommandInsert += `-metadata:s:a:${audioIdx} language=${inputs.tag_language} `;
-        response.infoLog += `☒Audio stream detected as having no language, tagging as ${inputs.tag_language}. \n`;
+        response.infoLog += `☒Audio stream 0:a:${audioIdx} detected as having no language, tagging as ${inputs.tag_language}. \n`;
         convert = true;
       } else if (typeof file.ffProbeData.streams[i].tags.language === 'undefined') {
         // Checks if the tags.language metadata is completely missing.
         // If so this would cause playback to show language as "undefined".
         // No catch error here otherwise it would never detect the metadata as missing.
         ffmpegCommandInsert += `-metadata:s:a:${audioIdx} language=${inputs.tag_language} `;
-        response.infoLog += `☒Audio stream detected as having no language, tagging as ${inputs.tag_language}. \n`;
+        response.infoLog += `☒Audio stream 0:a:${audioIdx} detected as having no language, tagging as ${inputs.tag_language}. \n`;
         convert = true;
       }
     }
@@ -222,17 +222,17 @@ const plugin = (file, librarySettings, inputs, otherArguments) => {
       ) {
         if (file.ffProbeData.streams[i].channels === 8) {
           ffmpegCommandInsert += `-metadata:s:a:${audioIdx} title="7.1" `;
-          response.infoLog += `☒Audio stream detected as 8 channel with no title, tagging. Stream 0:a:${audioIdx} \n`;
+          response.infoLog += `☒Audio stream 0:a:${audioIdx} detected as 8 channel with no title, tagging. \n`;
           convert = true;
         }
         if (file.ffProbeData.streams[i].channels === 6) {
           ffmpegCommandInsert += `-metadata:s:a:${audioIdx} title="5.1" `;
-          response.infoLog += `☒Audio stream detected as 6 channel with no title, tagging. Stream 0:a:${audioIdx} \n`;
+          response.infoLog += `☒Audio stream 0:a:${audioIdx} detected as 6 channel with no title, tagging. \n`;
           convert = true;
         }
         if (file.ffProbeData.streams[i].channels === 2) {
           ffmpegCommandInsert += `-metadata:s:a:${audioIdx} title="2.0" `;
-          response.infoLog += `☒Audio stream detected as 2 channel with no title, tagging. Stream 0:a:${audioIdx} \n`;
+          response.infoLog += `☒Audio stream 0:a:${audioIdx} detected as 2 channel with no title, tagging. \n`;
           convert = true;
         }
       }

--- a/Community/Tdarr_Plugin_MC93_Migz3CleanAudio.js
+++ b/Community/Tdarr_Plugin_MC93_Migz3CleanAudio.js
@@ -139,7 +139,9 @@ const plugin = (file, librarySettings, inputs, otherArguments) => {
       ) {
         audioStreamsRemoved += 1;
         ffmpegCommandInsert += `-map -0:a:${audioIdx} `;
-        response.infoLog += `☒Audio stream 0:a:${audioIdx} has unwanted language tag ${file.ffProbeData.streams[i].tags.language.toLowerCase()}, removing. \n`;
+        response.infoLog += `☒Audio stream 0:a:${audioIdx} has unwanted language tag ${file.ffProbeData.streams[
+          i
+        ].tags.language.toLowerCase()}, removing. \n`;
         convert = true;
       }
     } catch (err) {
@@ -188,7 +190,8 @@ const plugin = (file, librarySettings, inputs, otherArguments) => {
             .includes('und')
         ) {
           ffmpegCommandInsert += `-metadata:s:a:${audioIdx} language=${inputs.tag_language} `;
-          response.infoLog += `☒Audio stream 0:a:${audioIdx} detected as having no language, tagging as ${inputs.tag_language}. \n`;
+          response.infoLog +=
+            `☒Audio stream 0:a:${audioIdx} detected as having no language, tagging as ${inputs.tag_language}. \n`;
           convert = true;
         }
       } catch (err) {
@@ -200,14 +203,16 @@ const plugin = (file, librarySettings, inputs, otherArguments) => {
       // No catch error here otherwise it would never detect the metadata as missing.
       if (typeof file.ffProbeData.streams[i].tags === 'undefined') {
         ffmpegCommandInsert += `-metadata:s:a:${audioIdx} language=${inputs.tag_language} `;
-        response.infoLog += `☒Audio stream 0:a:${audioIdx} detected as having no language, tagging as ${inputs.tag_language}. \n`;
+        response.infoLog +=
+          `☒Audio stream 0:a:${audioIdx} detected as having no language, tagging as ${inputs.tag_language}. \n`;
         convert = true;
       } else if (typeof file.ffProbeData.streams[i].tags.language === 'undefined') {
         // Checks if the tags.language metadata is completely missing.
         // If so this would cause playback to show language as "undefined".
         // No catch error here otherwise it would never detect the metadata as missing.
         ffmpegCommandInsert += `-metadata:s:a:${audioIdx} language=${inputs.tag_language} `;
-        response.infoLog += `☒Audio stream 0:a:${audioIdx} detected as having no language, tagging as ${inputs.tag_language}. \n`;
+        response.infoLog +=
+          `☒Audio stream 0:a:${audioIdx} detected as having no language, tagging as ${inputs.tag_language}. \n`;
         convert = true;
       }
     }

--- a/Community/Tdarr_Plugin_MC93_Migz4CleanSubs.js
+++ b/Community/Tdarr_Plugin_MC93_Migz4CleanSubs.js
@@ -111,7 +111,7 @@ const plugin = (file, librarySettings, inputs, otherArguments) => {
         ) === -1
       ) {
         ffmpegCommandInsert += `-map -0:s:${subtitleIdx} `;
-        response.infoLog += `☒Subtitle stream detected as being unwanted, removing. Stream 0:s:${subtitleIdx} \n`;
+        response.infoLog += `☒Subtitle stream 0:s:${subtitleIdx} has unwanted language tag ${file.ffProbeData.streams[i].tags.language.toLowerCase()}, removing. \n`;
         convert = true;
       }
     } catch (err) {
@@ -135,7 +135,7 @@ const plugin = (file, librarySettings, inputs, otherArguments) => {
             .includes('description'))
       ) {
         ffmpegCommandInsert += `-map -0:s:${subtitleIdx} `;
-        response.infoLog += `☒Subtitle stream detected as being descriptive, removing. Stream 0:s:${subtitleIdx} \n`;
+        response.infoLog += `☒Subtitle stream 0:s:${subtitleIdx} detected as being descriptive, removing. \n`;
         convert = true;
       }
     } catch (err) {
@@ -158,7 +158,7 @@ const plugin = (file, librarySettings, inputs, otherArguments) => {
             .includes('und')
         ) {
           ffmpegCommandInsert += `-metadata:s:s:${subtitleIdx} language=${inputs.tag_language} `;
-          response.infoLog += `☒Subtitle stream detected as having no language, tagging as ${inputs.tag_language}. \n`;
+          response.infoLog += `☒Subtitle stream 0:s:${subtitleIdx} detected as having no language, tagging as ${inputs.tag_language}. \n`;
           convert = true;
         }
       } catch (err) {
@@ -170,14 +170,14 @@ const plugin = (file, librarySettings, inputs, otherArguments) => {
       // No catch error here otherwise it would never detect the metadata as missing.
       if (typeof file.ffProbeData.streams[i].tags === 'undefined') {
         ffmpegCommandInsert += `-metadata:s:s:${subtitleIdx} language=${inputs.tag_language} `;
-        response.infoLog += `☒Subtitle stream detected as having no language, tagging as ${inputs.tag_language}. \n`;
+        response.infoLog += `☒Subtitle stream 0:s:${subtitleIdx} detected as having no language, tagging as ${inputs.tag_language}. \n`;
         convert = true;
       } else if (typeof file.ffProbeData.streams[i].tags.language === 'undefined') {
       // Checks if the tags.language metadata is completely missing.
       // If so this would cause playback to show language as "undefined".
       // No catch error here otherwise it would never detect the metadata as missing
         ffmpegCommandInsert += `-metadata:s:s:${subtitleIdx} language=${inputs.tag_language} `;
-        response.infoLog += `☒Subtitle stream detected as having no language, tagging as ${inputs.tag_language}. \n`;
+        response.infoLog += `☒Subtitle stream 0:s:${subtitleIdx} detected as having no language, tagging as ${inputs.tag_language}. \n`;
         convert = true;
       }
     }

--- a/Community/Tdarr_Plugin_MC93_Migz4CleanSubs.js
+++ b/Community/Tdarr_Plugin_MC93_Migz4CleanSubs.js
@@ -86,8 +86,9 @@ const plugin = (file, librarySettings, inputs, otherArguments) => {
 
   // Check if inputs.language has been configured. If it hasn't then exit plugin.
   if (inputs.language === '') {
-    response.infoLog += '☒Language/s to keep have not been configured, '
-    + 'please configure required options. Skipping this plugin.  \n';
+    response.infoLog +=
+      '☒Language/s to keep have not been configured, ' +
+      'please configure required options. Skipping this plugin.  \n';
     response.processFile = false;
     return response;
   }
@@ -111,7 +112,9 @@ const plugin = (file, librarySettings, inputs, otherArguments) => {
         ) === -1
       ) {
         ffmpegCommandInsert += `-map -0:s:${subtitleIdx} `;
-        response.infoLog += `☒Subtitle stream 0:s:${subtitleIdx} has unwanted language tag ${file.ffProbeData.streams[i].tags.language.toLowerCase()}, removing. \n`;
+        response.infoLog += `☒Subtitle stream 0:s:${subtitleIdx} has unwanted language tag ${file.ffProbeData.streams[
+          i
+        ].tags.language.toLowerCase()}, removing. \n`;
         convert = true;
       }
     } catch (err) {
@@ -158,7 +161,7 @@ const plugin = (file, librarySettings, inputs, otherArguments) => {
             .includes('und')
         ) {
           ffmpegCommandInsert += `-metadata:s:s:${subtitleIdx} language=${inputs.tag_language} `;
-          response.infoLog += `☒Subtitle stream 0:s:${subtitleIdx} detected as having no language, tagging as ${inputs.tag_language}. \n`;
+          response.infoLog += `☒Subtitle stream 0:s:${subtitleIdx} has no language, tagging as ${inputs.tag_language}. \n`;
           convert = true;
         }
       } catch (err) {
@@ -170,14 +173,14 @@ const plugin = (file, librarySettings, inputs, otherArguments) => {
       // No catch error here otherwise it would never detect the metadata as missing.
       if (typeof file.ffProbeData.streams[i].tags === 'undefined') {
         ffmpegCommandInsert += `-metadata:s:s:${subtitleIdx} language=${inputs.tag_language} `;
-        response.infoLog += `☒Subtitle stream 0:s:${subtitleIdx} detected as having no language, tagging as ${inputs.tag_language}. \n`;
+        response.infoLog += `☒Subtitle stream 0:s:${subtitleIdx} has no language, tagging as ${inputs.tag_language}. \n`;
         convert = true;
       } else if (typeof file.ffProbeData.streams[i].tags.language === 'undefined') {
       // Checks if the tags.language metadata is completely missing.
       // If so this would cause playback to show language as "undefined".
       // No catch error here otherwise it would never detect the metadata as missing
         ffmpegCommandInsert += `-metadata:s:s:${subtitleIdx} language=${inputs.tag_language} `;
-        response.infoLog += `☒Subtitle stream 0:s:${subtitleIdx} detected as having no language, tagging as ${inputs.tag_language}. \n`;
+        response.infoLog += `☒Subtitle stream 0:s:${subtitleIdx} has no language, tagging as ${inputs.tag_language}. \n`;
         convert = true;
       }
     }

--- a/Community/Tdarr_Plugin_MC93_Migz4CleanSubs.js
+++ b/Community/Tdarr_Plugin_MC93_Migz4CleanSubs.js
@@ -86,9 +86,9 @@ const plugin = (file, librarySettings, inputs, otherArguments) => {
 
   // Check if inputs.language has been configured. If it hasn't then exit plugin.
   if (inputs.language === '') {
-    response.infoLog +=
-      '☒Language/s to keep have not been configured, ' +
-      'please configure required options. Skipping this plugin.  \n';
+    response.infoLog
+      += '☒Language/s to keep have not been configured, '
+      + 'please configure required options. Skipping this plugin.  \n';
     response.processFile = false;
     return response;
   }
@@ -161,7 +161,8 @@ const plugin = (file, librarySettings, inputs, otherArguments) => {
             .includes('und')
         ) {
           ffmpegCommandInsert += `-metadata:s:s:${subtitleIdx} language=${inputs.tag_language} `;
-          response.infoLog += `☒Subtitle stream 0:s:${subtitleIdx} has no language, tagging as ${inputs.tag_language}. \n`;
+          response.infoLog
+            += `☒Subtitle stream 0:s:${subtitleIdx} has no language, tagging as ${inputs.tag_language}. \n`;
           convert = true;
         }
       } catch (err) {
@@ -173,14 +174,16 @@ const plugin = (file, librarySettings, inputs, otherArguments) => {
       // No catch error here otherwise it would never detect the metadata as missing.
       if (typeof file.ffProbeData.streams[i].tags === 'undefined') {
         ffmpegCommandInsert += `-metadata:s:s:${subtitleIdx} language=${inputs.tag_language} `;
-        response.infoLog += `☒Subtitle stream 0:s:${subtitleIdx} has no language, tagging as ${inputs.tag_language}. \n`;
+        response.infoLog
+          += `☒Subtitle stream 0:s:${subtitleIdx} has no language, tagging as ${inputs.tag_language}. \n`;
         convert = true;
       } else if (typeof file.ffProbeData.streams[i].tags.language === 'undefined') {
       // Checks if the tags.language metadata is completely missing.
       // If so this would cause playback to show language as "undefined".
       // No catch error here otherwise it would never detect the metadata as missing
         ffmpegCommandInsert += `-metadata:s:s:${subtitleIdx} language=${inputs.tag_language} `;
-        response.infoLog += `☒Subtitle stream 0:s:${subtitleIdx} has no language, tagging as ${inputs.tag_language}. \n`;
+        response.infoLog
+          += `☒Subtitle stream 0:s:${subtitleIdx} has no language, tagging as ${inputs.tag_language}. \n`;
         convert = true;
       }
     }


### PR DESCRIPTION
I found the wording a little clunky, and I wanted to explicitly see exactly what language was considered unwanted.