### PR TITLE
Bug fix for Chinese orginal language

### DIFF
--- a/Community/Tdarr_Plugin_henk_Keep_Native_Lang_Plus_Eng.js
+++ b/Community/Tdarr_Plugin_henk_Keep_Native_Lang_Plus_Eng.js
@@ -108,9 +108,15 @@ const processStreams = (result, file, user_langs) => {
   };
   let streamIndex = 0;
 
-  const langsTemp = result.original_language;
+  var langsTemp = result.original_language; //Change from const to var to re-define
+  
+  if (langsTemp == 'cn') langsTemp = 'zh'; //If the original language is pulled as Chinese 'cn' is used.  iso-language expects 'zh' for Chinese.
+  
   let langs = [];
 
+  /*
+  The TMDB should only every report a single language as original language and is not reliant on imdb languages.
+  
   if (Array.isArray(langsTemp)) {
     // For loop because I thought some imdb stuff returns multiple languages
     // Translates 'en' to 'eng', because imdb uses a different format compared to ffmpeg
@@ -120,7 +126,15 @@ const processStreams = (result, file, user_langs) => {
   } else {
     langs.push(languages.alpha2ToAlpha3B(langsTemp));
   }
-
+  */
+  langs.push(languages.alpha2ToAlpha3B(langsTemp));
+  
+  //Some console reporting for clarification of what the plugin is using and reporting.
+  response.infoLog += 'Original language: ';
+  response.infoLog += `${langsTemp}`;
+  response.infoLog += ', Using code: ';
+  response.infoLog += `${languages.alpha2ToAlpha3B(langsTemp)}\n`;
+  
   if (user_langs) {
     langs = langs.concat(user_langs);
   }

--- a/Community/Tdarr_Plugin_henk_Keep_Native_Lang_Plus_Eng.js
+++ b/Community/Tdarr_Plugin_henk_Keep_Native_Lang_Plus_Eng.js
@@ -108,32 +108,15 @@ const processStreams = (result, file, user_langs) => {
   };
   let streamIndex = 0;
 
-  var langsTemp = result.original_language; //Change from const to var to re-define
-  
-  if (langsTemp == 'cn') langsTemp = 'zh'; //If the original language is pulled as Chinese 'cn' is used.  iso-language expects 'zh' for Chinese.
+  //If the original language is pulled as Chinese 'cn' is used.  iso-language expects 'zh' for Chinese.
+  const langsTemp = result.original_language === 'cn' ? 'zh' : result.original_language;
   
   let langs = [];
 
-  /*
-  The TMDB should only every report a single language as original language and is not reliant on imdb languages.
-  
-  if (Array.isArray(langsTemp)) {
-    // For loop because I thought some imdb stuff returns multiple languages
-    // Translates 'en' to 'eng', because imdb uses a different format compared to ffmpeg
-    for (let i = 0; i < langsTemp.length; i += 1) {
-      langs.push(languages.alpha2ToAlpha3B(langsTemp));
-    }
-  } else {
-    langs.push(languages.alpha2ToAlpha3B(langsTemp));
-  }
-  */
   langs.push(languages.alpha2ToAlpha3B(langsTemp));
   
   //Some console reporting for clarification of what the plugin is using and reporting.
-  response.infoLog += 'Original language: ';
-  response.infoLog += `${langsTemp}`;
-  response.infoLog += ', Using code: ';
-  response.infoLog += `${languages.alpha2ToAlpha3B(langsTemp)}\n`;
+  response.infoLog += `Original language: ${langsTemp}, Using code: ${languages.alpha2ToAlpha3B(langsTemp)}\n`;
   
   if (user_langs) {
     langs = langs.concat(user_langs);

--- a/Community/Tdarr_Plugin_henk_Keep_Native_Lang_Plus_Eng.js
+++ b/Community/Tdarr_Plugin_henk_Keep_Native_Lang_Plus_Eng.js
@@ -108,16 +108,16 @@ const processStreams = (result, file, user_langs) => {
   };
   let streamIndex = 0;
 
-  //If the original language is pulled as Chinese 'cn' is used.  iso-language expects 'zh' for Chinese.
+  // If the original language is pulled as Chinese 'cn' is used.  iso-language expects 'zh' for Chinese.
   const langsTemp = result.original_language === 'cn' ? 'zh' : result.original_language;
-  
+
   let langs = [];
 
   langs.push(languages.alpha2ToAlpha3B(langsTemp));
-  
-  //Some console reporting for clarification of what the plugin is using and reporting.
+
+  // Some console reporting for clarification of what the plugin is using and reporting.
   response.infoLog += `Original language: ${langsTemp}, Using code: ${languages.alpha2ToAlpha3B(langsTemp)}\n`;
-  
+
   if (user_langs) {
     langs = langs.concat(user_langs);
   }


### PR DESCRIPTION
Bug where a Chinese original language movie would be set as und or undefined because of the return value from TMBD as 'cn'.  The iso-language expects 'zh' for Chinese.
Also the array may be unnecessary given TMDB should only every report a single language and is not reliant on imdb multiple languages.