### PR TITLE
Update HDR Flow

### DIFF
--- a/FlowPlugins/CommunityFlowPlugins/video/checkHdr/1.0.0/index.js
+++ b/FlowPlugins/CommunityFlowPlugins/video/checkHdr/1.0.0/index.js
@@ -38,7 +38,7 @@ var plugin = function (args) {
         for (var i = 0; i < args.inputFileObj.ffProbeData.streams.length; i += 1) {
             var stream = args.inputFileObj.ffProbeData.streams[i];
             if (stream.codec_type === 'video'
-                && stream.transfer_characteristics === 'smpte2084'
+                && stream.color_transfer === 'smpte2084'
                 && stream.color_primaries === 'bt2020'
                 && stream.color_range === 'tv') {
                 isHdr = true;

--- a/FlowPluginsTs/CommunityFlowPlugins/video/checkHdr/1.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/video/checkHdr/1.0.0/index.ts
@@ -43,7 +43,7 @@ const plugin = (args: IpluginInputArgs): IpluginOutputArgs => {
       const stream = args.inputFileObj.ffProbeData.streams[i];
       if (
         stream.codec_type === 'video'
-        && stream.transfer_characteristics === 'smpte2084'
+        && stream.color_transfer === 'smpte2084'
         && stream.color_primaries === 'bt2020'
         && stream.color_range === 'tv'
       ) {


### PR DESCRIPTION
HDR Flow is looking for "transfer_characteristics" ffprobe attribute that doesn't exist. I believe the correct attribute should be "color_transfer"
![image](https://github.com/HaveAGitGat/Tdarr_Plugins/assets/32966295/7374aa4a-ebfe-4786-8596-243617edede4)
