### PR TITLE
Update transcodeAddAudioStream.js

### DIFF
--- a/methods/library/actions/transcodeAddAudioStream.js
+++ b/methods/library/actions/transcodeAddAudioStream.js
@@ -122,7 +122,7 @@ module.exports = function transcodeAddAudioStream(
           };
         } else {
           return {
-            preset: `,-map 0:v -map 0:${highestChannelCount.index} -map 0:a -map 0:s? -map 0:d? -c copy -c:a:0 ${audioEncoder} -ac ${channelCount}`,
+            preset: `,-map 0:v -map 0:${highestChannelCount.index} -map 0:a -map 0:s? -map 0:d? -c copy -c:a:0 ${audioEncoder} -ac ${channelCount} -max_muxing_queue_size 9999`,
             processFile: true,
             note: `The required channel count ${channelCount} is lower than the highest available channel count (${highestChannelCount.channels}). Adding! \n`,
           };
@@ -155,7 +155,7 @@ module.exports = function transcodeAddAudioStream(
           };
         } else {
           return {
-            preset: `,-map 0:v -map 0:${highestChannelCount.index} -map 0:a -map 0:s? -map 0:d? -c copy -c:a:0 ${audioEncoder} -ac ${highestChannelCount.channels}`,
+            preset: `,-map 0:v -map 0:${highestChannelCount.index} -map 0:a -map 0:s? -map 0:d? -c copy -c:a:0 ${audioEncoder} -ac ${highestChannelCount.channels} -max_muxing_queue_size 9999`,
             processFile: true,
             note: `The required channel count (${channelCount}) is higher than the highest channel available in specified lang tag (${highestChannelCount.channels}). Adding lower channel track. \n`,
           };
@@ -229,7 +229,7 @@ module.exports = function transcodeAddAudioStream(
           };
         } else {
           return {
-            preset: `,-map 0:v -map 0:${highestChannelCount.index} -map 0:a -map 0:s? -map 0:d? -c copy -c:a:0 ${audioEncoder} -ac ${channelCount}`,
+            preset: `,-map 0:v -map 0:${highestChannelCount.index} -map 0:a -map 0:s? -map 0:d? -c copy -c:a:0 ${audioEncoder} -ac ${channelCount} -max_muxing_queue_size 9999`,
             processFile: true,
             note: `The required channel count ${channelCount} is lower than the highest available channel count (${highestChannelCount.channels}). Adding! \n`,
           };
@@ -260,7 +260,7 @@ module.exports = function transcodeAddAudioStream(
           };
         } else {
           return {
-            preset: `,-map 0:v -map 0:${highestChannelCount.index} -map 0:a -map 0:s? -map 0:d? -c copy -c:a:0 ${audioEncoder} -ac ${highestChannelCount.channels}`,
+            preset: `,-map 0:v -map 0:${highestChannelCount.index} -map 0:a -map 0:s? -map 0:d? -c copy -c:a:0 ${audioEncoder} -ac ${highestChannelCount.channels} -max_muxing_queue_size 9999`,
             processFile: true,
             note: `The required channel count (${channelCount}) is higher than the highest channel available in specified lang tag (${highestChannelCount.channels}). Adding lower channel track. \n`,
           };


### PR DESCRIPTION
I have added the following setting to the preset commands: -max_muxing_queue_size 9999
Some movies are not processed due to the following error message: Too many packets buffered for output stream 0:0.