### PR TITLE
Use filtergraph to specify 10-bit pixel format

### DIFF
--- a/Community/Tdarr_Plugin_bsh1_Boosh_FFMPEG_QSV_HEVC.js
+++ b/Community/Tdarr_Plugin_bsh1_Boosh_FFMPEG_QSV_HEVC.js
@@ -606,7 +606,7 @@ const plugin = (file, librarySettings, inputs, otherArguments) => {
   // With this set we also disable hardware decode for compatibility later
   if (inputs.enable_10bit === true) {
     main10 = true;
-    extraArguments += '-profile:v main10 -pix_fmt p010le ';
+    extraArguments += '-profile:v main10 -vf scale_qsv=format=p010le ';
     response.infoLog += '10 bit encode enabled. Setting Main10 Profile & 10 bit pixel format \n';
   }
 

--- a/tests/Community/Tdarr_Plugin_bsh1_Boosh_FFMPEG_QSV_HEVC.js
+++ b/tests/Community/Tdarr_Plugin_bsh1_Boosh_FFMPEG_QSV_HEVC.js
@@ -80,7 +80,7 @@ const tests = [
       linux: {
         processFile: true,
         preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv \n'
-          + '      -init_hw_device qsv:hw_any,child_device_type=vaapi <io> -map 0 -c:v hevc_qsv -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -profile:v main10 -pix_fmt p010le  ',
+          + '      -init_hw_device qsv:hw_any,child_device_type=vaapi <io> -map 0 -c:v hevc_qsv -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -profile:v main10 -vf scale_qsv=format=p010le  ',
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,
@@ -98,7 +98,7 @@ const tests = [
       win32: {
         processFile: true,
         preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv \n'
-          + '      -init_hw_device qsv:hw_any,child_device_type=d3d11va <io> -map 0 -c:v hevc_qsv -load_plugin hevc_hw -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -profile:v main10 -pix_fmt p010le  ',
+          + '      -init_hw_device qsv:hw_any,child_device_type=d3d11va <io> -map 0 -c:v hevc_qsv -load_plugin hevc_hw -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -profile:v main10 -vf scale_qsv=format=p010le  ',
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,
@@ -115,7 +115,7 @@ const tests = [
       },
       darwin: {
         processFile: true,
-        preset: '-fflags +genpts -hwaccel videotoolbox<io> -map 0 -c:v hevc_videotoolbox -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset fast -c:a copy -c:s copy -max_muxing_queue_size 9999 -profile:v main10 -pix_fmt p010le ',
+        preset: '-fflags +genpts -hwaccel videotoolbox<io> -map 0 -c:v hevc_videotoolbox -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset fast -c:a copy -c:s copy -max_muxing_queue_size 9999 -profile:v main10 -vf scale_qsv=format=p010le ',
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,


### PR DESCRIPTION
Fixes https://github.com/HaveAGitGat/Tdarr/issues/795

After the ffmpeg 6 upgrade, the `Boosh-Transcode using QSV GPU & FFMPEG` plugin would no longer be able to transcode to 10-bit HEVC, and would give the following error:

> Impossible to convert between the formats supported by the filter 'Parsed_null_0' and the filter 'auto_scale_0'

The reason I was given is:

> `-pix_fmt`, `-s`, and the like are just sugar for `-vf scale=[...]`, and the scale filter only operates on software frames. if you're using hardware frames, you need to insert the filter yourself, and pick the appropriate one for your use-case

This PR addresses the issue by replacing `-pix_fmt` with `-vf scale=[...]`. With this change I was able to upgrade to the latest version is Tdarr and still output 10-bit HEVC.