### PR TITLE
Update wording for description of upper bound of New_file_size_check

### DIFF
--- a/Community/Tdarr_Plugin_a9he_New_file_size_check.js
+++ b/Community/Tdarr_Plugin_a9he_New_file_size_check.js
@@ -17,7 +17,7 @@ const details = () => ({
       },
       tooltip:
         `Enter the upper bound % size for the new file. For example, if '110' is entered, 
-        then if the new file size is 11% larger than the original, an error will be given.`,
+        then if the new file size is greater than 110% the size of the original, an error will be given.`,
     },
     {
       name: 'lowerBound',


### PR DESCRIPTION
The wording was unclear and ambiguous for Upper Bound. Updated to clarify while mirroring style of Lower Bound