### PR TITLE
Update Tdarr_Plugin_bsh1_Boosh_FFMPEG_QSV_HEVC.js

### DIFF
--- a/Community/Tdarr_Plugin_bsh1_Boosh_FFMPEG_QSV_HEVC.js
+++ b/Community/Tdarr_Plugin_bsh1_Boosh_FFMPEG_QSV_HEVC.js
@@ -731,20 +731,23 @@ const plugin = (file, librarySettings, inputs, otherArguments) => {
 
   // HW ACCEL FLAGS
   // Account for different OS
-  switch (os.platform()) {
-    case 'darwin': // Mac OS - Enable videotoolbox instead of QSV
-      response.preset += '-hwaccel videotoolbox';
-      break;
-    case 'linux': // Linux - Full device, should fix child_device_type warnings
-      response.preset += `-hwaccel qsv -hwaccel_output_format qsv 
+  if (main10 === false) {
+    // On testing it seems the below will automatically enable hardware decoding which causes issues...
+    switch (os.platform()) {
+      case 'darwin': // Mac OS - Enable videotoolbox instead of QSV
+        response.preset += '-hwaccel videotoolbox';
+        break;
+      case 'linux': // Linux - Full device, should fix child_device_type warnings
+        response.preset += `-hwaccel qsv -hwaccel_output_format qsv 
       -init_hw_device qsv:hw_any,child_device_type=vaapi `;
-      break;
-    case 'win32': // Windows - Full device, should fix child_device_type warnings
-      response.preset += `-hwaccel qsv -hwaccel_output_format qsv 
+        break;
+      case 'win32': // Windows - Full device, should fix child_device_type warnings
+        response.preset += `-hwaccel qsv -hwaccel_output_format qsv 
       -init_hw_device qsv:hw_any,child_device_type=d3d11va `;
-      break;
-    default:
-      response.preset += '-hwaccel qsv -hwaccel_output_format qsv -init_hw_device qsv:hw_any ';
+        break;
+      default:
+        response.preset += '-hwaccel qsv -hwaccel_output_format qsv -init_hw_device qsv:hw_any ';
+    }
   }
 
   // DECODE FLAGS

--- a/tests/Community/Tdarr_Plugin_bsh1_Boosh_FFMPEG_QSV_HEVC.js
+++ b/tests/Community/Tdarr_Plugin_bsh1_Boosh_FFMPEG_QSV_HEVC.js
@@ -79,8 +79,7 @@ const tests = [
     output: {
       linux: {
         processFile: true,
-        preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv \n'
-          + '      -init_hw_device qsv:hw_any,child_device_type=vaapi <io> -map 0 -c:v hevc_qsv -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -profile:v main10 -vf scale_qsv=format=p010le  ',
+        preset: '-fflags +genpts<io> -map 0 -c:v hevc_qsv -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -profile:v main10 -vf scale_qsv=format=p010le  ',
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,
@@ -97,8 +96,7 @@ const tests = [
       },
       win32: {
         processFile: true,
-        preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv \n'
-          + '      -init_hw_device qsv:hw_any,child_device_type=d3d11va <io> -map 0 -c:v hevc_qsv -load_plugin hevc_hw -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -profile:v main10 -vf scale_qsv=format=p010le  ',
+        preset: '-fflags +genpts<io> -map 0 -c:v hevc_qsv -load_plugin hevc_hw -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -profile:v main10 -vf scale_qsv=format=p010le  ',
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,
@@ -115,7 +113,7 @@ const tests = [
       },
       darwin: {
         processFile: true,
-        preset: '-fflags +genpts -hwaccel videotoolbox<io> -map 0 -c:v hevc_videotoolbox -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset fast -c:a copy -c:s copy -max_muxing_queue_size 9999 -profile:v main10 -vf scale_qsv=format=p010le ',
+        preset: '-fflags +genpts<io> -map 0 -c:v hevc_videotoolbox -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset fast -c:a copy -c:s copy -max_muxing_queue_size 9999 -profile:v main10 -vf scale_qsv=format=p010le ',
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,

--- a/tests/Community/Tdarr_Plugin_bsh1_Boosh_FFMPEG_QSV_HEVC.js
+++ b/tests/Community/Tdarr_Plugin_bsh1_Boosh_FFMPEG_QSV_HEVC.js
@@ -79,7 +79,7 @@ const tests = [
     output: {
       linux: {
         processFile: true,
-        preset: '-fflags +genpts<io> -map 0 -c:v hevc_qsv -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -profile:v main10 -vf scale_qsv=format=p010le  ',
+        preset: '-fflags +genpts <io> -map 0 -c:v hevc_qsv -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -profile:v main10 -vf scale_qsv=format=p010le  ',
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,
@@ -96,7 +96,7 @@ const tests = [
       },
       win32: {
         processFile: true,
-        preset: '-fflags +genpts<io> -map 0 -c:v hevc_qsv -load_plugin hevc_hw -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -profile:v main10 -vf scale_qsv=format=p010le  ',
+        preset: '-fflags +genpts <io> -map 0 -c:v hevc_qsv -load_plugin hevc_hw -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -profile:v main10 -vf scale_qsv=format=p010le  ',
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,
@@ -113,7 +113,7 @@ const tests = [
       },
       darwin: {
         processFile: true,
-        preset: '-fflags +genpts<io> -map 0 -c:v hevc_videotoolbox -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset fast -c:a copy -c:s copy -max_muxing_queue_size 9999 -profile:v main10 -vf scale_qsv=format=p010le ',
+        preset: '-fflags +genpts <io> -map 0 -c:v hevc_videotoolbox -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset fast -c:a copy -c:s copy -max_muxing_queue_size 9999 -profile:v main10 -vf scale_qsv=format=p010le ',
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,


### PR DESCRIPTION
Fixed up an issue with HW decoding. If the input file is 10 bit or 10bit is set on options, the plugin should disable hw decoding to avoid odd encode errors. It seems though when -hwaccel qsv is set then ffmpeg automatically enables hw decoding, so just protected against that. 
There's been several reports of issues with certain files & I think this is the cause. I've tested and that appears to resolve the transcode error & hw decoding isn't super important