### PR TITLE
Better precision for checking file duration

### DIFF
--- a/Community/Tdarr_Plugin_a9hf_New_file_duration_check.js
+++ b/Community/Tdarr_Plugin_a9hf_New_file_duration_check.js
@@ -65,7 +65,7 @@ const plugin = (file, librarySettings, inputs, otherArguments) => {
   newData = getData(file);
   oldData = getData(otherArguments.originalLibraryFile);
 
-  const ratio = ((newData / oldData) * 100.0).toFixed(2);
+  const ratio = ((newData / oldData) * 100.0).toFixed(3);
 
   const dataText = `New file has duration ${newData} s which is ${ratio}% `
     + `of original file duration:  ${oldData} s`;

--- a/Community/Tdarr_Plugin_a9hf_New_file_duration_check.js
+++ b/Community/Tdarr_Plugin_a9hf_New_file_duration_check.js
@@ -8,7 +8,7 @@ const details = () => ({
   Operation: 'Transcode',
   Description: `Give an error if new file is not within the specified upper and lower bound duration limits.
   Make sure MediaInfo scan is enabled in library settings \n\n`,
-  Version: '1.01',
+  Version: '1.02',
   Tags: '',
   Inputs: [
     {

--- a/Community/Tdarr_Plugin_a9hf_New_file_duration_check.js
+++ b/Community/Tdarr_Plugin_a9hf_New_file_duration_check.js
@@ -8,13 +8,13 @@ const details = () => ({
   Operation: 'Transcode',
   Description: `Give an error if new file is not within the specified upper and lower bound duration limits.
   Make sure MediaInfo scan is enabled in library settings \n\n`,
-  Version: '1.00',
+  Version: '1.01',
   Tags: '',
   Inputs: [
     {
       name: 'upperBound',
       type: 'number',
-      defaultValue: 101,
+      defaultValue: 100.5,
       inputUI: {
         type: 'text',
       },
@@ -25,7 +25,7 @@ const details = () => ({
     {
       name: 'lowerBound',
       type: 'number',
-      defaultValue: 99,
+      defaultValue: 99.5,
       inputUI: {
         type: 'text',
       },
@@ -50,8 +50,8 @@ const plugin = (file, librarySettings, inputs, otherArguments) => {
     infoLog: '',
   };
 
-  let newData = 0;
-  let oldData = 0;
+  let newData = 0.0;
+  let oldData = 0.0;
 
   const getData = (obj) => {
     try {
@@ -65,12 +65,12 @@ const plugin = (file, librarySettings, inputs, otherArguments) => {
   newData = getData(file);
   oldData = getData(otherArguments.originalLibraryFile);
 
-  const ratio = parseInt((newData / oldData) * 100, 10);
+  const ratio = ((newData / oldData) * 100.0).toFixed(2);
 
   const dataText = `New file has duration ${newData} s which is ${ratio}% `
     + `of original file duration:  ${oldData} s`;
 
-  const getBound = (bound) => (bound / 100) * oldData;
+  const getBound = (bound) => (bound / 100.0) * oldData;
 
   const errText = 'New file duration not within limits.';
   if (newData > getBound(inputs.upperBound)) {


### PR DESCRIPTION
Lets you set upper and lower bounds more accurately and prints out more accurate error figures. Default has error range of 2%, this default has error range of 1% (.5% above or below).

In testing it appears that going even to 99.8 <> 100.2 would also be acceptable and present little to no false positives with an error range of .4%. I've seen random failures that are just barely caught at 98% of original.

newData & oldData maintain up to 3 to 5 decimal places of accuracy sometimes. This allows ratio to more accurately reflect that. 3 places should be sufficient.