### PR TITLE
Add opus support to EnsureAudioStream

### DIFF
--- a/FlowPluginsTs/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandEnsureAudioStream/1.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandEnsureAudioStream/1.0.0/index.ts
@@ -31,6 +31,7 @@ const details = (): IpluginDetails => ({
           'eac3',
           'dca',
           'flac',
+          'libopus',
           'mp2',
           'libmp3lame',
           'truehd',
@@ -190,6 +191,10 @@ const plugin = (args: IpluginInputArgs): IpluginOutputArgs => {
 
   if (audioEncoder === 'libmp3lame') {
     audioCodec = 'mp3';
+  }
+
+  if (audioEncoder === 'libopus') {
+    audioCodec = 'opus';
   }
 
   const addedOrExists = attemptMakeStream({


### PR DESCRIPTION
This PR still needs to be compiled with TSC, I just made a quick edit to make it easier for @HaveAGitGat . I am doing this from github's web environment so I can't compile the typescript myself. 

For reference, ffmpeg uses `libopus` as its opus encoder so it needs the little if condition to convert this encoder name to the `opus` codec name.