### PR TITLE
fix(#277): Update Tdarr_Plugin_sdd3_Remove_Commentary_Tracks.js

### DIFF
--- a/Community/Tdarr_Plugin_sdd3_Remove_Commentary_Tracks.js
+++ b/Community/Tdarr_Plugin_sdd3_Remove_Commentary_Tracks.js
@@ -56,6 +56,7 @@ const plugin = (file, librarySettings, inputs, otherArguments) => {
       if (
         file.ffProbeData.streams[i].codec_type.toLowerCase() == "audio" &&
         file.ffProbeData.streams[i].disposition.comment == 1 ||
+        file.ffProbeData.streams[i].codec_type.toLowerCase() == "audio" &&
         file.ffProbeData.streams[i].tags.title
           .toLowerCase()
           .includes("commentary")


### PR DESCRIPTION
As stated in #277 , without this line of code the plugin keeps failing when detecting a subtitle with commentary tagged in it.