### PR TITLE
ignore cert mismatch for *.plex.direct

### DIFF
--- a/Community/Tdarr_Plugin_goof1_URL_Plex_Refresh.js
+++ b/Community/Tdarr_Plugin_goof1_URL_Plex_Refresh.js
@@ -36,7 +36,7 @@ const details = () => ({
         type: 'text',
       },
       tooltip: `
-               Enter the IP address/URL for Plex. Must include http(s)://
+               Enter the IP address/URL for Plex.
                \\nExample:\\n
                192.168.0.10
                \\nExample:\\n

--- a/Community/Tdarr_Plugin_goof1_URL_Plex_Refresh.js
+++ b/Community/Tdarr_Plugin_goof1_URL_Plex_Refresh.js
@@ -201,7 +201,7 @@ const plugin = async (file, librarySettings, inputs, otherArguments) => {
     return response;
   } if (type === 'https') {
     await new Promise((resolve) => {
-      https.get(urlNoToken + token, (res) => {
+      https.get(urlNoToken + token, { rejectUnauthorized: false }, (res) => {
         checkReply(response, res.statusCode, urlNoToken);
         resolve();
       }).on('error', (e) => {


### PR DESCRIPTION
add parameter to ignore cert mismatches for custom domains since plex tries to push everything through their generated subdomains and it may see a cert issue.