### PR TITLE
Fix for HW decode & High10 - Tdarr_Plugin_bsh1_Boosh_FFMPEG_QSV_HEVC.js

### DIFF
--- a/tests/Community/Tdarr_Plugin_bsh1_Boosh_FFMPEG_QSV_HEVC.js
+++ b/tests/Community/Tdarr_Plugin_bsh1_Boosh_FFMPEG_QSV_HEVC.js
@@ -79,7 +79,8 @@ const tests = [
     output: {
       linux: {
         processFile: true,
-        preset: '-fflags +genpts <io> -map 0 -c:v hevc_qsv -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -profile:v main10 -vf scale_qsv=format=p010le  ',
+        preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv \n'
+          + '      -init_hw_device qsv:hw_any,child_device_type=vaapi -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -profile:v main10 -vf scale_qsv=format=p010le  ',
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,
@@ -96,7 +97,8 @@ const tests = [
       },
       win32: {
         processFile: true,
-        preset: '-fflags +genpts <io> -map 0 -c:v hevc_qsv -load_plugin hevc_hw -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -profile:v main10 -vf scale_qsv=format=p010le  ',
+        preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv \n'
+          + '      -init_hw_device qsv:hw_any,child_device_type=d3d11va -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -load_plugin hevc_hw -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -profile:v main10 -vf scale_qsv=format=p010le  ',
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,
@@ -113,7 +115,7 @@ const tests = [
       },
       darwin: {
         processFile: true,
-        preset: '-fflags +genpts <io> -map 0 -c:v hevc_videotoolbox -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset fast -c:a copy -c:s copy -max_muxing_queue_size 9999 -profile:v main10 -vf scale_qsv=format=p010le ',
+        preset: '-fflags +genpts -hwaccel videotoolbox<io> -map 0 -c:v hevc_videotoolbox -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset fast -c:a copy -c:s copy -max_muxing_queue_size 9999 -profile:v main10 -vf scale_qsv=format=p010le ',
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,


### PR DESCRIPTION
Previous fix broke 10bit encodes. New fix sorts that & fixes up when HW decode should be used. H264 High10 was the problem all along, QSV seems to be happy decoding most 10bit files but High10 throws a spanner in. So now we enable SW decode for anything High10 and use normal HW decode on the rest. Pixel format cmd has a small adjustment depending on HW or SW decode.

Got some new test files to cover 10bit files better in future. Also I don't think there's test data for High10 files. Not sure if that's worth setting up now that Flows is a thing?