### PR TITLE
Prevent needless tmdb api calls

### DIFF
--- a/Community/Tdarr_Plugin_henk_Keep_Native_Lang_Plus_Eng.js
+++ b/Community/Tdarr_Plugin_henk_Keep_Native_Lang_Plus_Eng.js
@@ -147,7 +147,7 @@ const processStreams = (result, file, user_langs) => {
         if (langs.includes(stream.tags.language)) {
           tracks.keep.push(streamIndex);
           // Set processed flag
-          response.preset += `-c:a copy -metadata:s:a:${streamIndex} copyright="henk_knlpe" `
+          response.preset += `-c:a copy -metadata:s:a:${streamIndex} copyright="henk_knlpe" `;
         } else {
           tracks.remove.push(streamIndex);
           response.preset += `-map -0:a:${streamIndex} `;
@@ -252,7 +252,7 @@ const plugin = async (file, librarySettings, inputs, otherArguments) => {
       += '☑File has already been processed by this plugin.\n';
     return response;
   }
-  
+
   if (inputs.priority) {
     if (inputs.priority === 'sonarr') {
       prio = ['sonarr', 'radarr'];
@@ -320,13 +320,13 @@ const plugin = async (file, librarySettings, inputs, otherArguments) => {
   } else {
     response.infoLog += '☒Couldn\'t find the IMDB id of this file. Skipping. \n';
   }
-  // Only to set processed flag 
+  // Only to set processed flag
   if (!response.processFile) {
     response.preset = ', -map 0 -c:v copy -c:a copy -metadata:s:a copyright="henk_knlpe" -c:s copy';
     response.processFile = true;
-	  response.infoLog += '☑Setting processed flag ONLY to prevent needless TMDB api calls. \n';
+    response.infoLog += '☑Setting processed flag ONLY to prevent needless TMDB api calls. \n';
   }
-  
+
   return response;
 };
 


### PR DESCRIPTION
This modification adds a kill plugin command based off of henk_Add_Specific_Audio_Codec plugin.

With Tdarr's cyclic processing this plugin will always check and potentially run an API call to tmdb.  

This is used to process the plugin once.
Then check if the plugin has been processed by checking for copyright metadata set within the audio.
If true plugin will terminate.
If false plugin will continue.