### PR TITLE
Update Tdarr_Plugin_bsh1_Boosh_FFMPEG_QSV_HEVC - Improving hw cmd & removing mkvpropedit

### DIFF
--- a/Community/Tdarr_Plugin_bsh1_Boosh_FFMPEG_QSV_HEVC.js
+++ b/Community/Tdarr_Plugin_bsh1_Boosh_FFMPEG_QSV_HEVC.js
@@ -26,9 +26,8 @@ const details = () => ({
     Settings are dependant on file bitrate working by the logic that H265 can support the same amount of data at half 
     the bitrate of H264. This plugin will skip files already in HEVC, AV1 & VP9 unless "reconvert_hevc" is marked as 
     true. If it is then these will be reconverted again if they exceed the bitrate specified in "hevc_max_bitrate".
-    This plugin will also attempt to use mkvpropedit to generate accurate bitrate metadata in MKV files.
-    It's not required to enable mkvpropedit but highly recommended to ensure accurate bitrates are used when 
-    encoding your media.`,
+    This plugin relies on understanding the accurate video bitrate of your files. It's highly recommended to remux 
+    into MKV & enable "Run mkvpropedit on files before running plugins" under Tdarr>Options.`,
   Version: '1.21',
   Tags: 'pre-processing,ffmpeg,video only,qsv,h265,hevc,mkvpropedit,configurable',
   Inputs: [
@@ -737,18 +736,18 @@ const plugin = (file, librarySettings, inputs, otherArguments) => {
   // Account for different OS setup for QSV HEVC encode.
   switch (os.platform()) {
     case 'darwin':
-      response.preset += 'hevc_videotoolbox ';
+      response.preset += 'hevc_videotoolbox';
       // Mac OS & uses hevc_videotoolbox not QSV - Only shows up on Mac installs
       break;
     case 'linux':
-      response.preset += 'hevc_qsv ';
+      response.preset += 'hevc_qsv';
       break;
     case 'win32':
-      response.preset += 'hevc_qsv -load_plugin hevc_hw ';
+      response.preset += 'hevc_qsv -load_plugin hevc_hw';
       // Windows needs the additional -load_plugin. Tested working on a Win 10 - i5-10505
       break;
     default:
-      response.preset += 'hevc_qsv '; // Default to QSV
+      response.preset += 'hevc_qsv'; // Default to QSV
   }
 
   // If HW decode is happening add hwupload to encode

--- a/Community/Tdarr_Plugin_bsh1_Boosh_FFMPEG_QSV_HEVC.js
+++ b/Community/Tdarr_Plugin_bsh1_Boosh_FFMPEG_QSV_HEVC.js
@@ -157,7 +157,6 @@ const details = () => ({
       https://ffmpeg.org/ffmpeg-codecs.html#toc-HEVC-Options-1
       \\n
       ==WARNING== \\n
-      Just because a cmd is mentioned doesn't mean your installed version of ffmpeg supports it... 
       Be certain to verify the cmds work before adding to your workflow. \\n
       Check Tdarr Help Tab. Enter ffmpeg cmd - "-h encoder=hevc_qsv". This will give a list of supported commands. \\n
       MAC SPECIFIC - This option is ignored on Mac because videotoolbox is used rather than qsv.

--- a/Community/Tdarr_Plugin_bsh1_Boosh_FFMPEG_QSV_HEVC.js
+++ b/Community/Tdarr_Plugin_bsh1_Boosh_FFMPEG_QSV_HEVC.js
@@ -720,8 +720,14 @@ const plugin = (file, librarySettings, inputs, otherArguments) => {
         case 'h264':
           response.preset += '-c:v h264_qsv';
           break;
+        case 'vc1': // VC1 no longer supported on latest intel HW
+          // response.preset += '-c:v vc1_qsv';
+          break;
         case 'mjpeg':
           response.preset += '-c:v mjpeg_qsv';
+          break;
+        case 'vp8': // VP8 no longer supported on latest intel HW
+          // response.preset += '-c:v vp8_qsv';
           break;
         case 'hevc':
           response.preset += '-c:v hevc_qsv';

--- a/Community/Tdarr_Plugin_bsh1_Boosh_FFMPEG_QSV_HEVC.js
+++ b/Community/Tdarr_Plugin_bsh1_Boosh_FFMPEG_QSV_HEVC.js
@@ -28,8 +28,8 @@ const details = () => ({
     true. If it is then these will be reconverted again if they exceed the bitrate specified in "hevc_max_bitrate".
     This plugin relies on understanding the accurate video bitrate of your files. It's highly recommended to remux 
     into MKV & enable "Run mkvpropedit on files before running plugins" under Tdarr>Options.`,
-  Version: '1.21',
-  Tags: 'pre-processing,ffmpeg,video only,qsv,h265,hevc,mkvpropedit,configurable',
+  Version: '1.3',
+  Tags: 'pre-processing,ffmpeg,video only,qsv,h265,hevc,configurable',
   Inputs: [
     {
       name: 'container',

--- a/Community/Tdarr_Plugin_bsh1_Boosh_FFMPEG_QSV_HEVC.js
+++ b/Community/Tdarr_Plugin_bsh1_Boosh_FFMPEG_QSV_HEVC.js
@@ -670,7 +670,7 @@ const plugin = (file, librarySettings, inputs, otherArguments) => {
     if (inputs.extra_qsv_options.search('-vf scale_qsv') >= 0) {
       extraArguments += '-profile:v main10';
       // eslint-disable-next-line no-param-reassign
-      inputs.extra_qsv_options += ':format=p010le'; // Only add on the pixel format to existing scale_qsv cmd
+      inputs.extra_qsv_options += ',format=p010le'; // Only add on the pixel format to existing scale_qsv cmd
     } else {
       extraArguments += '-profile:v main10 -vf scale_qsv=format=p010le';
     }

--- a/tests/Community/Tdarr_Plugin_bsh1_Boosh_FFMPEG_QSV_HEVC.js
+++ b/tests/Community/Tdarr_Plugin_bsh1_Boosh_FFMPEG_QSV_HEVC.js
@@ -149,12 +149,13 @@ const tests = [
     output: {
       linux: {
         processFile: true,
-        preset: '-fflags +genpts <io> -map 0 -c:v hevc_qsv -b:v 3227k -minrate 2420k -maxrate 4034k -bufsize 6454k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f matroska -profile:v main10 -pix_fmt p010le ',
+        preset: '-fflags +genpts -hwaccel_output_format qsv \n'
+          + '        -init_hw_device qsv:hw,child_device_type=vaapi -c:v h264<io> -map 0 -c:v hevc_qsv -b:v 3227k -minrate 2420k -maxrate 4034k -bufsize 6454k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f matroska -profile:v main10 -pix_fmt p010le ',
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,
         infoLog: '☑ It looks like the current video bitrate is 6454kbps. \n'
-          + 'Input file is 10bit using High10. Disabling hardware decoding to avoid problems. \n'
+          + 'Input file is h264 High10. Hardware Decode not supported. \n'
           + '10 bit encode enabled. Setting Main10 Profile & 10 bit pixel format \n'
           + 'Container for output selected as mkv. \n'
           + 'Encode variable bitrate settings: \n'
@@ -166,12 +167,13 @@ const tests = [
       },
       win32: {
         processFile: true,
-        preset: '-fflags +genpts <io> -map 0 -c:v hevc_qsv -b:v 3227k -minrate 2420k -maxrate 4034k -bufsize 6454k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f matroska -profile:v main10 -pix_fmt p010le ',
+        preset: '-fflags +genpts -hwaccel_output_format qsv \n'
+          + '        -init_hw_device qsv:hw,child_device_type=d3d11va -c:v h264<io> -map 0 -c:v hevc_qsv -b:v 3227k -minrate 2420k -maxrate 4034k -bufsize 6454k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f matroska -profile:v main10 -pix_fmt p010le ',
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,
         infoLog: '☑ It looks like the current video bitrate is 6454kbps. \n'
-          + 'Input file is 10bit using High10. Disabling hardware decoding to avoid problems. \n'
+          + 'Input file is h264 High10. Hardware Decode not supported. \n'
           + '10 bit encode enabled. Setting Main10 Profile & 10 bit pixel format \n'
           + 'Container for output selected as mkv. \n'
           + 'Encode variable bitrate settings: \n'
@@ -183,7 +185,7 @@ const tests = [
       },
       darwin: {
         processFile: true,
-        preset: '-fflags +genpts <io> -map 0 -c:v hevc_videotoolbox -b:v 3227k -minrate 2420k -maxrate 4034k -bufsize 6454k -preset fast -c:a copy -c:s copy -f matroska -profile:v main10 -pix_fmt p010le ',
+        preset: '-fflags +genpts -c:v h264<io> -map 0 -c:v hevc_videotoolbox -b:v 3227k -minrate 2420k -maxrate 4034k -bufsize 6454k -preset fast -c:a copy -c:s copy -f matroska -profile:v main10 -pix_fmt p010le ',
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,
@@ -501,6 +503,78 @@ const tests = [
       darwin: {
         processFile: true,
         preset: '-fflags +genpts -hwaccel videotoolbox<io> -map 0 -c:v hevc_videotoolbox -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset slow -c:a copy -c:s copy -max_muxing_queue_size 9999 -f matroska ',
+        handBrakeMode: false,
+        FFmpegMode: true,
+        reQueueAfter: true,
+        infoLog: '☑ It looks like the current video bitrate is 1206kbps. \n'
+          + '10 bit encode enabled. Setting Main10 Profile & 10 bit pixel format \n'
+          + 'Container for output selected as mkv. \n'
+          + 'Encode variable bitrate settings: \n'
+          + 'Target = 603k \n'
+          + 'Minimum = 452k \n'
+          + 'Maximum = 754k \n'
+          + '==ALERT== OS detected as MAC - This will use VIDEOTOOLBOX to encode which is NOT QSV\n'
+          + 'cmds set in extra_qsv_options will be IGNORED!\n'
+          + 'File Transcoding... \n',
+        container: '.mkv',
+      },
+    },
+  },
+  // Test 8
+  {
+    input: {
+      file: (() => {
+        const file = _.cloneDeep(require('../sampleData/media/sampleH264_1.json'));
+        file.ffProbeData.streams[0].bits_per_raw_sample = '10';
+        file.video_codec_name = 'vc1';
+        return file;
+      })(),
+      librarySettings: {},
+      inputs: {
+        container: 'mkv',
+        encoder_speedpreset: 'fast',
+      },
+      otherArguments: {},
+    },
+    output: {
+      linux: {
+        processFile: true,
+        preset: '-fflags +genpts -hwaccel_output_format qsv \n'
+          + '        -init_hw_device qsv:hw_any,child_device_type=vaapi -c:v vc1<io> -map 0 -c:v hevc_qsv -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f matroska -profile:v main10 -pix_fmt p010le ',
+        FFmpegMode: true,
+        reQueueAfter: true,
+        infoLog: '☑ It looks like the current video bitrate is 1206kbps. \n'
+          + 'Input file is vc1. Hardware Decode not supported. \n'
+          + '10 bit encode enabled. Setting Main10 Profile & 10 bit pixel format \n'
+          + 'Container for output selected as mkv. \n'
+          + 'Encode variable bitrate settings: \n'
+          + 'Target = 603k \n'
+          + 'Minimum = 452k \n'
+          + 'Maximum = 754k \n'
+          + 'File Transcoding... \n',
+        container: '.mkv',
+      },
+      win32: {
+        processFile: true,
+        preset: '-fflags +genpts -hwaccel_output_format qsv \n'
+          + '        -init_hw_device qsv:hw,child_device_type=d3d11va -c:v vc1<io> -map 0 -c:v hevc_qsv -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f matroska -profile:v main10 -pix_fmt p010le ',
+        handBrakeMode: false,
+        FFmpegMode: true,
+        reQueueAfter: true,
+        infoLog: '☑ It looks like the current video bitrate is 1206kbps. \n'
+          + 'Input file is vc1. Hardware Decode not supported. \n'
+          + '10 bit encode enabled. Setting Main10 Profile & 10 bit pixel format \n'
+          + 'Container for output selected as mkv. \n'
+          + 'Encode variable bitrate settings: \n'
+          + 'Target = 603k \n'
+          + 'Minimum = 452k \n'
+          + 'Maximum = 754k \n'
+          + 'File Transcoding... \n',
+        container: '.mkv',
+      },
+      darwin: {
+        processFile: true,
+        preset: '-fflags +genpts -c:v vc1<io> -map 0 -c:v hevc_videotoolbox -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset slow -c:a copy -c:s copy -max_muxing_queue_size 9999 -f matroska ',
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,

--- a/tests/Community/Tdarr_Plugin_bsh1_Boosh_FFMPEG_QSV_HEVC.js
+++ b/tests/Community/Tdarr_Plugin_bsh1_Boosh_FFMPEG_QSV_HEVC.js
@@ -21,12 +21,11 @@ const tests = [
       linux: {
         processFile: true,
         preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv \n'
-          + '      -init_hw_device qsv:hw_any,child_device_type=vaapi -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset slow  -c:a copy -c:s copy -max_muxing_queue_size 9999  ',
+          + '        -init_hw_device qsv:hw_any,child_device_type=vaapi -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset slow  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f matroska -vf "hwupload=extra_hw_frames=64,format=qsv" ',
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,
-        infoLog: 'Input file is not MKV so cannot use mkvpropedit to get new file stats. Continuing but file stats will likely be inaccurate...\n'
-          + '☑ It looks like the current video bitrate is 1206kbps. \n'
+        infoLog: '☑ It looks like the current video bitrate is 1206kbps. \n'
           + 'Container for output selected as mkv. \n'
           + 'Encode variable bitrate settings: \n'
           + 'Target = 603k \n'
@@ -38,12 +37,11 @@ const tests = [
       win32: {
         processFile: true,
         preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv \n'
-          + '      -init_hw_device qsv:hw_any,child_device_type=d3d11va -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -load_plugin hevc_hw -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset slow  -c:a copy -c:s copy -max_muxing_queue_size 9999  ',
+          + '        -init_hw_device qsv=qsv:MFX_IMPL_hw -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -load_plugin hevc_hw -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset slow  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f matroska -vf "hwupload=extra_hw_frames=64,format=qsv" ',
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,
-        infoLog: 'Input file is not MKV so cannot use mkvpropedit to get new file stats. Continuing but file stats will likely be inaccurate...\n'
-          + '☑ It looks like the current video bitrate is 1206kbps. \n'
+        infoLog: '☑ It looks like the current video bitrate is 1206kbps. \n'
           + 'Container for output selected as mkv. \n'
           + 'Encode variable bitrate settings: \n'
           + 'Target = 603k \n'
@@ -54,12 +52,11 @@ const tests = [
       },
       darwin: {
         processFile: true,
-        preset: '-fflags +genpts -hwaccel videotoolbox<io> -map 0 -c:v hevc_videotoolbox -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset slow -c:a copy -c:s copy -max_muxing_queue_size 9999 ',
+        preset: '-fflags +genpts -hwaccel videotoolbox<io> -map 0 -c:v hevc_videotoolbox -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset slow -c:a copy -c:s copy -max_muxing_queue_size 9999 -f matroska ',
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,
-        infoLog: 'Input file is not MKV so cannot use mkvpropedit to get new file stats. Continuing but file stats will likely be inaccurate...\n'
-          + '☑ It looks like the current video bitrate is 1206kbps. \n'
+        infoLog: '☑ It looks like the current video bitrate is 1206kbps. \n'
           + 'Container for output selected as mkv. \n'
           + 'Encode variable bitrate settings: \n'
           + 'Target = 603k \n'
@@ -88,12 +85,11 @@ const tests = [
       linux: {
         processFile: true,
         preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv \n'
-          + '      -init_hw_device qsv:hw_any,child_device_type=vaapi -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -profile:v main10 -vf scale_qsv=format=p010le  ',
+          + '        -init_hw_device qsv:hw_any,child_device_type=vaapi -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f mp4 -profile:v main10 -vf scale_qsv=format=p010le -vf "hwupload=extra_hw_frames=64,format=qsv" ',
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,
-        infoLog: 'Input file is not MKV so cannot use mkvpropedit to get new file stats. Continuing but file stats will likely be inaccurate...\n'
-          + '☑ It looks like the current video bitrate is 1206kbps. \n'
+        infoLog: '☑ It looks like the current video bitrate is 1206kbps. \n'
           + '10 bit encode enabled. Setting Main10 Profile & 10 bit pixel format \n'
           + 'Container for output selected as mp4. \n'
           + 'Encode variable bitrate settings: \n'
@@ -106,12 +102,11 @@ const tests = [
       win32: {
         processFile: true,
         preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv \n'
-          + '      -init_hw_device qsv:hw_any,child_device_type=d3d11va -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -load_plugin hevc_hw -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -profile:v main10 -vf scale_qsv=format=p010le  ',
+          + '        -init_hw_device qsv=qsv:MFX_IMPL_hw -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -load_plugin hevc_hw -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f mp4 -profile:v main10 -vf scale_qsv=format=p010le -vf "hwupload=extra_hw_frames=64,format=qsv" ',
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,
-        infoLog: 'Input file is not MKV so cannot use mkvpropedit to get new file stats. Continuing but file stats will likely be inaccurate...\n'
-          + '☑ It looks like the current video bitrate is 1206kbps. \n'
+        infoLog: '☑ It looks like the current video bitrate is 1206kbps. \n'
           + '10 bit encode enabled. Setting Main10 Profile & 10 bit pixel format \n'
           + 'Container for output selected as mp4. \n'
           + 'Encode variable bitrate settings: \n'
@@ -123,7 +118,7 @@ const tests = [
       },
       darwin: {
         processFile: true,
-        preset: '-fflags +genpts -hwaccel videotoolbox<io> -map 0 -c:v hevc_videotoolbox -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset fast -c:a copy -c:s copy -max_muxing_queue_size 9999 -profile:v main10 -vf scale_qsv=format=p010le ',
+        preset: '-fflags +genpts -hwaccel videotoolbox<io> -map 0 -c:v hevc_videotoolbox -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset fast -c:a copy -c:s copy -max_muxing_queue_size 9999 -f mp4 -profile:v main10 -vf scale_qsv=format=p010le ',
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,
@@ -148,7 +143,6 @@ const tests = [
       file: (() => {
         const file = _.cloneDeep(require('../sampleData/media/sampleH264_2.json'));
         file.ffProbeData.streams[0].profile = 'High 10';
-        file.mediaInfo.track[0].extra.JBDONEDATE = new Date().toISOString();
         return file;
       })(),
       librarySettings: {},
@@ -161,17 +155,11 @@ const tests = [
     output: {
       linux: {
         processFile: true,
-        preset: '-fflags +genpts <io> -map 0 -c:v hevc_qsv -b:v 3227k -minrate 2420k -maxrate 4034k -bufsize 6454k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -profile:v main10 -pix_fmt p010le  -map_metadata:g -1 -metadata JBDONEDATE=2674800000',
+        preset: '-fflags +genpts <io> -map 0 -c:v hevc_qsv -b:v 3227k -minrate 2420k -maxrate 4034k -bufsize 6454k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f matroska -profile:v main10 -pix_fmt p010le ',
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,
-        infoLog: "Checking file stats - If stats are older than 7 days we'll grab new stats.\n"
-          + '\n'
-          + `    Stats threshold: ${statsThresString}\n`
-          + '\n'
-          + `    Current stats date: ${datStatsString}\n`
-          + '☑ File stats are upto date! - Continuing...\n'
-          + '☑ It looks like the current video bitrate is 6454kbps. \n'
+        infoLog: '☑ It looks like the current video bitrate is 6454kbps. \n'
           + 'Input file is 10bit using High10. Disabling hardware decoding to avoid problems. \n'
           + '10 bit encode enabled. Setting Main10 Profile & 10 bit pixel format \n'
           + 'Container for output selected as mkv. \n'
@@ -184,17 +172,11 @@ const tests = [
       },
       win32: {
         processFile: true,
-        preset: '-fflags +genpts <io> -map 0 -c:v hevc_qsv -load_plugin hevc_hw -b:v 3227k -minrate 2420k -maxrate 4034k -bufsize 6454k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -profile:v main10 -pix_fmt p010le  -map_metadata:g -1 -metadata JBDONEDATE=2674800000',
+        preset: '-fflags +genpts <io> -map 0 -c:v hevc_qsv -load_plugin hevc_hw -b:v 3227k -minrate 2420k -maxrate 4034k -bufsize 6454k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f matroska -profile:v main10 -pix_fmt p010le ',
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,
-        infoLog: "Checking file stats - If stats are older than 7 days we'll grab new stats.\n"
-          + '\n'
-          + `    Stats threshold: ${statsThresString}\n`
-          + '\n'
-          + `    Current stats date: ${datStatsString}\n`
-          + '☑ File stats are upto date! - Continuing...\n'
-          + '☑ It looks like the current video bitrate is 6454kbps. \n'
+        infoLog: '☑ It looks like the current video bitrate is 6454kbps. \n'
           + 'Input file is 10bit using High10. Disabling hardware decoding to avoid problems. \n'
           + '10 bit encode enabled. Setting Main10 Profile & 10 bit pixel format \n'
           + 'Container for output selected as mkv. \n'
@@ -207,17 +189,11 @@ const tests = [
       },
       darwin: {
         processFile: true,
-        preset: '-fflags +genpts <io> -map 0 -c:v hevc_videotoolbox -b:v 3227k -minrate 2420k -maxrate 4034k -bufsize 6454k -preset fast -c:a copy -c:s copy -profile:v main10 -pix_fmt p010le  -map_metadata:g -1 -metadata JBDONEDATE=2674800000',
+        preset: '-fflags +genpts <io> -map 0 -c:v hevc_videotoolbox -b:v 3227k -minrate 2420k -maxrate 4034k -bufsize 6454k -preset fast -c:a copy -c:s copy -f matroska -profile:v main10 -pix_fmt p010le ',
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,
-        infoLog: "Checking file stats - If stats are older than 7 days we'll grab new stats.\n"
-          + '\n'
-          + `    Stats threshold: ${statsThresString}\n`
-          + '\n'
-          + `    Current stats date: ${datStatsString}\n`
-          + '☑ File stats are upto date! - Continuing...\n'
-          + '☑ It looks like the current video bitrate is 6454kbps. \n'
+        infoLog: '☑ It looks like the current video bitrate is 6454kbps. \n'
           + 'Input file is 10bit using High10. Disabling hardware decoding to avoid problems. \n'
           + '10 bit encode enabled. Setting Main10 Profile & 10 bit pixel format \n'
           + 'Container for output selected as mkv. \n'
@@ -237,9 +213,8 @@ const tests = [
     input: {
       file: (() => {
         const file = _.cloneDeep(require('../sampleData/media/sampleH265_1.json'));
-        file.mediaInfo.track[1].BitRate = 12059590;
+        file.mediaInfo.track[1].BitRate = 12000000;
         file.ffProbeData.streams[0].profile = 'Main 10';
-        file.mediaInfo.track[0].extra.JBDONEDATE = new Date().toISOString();
         return file;
       })(),
       librarySettings: {},
@@ -256,73 +231,55 @@ const tests = [
       linux: {
         processFile: true,
         preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv \n'
-          + '      -init_hw_device qsv:hw_any,child_device_type=vaapi -c:v hevc_qsv<io> -map 0 -c:v hevc_qsv -load_plugin hevc_hw -b:v 6030k -minrate 4523k -maxrate 7538k -bufsize 12060k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -profile:v main10 -vf scale_qsv=format=p010le  -map_metadata:g -1 -metadata JBDONEDATE=2674800000',
+          + '        -init_hw_device qsv:hw_any,child_device_type=vaapi -c:v hevc_qsv<io> -map 0 -c:v hevc_qsv -load_plugin hevc_hw -b:v 6000k -minrate 4500k -maxrate 7500k -bufsize 12000k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f matroska -profile:v main10 -vf scale_qsv=format=p010le -vf "hwupload=extra_hw_frames=64,format=qsv" ',
         FFmpegMode: true,
         reQueueAfter: true,
-        infoLog: "Checking file stats - If stats are older than 7 days we'll grab new stats.\n"
-          + '\n'
-          + `    Stats threshold: ${statsThresString}\n`
-          + '\n'
-          + `    Current stats date: ${datStatsString}\n`
-          + '☑ File stats are upto date! - Continuing...\n'
-          + '☑ It looks like the current video bitrate is 12060kbps. \n'
+        infoLog: '☑ It looks like the current video bitrate is 12000kbps. \n'
           + 'Reconvert_hevc is true & the file is already HEVC, VP9 or AV1. Using HEVC specific cutoff of 6000kbps. \n'
           + '☒ The file is still above this new cutoff! Reconverting. \n'
           + '10 bit encode enabled. Setting Main10 Profile & 10 bit pixel format \n'
           + 'Container for output selected as mkv. \n'
           + 'Encode variable bitrate settings: \n'
-          + 'Target = 6030k \n'
-          + 'Minimum = 4523k \n'
-          + 'Maximum = 7538k \n'
+          + 'Target = 6000k \n'
+          + 'Minimum = 4500k \n'
+          + 'Maximum = 7500k \n'
           + 'File Transcoding... \n',
         container: '.mkv',
       },
       win32: {
         processFile: true,
         preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv \n'
-          + '      -init_hw_device qsv:hw_any,child_device_type=d3d11va -c:v hevc_qsv<io> -map 0 -c:v hevc_qsv -load_plugin hevc_hw -b:v 6030k -minrate 4523k -maxrate 7538k -bufsize 12060k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -profile:v main10 -vf scale_qsv=format=p010le  -map_metadata:g -1 -metadata JBDONEDATE=2674800000',
+          + '        -init_hw_device qsv=qsv:MFX_IMPL_hw -c:v hevc_qsv<io> -map 0 -c:v hevc_qsv -load_plugin hevc_hw -b:v 6000k -minrate 4500k -maxrate 7500k -bufsize 12000k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f matroska -profile:v main10 -vf scale_qsv=format=p010le -vf "hwupload=extra_hw_frames=64,format=qsv" ',
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,
-        infoLog: "Checking file stats - If stats are older than 7 days we'll grab new stats.\n"
-          + '\n'
-          + `    Stats threshold: ${statsThresString}\n`
-          + '\n'
-          + `    Current stats date: ${datStatsString}\n`
-          + '☑ File stats are upto date! - Continuing...\n'
-          + '☑ It looks like the current video bitrate is 12060kbps. \n'
+        infoLog: '☑ It looks like the current video bitrate is 12000kbps. \n'
           + 'Reconvert_hevc is true & the file is already HEVC, VP9 or AV1. Using HEVC specific cutoff of 6000kbps. \n'
           + '☒ The file is still above this new cutoff! Reconverting. \n'
           + '10 bit encode enabled. Setting Main10 Profile & 10 bit pixel format \n'
           + 'Container for output selected as mkv. \n'
           + 'Encode variable bitrate settings: \n'
-          + 'Target = 6030k \n'
-          + 'Minimum = 4523k \n'
-          + 'Maximum = 7538k \n'
+          + 'Target = 6000k \n'
+          + 'Minimum = 4500k \n'
+          + 'Maximum = 7500k \n'
           + 'File Transcoding... \n',
         container: '.mkv',
       },
       darwin: {
         processFile: true,
-        preset: '-fflags +genpts <io> -map 0 -c:v hevc_videotoolbox -b:v 6030k -minrate 4523k -maxrate 7538k -bufsize 12060k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -profile:v main10 -vf scale_qsv=format=p010le  -map_metadata:g -1 -metadata JBDONEDATE=2674800000',
+        preset: '-fflags +genpts <io> -map 0 -c:v hevc_videotoolbox -b:v 6000k -minrate 4500k -maxrate 7500k -bufsize 12000k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -profile:v main10 -f matroska -profile:v main10 -vf scale_qsv=format=p010le',
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,
-        infoLog: "Checking file stats - If stats are older than 7 days we'll grab new stats.\n"
-          + '\n'
-          + `    Stats threshold: ${statsThresString}\n`
-          + '\n'
-          + `    Current stats date: ${datStatsString}\n`
-          + '☑ File stats are upto date! - Continuing...\n'
-          + '☑ It looks like the current video bitrate is 12060kbps. \n'
+        infoLog: '☑ It looks like the current video bitrate is 12000kbps. \n'
           + 'Reconvert_hevc is true & the file is already HEVC, VP9 or AV1. Using HEVC specific cutoff of 6000kbps. \n'
           + '☒ The file is still above this new cutoff! Reconverting. \n'
           + '10 bit encode enabled. Setting Main10 Profile & 10 bit pixel format \n'
           + 'Container for output selected as mkv. \n'
           + 'Encode variable bitrate settings: \n'
-          + 'Target = 6030k \n'
-          + 'Minimum = 4523k \n'
-          + 'Maximum = 7538k \n'
+          + 'Target = 6000k \n'
+          + 'Minimum = 4500k \n'
+          + 'Maximum = 7500k \n'
           + '==ALERT== OS detected as MAC - This will use VIDEOTOOLBOX to encode which is NOT QSV\n'
           + 'cmds set in extra_qsv_options will be IGNORED!\n'
           + 'File Transcoding... \n',
@@ -356,13 +313,7 @@ const tests = [
       handBrakeMode: false,
       FFmpegMode: true,
       reQueueAfter: true,
-      infoLog: "Checking file stats - If stats are older than 7 days we'll grab new stats.\n"
-        + '\n'
-        + `    Stats threshold: ${statsThresString}\n`
-        + '\n'
-        + `    Current stats date: ${datStatsString}\n`
-        + '☑ File stats are upto date! - Continuing...\n'
-        + '☑ It looks like the current video bitrate is 5000kbps. \n'
+      infoLog: '☑ It looks like the current video bitrate is 5000kbps. \n'
         + 'Reconvert_hevc is true & the file is already HEVC, VP9 or AV1. Using HEVC specific cutoff of 6000kbps. \n'
         + '☑ The file is NOT above this new cutoff. Exiting plugin. \n',
       container: '.mkv',
@@ -372,37 +323,7 @@ const tests = [
   {
     input: {
       file: (() => {
-        const file = _.cloneDeep(require('../sampleData/media/sampleH265_1.json'));
-        file.container = 'mp4';
-        return file;
-      })(),
-      librarySettings: {},
-      inputs: {
-        container: 'mp4',
-        encoder_speedpreset: 'fast',
-        bitrate_cutoff: '3500',
-      },
-      otherArguments: {},
-    },
-    output: {
-      processFile: false,
-      preset: '',
-      handBrakeMode: false,
-      FFmpegMode: true,
-      reQueueAfter: true,
-      infoLog: 'Input file is not MKV so cannot use mkvpropedit to get new file stats. Continuing but file stats will likely be inaccurate...\n'
-        + '==WARNING== Failed to get an accurate video bitrate, falling back to old method to get OVERALL file bitrate of 3059kbps. Bitrate calculations for video encode will likely be inaccurate... \n'
-        + '☑ Current bitrate is below set cutoff of 3500kbps. \n'
-        + 'Cancelling plugin. \n',
-      container: '.mp4',
-    },
-  },
-  // Test 6
-  {
-    input: {
-      file: (() => {
         const file = _.cloneDeep(require('../sampleData/media/sampleH264_2.json'));
-        file.mediaInfo.track[0].extra.JBDONEDATE = new Date().toISOString();
         file.ffProbeData.streams[3].codec_name = 'hdmv_pgs_subtitle';
         file.ffProbeData.streams[4].codec_name = 'eia_608';
         file.ffProbeData.streams[5].codec_name = 'subrip';
@@ -421,17 +342,11 @@ const tests = [
       linux: {
         processFile: true,
         preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv \n'
-          + '      -init_hw_device qsv:hw_any,child_device_type=vaapi -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -load_plugin hevc_hw -b:v 3227k -minrate 2420k -maxrate 4034k -bufsize 6454k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -map -0:3 -map -0:4 -map -0:5 -map -0:6  -map_metadata:g -1 -metadata JBDONEDATE=2674800000',
+          + '        -init_hw_device qsv:hw_any,child_device_type=vaapi -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -load_plugin hevc_hw -b:v 3227k -minrate 2420k -maxrate 4034k -bufsize 6454k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -map -0:3 -map -0:4 -map -0:5 -map -0:6 -f mp4 -vf "hwupload=extra_hw_frames=64,format=qsv" ',
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,
-        infoLog: "Checking file stats - If stats are older than 7 days we'll grab new stats.\n"
-          + '\n'
-          + `    Stats threshold: ${statsThresString}\n`
-          + '\n'
-          + `    Current stats date: ${datStatsString}\n`
-          + '☑ File stats are upto date! - Continuing...\n'
-          + '☑ It looks like the current video bitrate is 6454kbps. \n'
+        infoLog: '☑ It looks like the current video bitrate is 6454kbps. \n'
           + 'Container for output selected as mp4. \n'
           + 'Encode variable bitrate settings: \n'
           + 'Target = 3227k \n'
@@ -443,17 +358,11 @@ const tests = [
       win32: {
         processFile: true,
         preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv \n'
-          + '      -init_hw_device qsv:hw_any,child_device_type=d3d11va -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -load_plugin hevc_hw -b:v 3227k -minrate 2420k -maxrate 4034k -bufsize 6454k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -map -0:3 -map -0:4 -map -0:5 -map -0:6  -map_metadata:g -1 -metadata JBDONEDATE=2674800000',
+          + '        -init_hw_device qsv=qsv:MFX_IMPL_hw -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -load_plugin hevc_hw -b:v 3227k -minrate 2420k -maxrate 4034k -bufsize 6454k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -map -0:3 -map -0:4 -map -0:5 -map -0:6 -f mp4 -vf "hwupload=extra_hw_frames=64,format=qsv" ',
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,
-        infoLog: "Checking file stats - If stats are older than 7 days we'll grab new stats.\n"
-          + '\n'
-          + `    Stats threshold: ${statsThresString}\n`
-          + '\n'
-          + `    Current stats date: ${datStatsString}\n`
-          + '☑ File stats are upto date! - Continuing...\n'
-          + '☑ It looks like the current video bitrate is 6454kbps. \n'
+        infoLog: '☑ It looks like the current video bitrate is 6454kbps. \n'
           + 'Container for output selected as mp4. \n'
           + 'Encode variable bitrate settings: \n'
           + 'Target = 3227k \n'
@@ -464,17 +373,11 @@ const tests = [
       },
       darwin: {
         processFile: true,
-        preset: '-fflags +genpts -hwaccel videotoolbox<io> -map 0 -c:v hevc_videotoolbox<io> -map 0 -c:v hevc_qsv -load_plugin hevc_hw -b:v 3227k -minrate 2420k -maxrate 4034k -bufsize 6454k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -map -0:3 -map -0:4 -map -0:5 -map -0:6  -map_metadata:g -1 -metadata JBDONEDATE=2674800000',
+        preset: '-fflags +genpts -hwaccel videotoolbox<io> -map 0 -c:v hevc_videotoolbox<io> -map 0 -c:v hevc_qsv -load_plugin hevc_hw -b:v 3227k -minrate 2420k -maxrate 4034k -bufsize 6454k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -map -0:3 -map -0:4 -map -0:5 -map -0:6 -f mp4',
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,
-        infoLog: "Checking file stats - If stats are older than 7 days we'll grab new stats.\n"
-          + '\n'
-          + `    Stats threshold: ${statsThresString}\n`
-          + '\n'
-          + `    Current stats date: ${datStatsString}\n`
-          + '☑ File stats are upto date! - Continuing...\n'
-          + '☑ It looks like the current video bitrate is 6454kbps. \n'
+        infoLog: '☑ It looks like the current video bitrate is 6454kbps. \n'
           + 'Container for output selected as mp4. \n'
           + 'Encode variable bitrate settings: \n'
           + 'Target = 3227k \n'
@@ -485,12 +388,11 @@ const tests = [
       },
     },
   },
-  // Test 7
+  // Test 6
   {
     input: {
       file: (() => {
         const file = _.cloneDeep(require('../sampleData/media/sampleH264_2.json'));
-        file.mediaInfo.track[0].extra.JBDONEDATE = new Date().toISOString();
         file.ffProbeData.streams[3].codec_name = 'mov_text';
         file.ffProbeData.streams[4].codec_name = 'eia_608';
         file.ffProbeData.streams[5].codec_name = 'timed_id3';
@@ -508,66 +410,48 @@ const tests = [
       linux: {
         processFile: true,
         preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv \n'
-          + '      -init_hw_device qsv:hw_any,child_device_type=vaapi -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -load_plugin hevc_hw -b:v 3227k -minrate 2420k -maxrate 4034k -bufsize 6454k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -map -0:d -map -0:3 -map -0:4 -map -0:5  -map_metadata:g -1 -metadata JBDONEDATE=2674800000',
+          + '        -init_hw_device qsv:hw_any,child_device_type=vaapi -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -load_plugin hevc_hw -b:v 3227k -minrate 2420k -maxrate 4034k -bufsize 6454k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -map -0:d -map -0:3 -map -0:4 -map -0:5 -f matroska -vf "hwupload=extra_hw_frames=64,format=qsv" ',
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,
-        infoLog: "Checking file stats - If stats are older than 7 days we'll grab new stats.\n"
-          + '\n'
-          + `    Stats threshold: ${statsThresString}\n`
-          + '\n'
-          + `    Current stats date: ${datStatsString}\n`
-          + '☑ File stats are upto date! - Continuing...\n'
-          + '☑ It looks like the current video bitrate is 6454kbps. \n'
-          + 'Container for output selected as mkv. \n'
-          + 'Encode variable bitrate settings: \n'
-          + 'Target = 3227k \n'
-          + 'Minimum = 2420k \n'
-          + 'Maximum = 4034k \n'
-          + 'File Transcoding... \n',
+        infoLog: '☑ It looks like the current video bitrate is 6454kbps. \n'
+        + 'Container for output selected as mkv. \n'
+        + 'Encode variable bitrate settings: \n'
+        + 'Target = 3227k \n'
+        + 'Minimum = 2420k \n'
+        + 'Maximum = 4034k \n'
+        + 'File Transcoding... \n',
         container: '.mkv',
       },
       win32: {
         processFile: true,
         preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv \n'
-          + '      -init_hw_device qsv:hw_any,child_device_type=d3d11va -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -load_plugin hevc_hw -b:v 3227k -minrate 2420k -maxrate 4034k -bufsize 6454k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -map -0:d -map -0:3 -map -0:4 -map -0:5  -map_metadata:g -1 -metadata JBDONEDATE=2674800000',
+          + '        -init_hw_device qsv=qsv:MFX_IMPL_hw -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -load_plugin hevc_hw -b:v 3227k -minrate 2420k -maxrate 4034k -bufsize 6454k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -map -0:d -map -0:3 -map -0:4 -map -0:5 -f matroska -vf "hwupload=extra_hw_frames=64,format=qsv" ',
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,
-        infoLog: "Checking file stats - If stats are older than 7 days we'll grab new stats.\n"
-          + '\n'
-          + `    Stats threshold: ${statsThresString}\n`
-          + '\n'
-          + `    Current stats date: ${datStatsString}\n`
-          + '☑ File stats are upto date! - Continuing...\n'
-          + '☑ It looks like the current video bitrate is 6454kbps. \n'
-          + 'Container for output selected as mkv. \n'
-          + 'Encode variable bitrate settings: \n'
-          + 'Target = 3227k \n'
-          + 'Minimum = 2420k \n'
-          + 'Maximum = 4034k \n'
-          + 'File Transcoding... \n',
+        infoLog: '☑ It looks like the current video bitrate is 6454kbps. \n'
+        + 'Container for output selected as mkv. \n'
+        + 'Encode variable bitrate settings: \n'
+        + 'Target = 3227k \n'
+        + 'Minimum = 2420k \n'
+        + 'Maximum = 4034k \n'
+        + 'File Transcoding... \n',
         container: '.mkv',
       },
       darwin: {
         processFile: true,
-        preset: '-fflags +genpts -hwaccel videotoolbox<io> -map 0 -c:v hevc_videotoolbox<io> -map 0 -c:v hevc_qsv -load_plugin hevc_hw -b:v 3227k -minrate 2420k -maxrate 4034k -bufsize 6454k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -map -0:d -map -0:3 -map -0:4 -map -0:5  -map_metadata:g -1 -metadata JBDONEDATE=2674800000',
+        preset: '-fflags +genpts -hwaccel videotoolbox<io> -map 0 -c:v hevc_videotoolbox<io> -map 0 -c:v hevc_qsv -load_plugin hevc_hw -b:v 3227k -minrate 2420k -maxrate 4034k -bufsize 6454k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -map -0:d -map -0:3 -map -0:4 -map -0:5 -f matroska ',
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,
-        infoLog: "Checking file stats - If stats are older than 7 days we'll grab new stats.\n"
-          + '\n'
-          + `    Stats threshold: ${statsThresString}\n`
-          + '\n'
-          + `    Current stats date: ${datStatsString}\n`
-          + '☑ File stats are upto date! - Continuing...\n'
-          + '☑ It looks like the current video bitrate is 6454kbps. \n'
-          + 'Container for output selected as mkv. \n'
-          + 'Encode variable bitrate settings: \n'
-          + 'Target = 3227k \n'
-          + 'Minimum = 2420k \n'
-          + 'Maximum = 4034k \n'
-          + 'File Transcoding... \n',
+        infoLog: '☑ It looks like the current video bitrate is 6454kbps. \n'
+        + 'Container for output selected as mkv. \n'
+        + 'Encode variable bitrate settings: \n'
+        + 'Target = 3227k \n'
+        + 'Minimum = 2420k \n'
+        + 'Maximum = 4034k \n'
+        + 'File Transcoding... \n',
         container: '.mkv',
       },
     },

--- a/tests/Community/Tdarr_Plugin_bsh1_Boosh_FFMPEG_QSV_HEVC.js
+++ b/tests/Community/Tdarr_Plugin_bsh1_Boosh_FFMPEG_QSV_HEVC.js
@@ -31,7 +31,7 @@ const tests = [
       win32: {
         processFile: true,
         preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv \n'
-          + '        -init_hw_device qsv=qsv:MFX_IMPL_hw -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -load_plugin hevc_hw -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset slow  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f matroska -vf "hwupload=extra_hw_frames=64,format=qsv" ',
+          + '        -init_hw_device qsv:hw,child_device_type=d3d11va -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset slow  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f matroska ',
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,
@@ -96,7 +96,7 @@ const tests = [
       win32: {
         processFile: true,
         preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv \n'
-          + '        -init_hw_device qsv=qsv:MFX_IMPL_hw -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -load_plugin hevc_hw -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f mp4 -profile:v main10 -vf scale_qsv=format=p010le -vf "hwupload=extra_hw_frames=64,format=qsv" ',
+          + '        -init_hw_device qsv:hw,child_device_type=d3d11va -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f mp4 -profile:v main10 -vf scale_qsv=format=p010le',
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,
@@ -166,7 +166,7 @@ const tests = [
       },
       win32: {
         processFile: true,
-        preset: '-fflags +genpts <io> -map 0 -c:v hevc_qsv -load_plugin hevc_hw -b:v 3227k -minrate 2420k -maxrate 4034k -bufsize 6454k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f matroska -profile:v main10 -pix_fmt p010le ',
+        preset: '-fflags +genpts <io> -map 0 -c:v hevc_qsv -b:v 3227k -minrate 2420k -maxrate 4034k -bufsize 6454k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f matroska -profile:v main10 -pix_fmt p010le ',
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,
@@ -243,7 +243,7 @@ const tests = [
       win32: {
         processFile: true,
         preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv \n'
-          + '        -init_hw_device qsv=qsv:MFX_IMPL_hw -c:v hevc_qsv<io> -map 0 -c:v hevc_qsv -load_plugin hevc_hw -b:v 6000k -minrate 4500k -maxrate 7500k -bufsize 12000k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f matroska -profile:v main10 -vf scale_qsv=format=p010le -vf "hwupload=extra_hw_frames=64,format=qsv" ',
+          + '        -init_hw_device qsv:hw,child_device_type=d3d11va -c:v hevc_qsv<io> -map 0 -c:v hevc_qsv -b:v 6000k -minrate 4500k -maxrate 7500k -bufsize 12000k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f matroska -profile:v main10 -vf scale_qsv=format=p010le ',
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,
@@ -352,7 +352,7 @@ const tests = [
       win32: {
         processFile: true,
         preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv \n'
-          + '        -init_hw_device qsv=qsv:MFX_IMPL_hw -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -load_plugin hevc_hw -b:v 3227k -minrate 2420k -maxrate 4034k -bufsize 6454k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -map -0:3 -map -0:4 -map -0:5 -map -0:6 -f mp4 -vf "hwupload=extra_hw_frames=64,format=qsv" ',
+          + '        -init_hw_device qsv:hw,child_device_type=d3d11va -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -b:v 3227k -minrate 2420k -maxrate 4034k -bufsize 6454k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -map -0:3 -map -0:4 -map -0:5 -map -0:6 -f mp4 ',
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,
@@ -420,7 +420,7 @@ const tests = [
       win32: {
         processFile: true,
         preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv \n'
-          + '        -init_hw_device qsv=qsv:MFX_IMPL_hw -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -load_plugin hevc_hw -b:v 3227k -minrate 2420k -maxrate 4034k -bufsize 6454k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -map -0:d -map -0:3 -map -0:4 -map -0:5 -f matroska -vf "hwupload=extra_hw_frames=64,format=qsv" ',
+          + '        -init_hw_device qsv:hw,child_device_type=d3d11va -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -b:v 3227k -minrate 2420k -maxrate 4034k -bufsize 6454k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -map -0:d -map -0:3 -map -0:4 -map -0:5 -f matroska ',
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,
@@ -450,6 +450,73 @@ const tests = [
       },
     },
   },
+  // Test 7
+  {
+    input: {
+      file: _.cloneDeep(require('../sampleData/media/sampleH264_1.json')),
+      librarySettings: {},
+      inputs: {
+        container: 'mkv',
+        encoder_speedpreset: 'fast',
+        extra_qsv_options: '-look_ahead 1 -look_ahead_depth 100 -extbrc 1 -rdo 1 -mbbrc 1 -b_strategy 1 -adaptive_i 1 -adaptive_b 1 -vf scale_qsv=1280:-1',
+        enable_10bit: 'true',
+      },
+      otherArguments: {},
+    },
+    output: {
+      linux: {
+        processFile: true,
+        preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv \n'
+          + '        -init_hw_device qsv:hw_any,child_device_type=vaapi -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset fast -look_ahead 1 -look_ahead_depth 100 -extbrc 1 -rdo 1 -mbbrc 1 -b_strategy 1 -adaptive_i 1 -adaptive_b 1 -vf scale_qsv=1280:-1:format=p010le  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f matroska -profile:v main10',
+        handBrakeMode: false,
+        FFmpegMode: true,
+        reQueueAfter: true,
+        infoLog: '☑ It looks like the current video bitrate is 1206kbps. \n'
+          + '10 bit encode enabled. Setting Main10 Profile & 10 bit pixel format \n'
+          + 'Container for output selected as mkv. \n'
+          + 'Encode variable bitrate settings: \n'
+          + 'Target = 603k \n'
+          + 'Minimum = 452k \n'
+          + 'Maximum = 754k \n'
+          + 'File Transcoding... \n',
+        container: '.mkv',
+      },
+      win32: {
+        processFile: true,
+        preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv \n'
+          + '        -init_hw_device qsv:hw,child_device_type=d3d11va -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset fast -look_ahead 1 -look_ahead_depth 100 -extbrc 1 -rdo 1 -mbbrc 1 -b_strategy 1 -adaptive_i 1 -adaptive_b 1 -vf scale_qsv=1280:-1:format=p010le  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f matroska -profile:v main10',
+        handBrakeMode: false,
+        FFmpegMode: true,
+        reQueueAfter: true,
+        infoLog: '☑ It looks like the current video bitrate is 1206kbps. \n'
+          + '10 bit encode enabled. Setting Main10 Profile & 10 bit pixel format \n'
+          + 'Container for output selected as mkv. \n'
+          + 'Encode variable bitrate settings: \n'
+          + 'Target = 603k \n'
+          + 'Minimum = 452k \n'
+          + 'Maximum = 754k \n'
+          + 'File Transcoding... \n',
+        container: '.mkv',
+      },
+      darwin: {
+        processFile: true,
+        preset: '-fflags +genpts -hwaccel videotoolbox<io> -map 0 -c:v hevc_videotoolbox -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset slow -c:a copy -c:s copy -max_muxing_queue_size 9999 -f matroska ',
+        handBrakeMode: false,
+        FFmpegMode: true,
+        reQueueAfter: true,
+        infoLog: '☑ It looks like the current video bitrate is 1206kbps. \n'
+          + '10 bit encode enabled. Setting Main10 Profile & 10 bit pixel format \n'
+          + 'Container for output selected as mkv. \n'
+          + 'Encode variable bitrate settings: \n'
+          + 'Target = 603k \n'
+          + 'Minimum = 452k \n'
+          + 'Maximum = 754k \n'
+          + '==ALERT== OS detected as MAC - This will use VIDEOTOOLBOX to encode which is NOT QSV\n'
+          + 'cmds set in extra_qsv_options will be IGNORED!\n'
+          + 'File Transcoding... \n',
+        container: '.mkv',
+      },
+    },
+  },
 ];
-
 void run(tests);

--- a/tests/Community/Tdarr_Plugin_bsh1_Boosh_FFMPEG_QSV_HEVC.js
+++ b/tests/Community/Tdarr_Plugin_bsh1_Boosh_FFMPEG_QSV_HEVC.js
@@ -14,34 +14,32 @@ const tests = [
     output: {
       linux: {
         processFile: true,
-        preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv \n'
-          + '        -init_hw_device qsv:hw_any,child_device_type=vaapi -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset slow  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f matroska -vf hwupload=extra_hw_frames=64,format=qsv ',
+        preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv -init_hw_device qsv:hw_any,child_device_type=vaapi -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset slow  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f matroska -vf hwupload=extra_hw_frames=64,format=qsv ',
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,
-        infoLog: '☑ It looks like the current video bitrate is 1206kbps. \n'
-          + 'Container for output selected as mkv. \n'
-          + 'Encode variable bitrate settings: \n'
-          + 'Target = 603k \n'
-          + 'Minimum = 452k \n'
-          + 'Maximum = 754k \n'
-          + 'File Transcoding... \n',
+        infoLog: '☑ It looks like the current video bitrate is 1206kbps.\n'
+          + 'Container for output selected as mkv.\n'
+          + 'Encode variable bitrate settings:\n'
+          + 'Target = 603k\n'
+          + 'Minimum = 452k\n'
+          + 'Maximum = 754k\n'
+          + 'File Transcoding...\n',
         container: '.mkv',
       },
       win32: {
         processFile: true,
-        preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv \n'
-          + '        -init_hw_device qsv:hw,child_device_type=d3d11va -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset slow  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f matroska -vf hwupload=extra_hw_frames=64,format=qsv ',
+        preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv -init_hw_device qsv:hw,child_device_type=d3d11va -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset slow  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f matroska -vf hwupload=extra_hw_frames=64,format=qsv ',
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,
-        infoLog: '☑ It looks like the current video bitrate is 1206kbps. \n'
-          + 'Container for output selected as mkv. \n'
-          + 'Encode variable bitrate settings: \n'
-          + 'Target = 603k \n'
-          + 'Minimum = 452k \n'
-          + 'Maximum = 754k \n'
-          + 'File Transcoding... \n',
+        infoLog: '☑ It looks like the current video bitrate is 1206kbps.\n'
+          + 'Container for output selected as mkv.\n'
+          + 'Encode variable bitrate settings:\n'
+          + 'Target = 603k\n'
+          + 'Minimum = 452k\n'
+          + 'Maximum = 754k\n'
+          + 'File Transcoding...\n',
         container: '.mkv',
       },
       darwin: {
@@ -50,15 +48,15 @@ const tests = [
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,
-        infoLog: '☑ It looks like the current video bitrate is 1206kbps. \n'
-          + 'Container for output selected as mkv. \n'
-          + 'Encode variable bitrate settings: \n'
-          + 'Target = 603k \n'
-          + 'Minimum = 452k \n'
-          + 'Maximum = 754k \n'
+        infoLog: '☑ It looks like the current video bitrate is 1206kbps.\n'
+          + 'Container for output selected as mkv.\n'
+          + 'Encode variable bitrate settings:\n'
+          + 'Target = 603k\n'
+          + 'Minimum = 452k\n'
+          + 'Maximum = 754k\n'
           + '==ALERT== OS detected as MAC - This will use VIDEOTOOLBOX to encode which is NOT QSV\n'
           + 'cmds set in extra_qsv_options will be IGNORED!\n'
-          + 'File Transcoding... \n',
+          + 'File Transcoding...\n',
         container: '.mkv',
       },
     },
@@ -78,36 +76,34 @@ const tests = [
     output: {
       linux: {
         processFile: true,
-        preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv \n'
-          + '        -init_hw_device qsv:hw_any,child_device_type=vaapi -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f mp4 -profile:v main10 -vf scale_qsv=format=p010le,hwupload=extra_hw_frames=64,format=qsv ',
+        preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv -init_hw_device qsv:hw_any,child_device_type=vaapi -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f mp4 -profile:v main10 -vf scale_qsv=format=p010le,hwupload=extra_hw_frames=64,format=qsv ',
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,
-        infoLog: '☑ It looks like the current video bitrate is 1206kbps. \n'
-          + '10 bit encode enabled. Setting Main10 Profile & 10 bit pixel format \n'
-          + 'Container for output selected as mp4. \n'
-          + 'Encode variable bitrate settings: \n'
-          + 'Target = 603k \n'
-          + 'Minimum = 452k \n'
-          + 'Maximum = 754k \n'
-          + 'File Transcoding... \n',
+        infoLog: '☑ It looks like the current video bitrate is 1206kbps.\n'
+          + '10 bit encode enabled. Setting Main10 Profile & 10 bit pixel format\n'
+          + 'Container for output selected as mp4.\n'
+          + 'Encode variable bitrate settings:\n'
+          + 'Target = 603k\n'
+          + 'Minimum = 452k\n'
+          + 'Maximum = 754k\n'
+          + 'File Transcoding...\n',
         container: '.mp4',
       },
       win32: {
         processFile: true,
-        preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv \n'
-          + '        -init_hw_device qsv:hw,child_device_type=d3d11va -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f mp4 -profile:v main10 -vf scale_qsv=format=p010le,hwupload=extra_hw_frames=64,format=qsv ',
+        preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv -init_hw_device qsv:hw,child_device_type=d3d11va -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f mp4 -profile:v main10 -vf scale_qsv=format=p010le,hwupload=extra_hw_frames=64,format=qsv ',
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,
-        infoLog: '☑ It looks like the current video bitrate is 1206kbps. \n'
-          + '10 bit encode enabled. Setting Main10 Profile & 10 bit pixel format \n'
-          + 'Container for output selected as mp4. \n'
-          + 'Encode variable bitrate settings: \n'
-          + 'Target = 603k \n'
-          + 'Minimum = 452k \n'
-          + 'Maximum = 754k \n'
-          + 'File Transcoding... \n',
+        infoLog: '☑ It looks like the current video bitrate is 1206kbps.\n'
+          + '10 bit encode enabled. Setting Main10 Profile & 10 bit pixel format\n'
+          + 'Container for output selected as mp4.\n'
+          + 'Encode variable bitrate settings:\n'
+          + 'Target = 603k\n'
+          + 'Minimum = 452k\n'
+          + 'Maximum = 754k\n'
+          + 'File Transcoding...\n',
         container: '.mp4',
       },
       darwin: {
@@ -117,16 +113,16 @@ const tests = [
         FFmpegMode: true,
         reQueueAfter: true,
         infoLog: 'Input file is not MKV so cannot use mkvpropedit to get new file stats. Continuing but file stats will likely be inaccurate...\n'
-          + '☑ It looks like the current video bitrate is 1206kbps. \n'
-          + '10 bit encode enabled. Setting Main10 Profile & 10 bit pixel format \n'
-          + 'Container for output selected as mp4. \n'
-          + 'Encode variable bitrate settings: \n'
-          + 'Target = 603k \n'
-          + 'Minimum = 452k \n'
-          + 'Maximum = 754k \n'
+          + '☑ It looks like the current video bitrate is 1206kbps.\n'
+          + '10 bit encode enabled. Setting Main10 Profile & 10 bit pixel format\n'
+          + 'Container for output selected as mp4.\n'
+          + 'Encode variable bitrate settings:\n'
+          + 'Target = 603k\n'
+          + 'Minimum = 452k\n'
+          + 'Maximum = 754k\n'
           + '==ALERT== OS detected as MAC - This will use VIDEOTOOLBOX to encode which is NOT QSV\n'
           + 'cmds set in extra_qsv_options will be IGNORED!\n'
-          + 'File Transcoding... \n',
+          + 'File Transcoding...\n',
         container: '.mp4',
       },
     },
@@ -149,38 +145,36 @@ const tests = [
     output: {
       linux: {
         processFile: true,
-        preset: '-fflags +genpts -hwaccel_output_format qsv \n'
-          + '        -init_hw_device qsv:hw,child_device_type=vaapi -c:v h264<io> -map 0 -c:v hevc_qsv -b:v 3227k -minrate 2420k -maxrate 4034k -bufsize 6454k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f matroska -profile:v main10 -pix_fmt p010le ',
+        preset: '-fflags +genpts -hwaccel_output_format qsv -init_hw_device qsv:hw,child_device_type=vaapi -c:v h264<io> -map 0 -c:v hevc_qsv -b:v 3227k -minrate 2420k -maxrate 4034k -bufsize 6454k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f matroska -profile:v main10 -pix_fmt p010le ',
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,
-        infoLog: '☑ It looks like the current video bitrate is 6454kbps. \n'
-          + 'Input file is h264 High10. Hardware Decode not supported. \n'
-          + '10 bit encode enabled. Setting Main10 Profile & 10 bit pixel format \n'
-          + 'Container for output selected as mkv. \n'
-          + 'Encode variable bitrate settings: \n'
-          + 'Target = 3227k \n'
-          + 'Minimum = 2420k \n'
-          + 'Maximum = 4034k \n'
-          + 'File Transcoding... \n',
+        infoLog: '☑ It looks like the current video bitrate is 6454kbps.\n'
+          + 'Input file is h264 High10. Hardware Decode not supported.\n'
+          + '10 bit encode enabled. Setting Main10 Profile & 10 bit pixel format\n'
+          + 'Container for output selected as mkv.\n'
+          + 'Encode variable bitrate settings:\n'
+          + 'Target = 3227k\n'
+          + 'Minimum = 2420k\n'
+          + 'Maximum = 4034k\n'
+          + 'File Transcoding...\n',
         container: '.mkv',
       },
       win32: {
         processFile: true,
-        preset: '-fflags +genpts -hwaccel_output_format qsv \n'
-          + '        -init_hw_device qsv:hw,child_device_type=d3d11va -c:v h264<io> -map 0 -c:v hevc_qsv -b:v 3227k -minrate 2420k -maxrate 4034k -bufsize 6454k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f matroska -profile:v main10 -pix_fmt p010le ',
+        preset: '-fflags +genpts -hwaccel_output_format qsv -init_hw_device qsv:hw,child_device_type=d3d11va -c:v h264<io> -map 0 -c:v hevc_qsv -b:v 3227k -minrate 2420k -maxrate 4034k -bufsize 6454k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f matroska -profile:v main10 -pix_fmt p010le ',
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,
-        infoLog: '☑ It looks like the current video bitrate is 6454kbps. \n'
-          + 'Input file is h264 High10. Hardware Decode not supported. \n'
-          + '10 bit encode enabled. Setting Main10 Profile & 10 bit pixel format \n'
-          + 'Container for output selected as mkv. \n'
-          + 'Encode variable bitrate settings: \n'
-          + 'Target = 3227k \n'
-          + 'Minimum = 2420k \n'
-          + 'Maximum = 4034k \n'
-          + 'File Transcoding... \n',
+        infoLog: '☑ It looks like the current video bitrate is 6454kbps.\n'
+          + 'Input file is h264 High10. Hardware Decode not supported.\n'
+          + '10 bit encode enabled. Setting Main10 Profile & 10 bit pixel format\n'
+          + 'Container for output selected as mkv.\n'
+          + 'Encode variable bitrate settings:\n'
+          + 'Target = 3227k\n'
+          + 'Minimum = 2420k\n'
+          + 'Maximum = 4034k\n'
+          + 'File Transcoding...\n',
         container: '.mkv',
       },
       darwin: {
@@ -189,17 +183,17 @@ const tests = [
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,
-        infoLog: '☑ It looks like the current video bitrate is 6454kbps. \n'
-          + 'Input file is 10bit using High10. Disabling hardware decoding to avoid problems. \n'
-          + '10 bit encode enabled. Setting Main10 Profile & 10 bit pixel format \n'
-          + 'Container for output selected as mkv. \n'
-          + 'Encode variable bitrate settings: \n'
-          + 'Target = 3227k \n'
-          + 'Minimum = 2420k \n'
-          + 'Maximum = 4034k \n'
+        infoLog: '☑ It looks like the current video bitrate is 6454kbps.\n'
+          + 'Input file is 10bit using High10. Disabling hardware decoding to avoid problems.\n'
+          + '10 bit encode enabled. Setting Main10 Profile & 10 bit pixel format\n'
+          + 'Container for output selected as mkv.\n'
+          + 'Encode variable bitrate settings:\n'
+          + 'Target = 3227k\n'
+          + 'Minimum = 2420k\n'
+          + 'Maximum = 4034k\n'
           + '==ALERT== OS detected as MAC - This will use VIDEOTOOLBOX to encode which is NOT QSV\n'
           + 'cmds set in extra_qsv_options will be IGNORED!\n'
-          + 'File Transcoding... \n',
+          + 'File Transcoding...\n',
         container: '.mkv',
       },
     },
@@ -226,39 +220,37 @@ const tests = [
     output: {
       linux: {
         processFile: true,
-        preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv \n'
-          + '        -init_hw_device qsv:hw_any,child_device_type=vaapi -c:v hevc_qsv<io> -map 0 -c:v hevc_qsv -b:v 6000k -minrate 4500k -maxrate 7500k -bufsize 12000k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f matroska -profile:v main10 -vf scale_qsv=format=p010le,hwupload=extra_hw_frames=64,format=qsv ',
+        preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv -init_hw_device qsv:hw_any,child_device_type=vaapi -c:v hevc_qsv<io> -map 0 -c:v hevc_qsv -b:v 6000k -minrate 4500k -maxrate 7500k -bufsize 12000k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f matroska -profile:v main10 -vf scale_qsv=format=p010le,hwupload=extra_hw_frames=64,format=qsv ',
         FFmpegMode: true,
         reQueueAfter: true,
-        infoLog: '☑ It looks like the current video bitrate is 12000kbps. \n'
-          + 'Reconvert_hevc is true & the file is already HEVC, VP9 or AV1. Using HEVC specific cutoff of 6000kbps. \n'
-          + '☒ The file is still above this new cutoff! Reconverting. \n'
-          + '10 bit encode enabled. Setting Main10 Profile & 10 bit pixel format \n'
-          + 'Container for output selected as mkv. \n'
-          + 'Encode variable bitrate settings: \n'
-          + 'Target = 6000k \n'
-          + 'Minimum = 4500k \n'
-          + 'Maximum = 7500k \n'
-          + 'File Transcoding... \n',
+        infoLog: '☑ It looks like the current video bitrate is 12000kbps.\n'
+          + 'Reconvert_hevc is true & the file is already HEVC, VP9 or AV1. Using HEVC specific cutoff of 6000kbps.\n'
+          + '☒ The file is still above this new cutoff! Reconverting.\n'
+          + '10 bit encode enabled. Setting Main10 Profile & 10 bit pixel format\n'
+          + 'Container for output selected as mkv.\n'
+          + 'Encode variable bitrate settings:\n'
+          + 'Target = 6000k\n'
+          + 'Minimum = 4500k\n'
+          + 'Maximum = 7500k\n'
+          + 'File Transcoding...\n',
         container: '.mkv',
       },
       win32: {
         processFile: true,
-        preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv \n'
-          + '        -init_hw_device qsv:hw,child_device_type=d3d11va -c:v hevc_qsv<io> -map 0 -c:v hevc_qsv -b:v 6000k -minrate 4500k -maxrate 7500k -bufsize 12000k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f matroska -profile:v main10 -vf scale_qsv=format=p010le,hwupload=extra_hw_frames=64,format=qsv ',
+        preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv -init_hw_device qsv:hw,child_device_type=d3d11va -c:v hevc_qsv<io> -map 0 -c:v hevc_qsv -b:v 6000k -minrate 4500k -maxrate 7500k -bufsize 12000k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f matroska -profile:v main10 -vf scale_qsv=format=p010le,hwupload=extra_hw_frames=64,format=qsv ',
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,
-        infoLog: '☑ It looks like the current video bitrate is 12000kbps. \n'
-          + 'Reconvert_hevc is true & the file is already HEVC, VP9 or AV1. Using HEVC specific cutoff of 6000kbps. \n'
-          + '☒ The file is still above this new cutoff! Reconverting. \n'
-          + '10 bit encode enabled. Setting Main10 Profile & 10 bit pixel format \n'
-          + 'Container for output selected as mkv. \n'
-          + 'Encode variable bitrate settings: \n'
-          + 'Target = 6000k \n'
-          + 'Minimum = 4500k \n'
-          + 'Maximum = 7500k \n'
-          + 'File Transcoding... \n',
+        infoLog: '☑ It looks like the current video bitrate is 12000kbps.\n'
+          + 'Reconvert_hevc is true & the file is already HEVC, VP9 or AV1. Using HEVC specific cutoff of 6000kbps.\n'
+          + '☒ The file is still above this new cutoff! Reconverting.\n'
+          + '10 bit encode enabled. Setting Main10 Profile & 10 bit pixel format\n'
+          + 'Container for output selected as mkv.\n'
+          + 'Encode variable bitrate settings:\n'
+          + 'Target = 6000k\n'
+          + 'Minimum = 4500k\n'
+          + 'Maximum = 7500k\n'
+          + 'File Transcoding...\n',
         container: '.mkv',
       },
       darwin: {
@@ -267,18 +259,18 @@ const tests = [
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,
-        infoLog: '☑ It looks like the current video bitrate is 12000kbps. \n'
-          + 'Reconvert_hevc is true & the file is already HEVC, VP9 or AV1. Using HEVC specific cutoff of 6000kbps. \n'
-          + '☒ The file is still above this new cutoff! Reconverting. \n'
-          + '10 bit encode enabled. Setting Main10 Profile & 10 bit pixel format \n'
-          + 'Container for output selected as mkv. \n'
-          + 'Encode variable bitrate settings: \n'
-          + 'Target = 6000k \n'
-          + 'Minimum = 4500k \n'
-          + 'Maximum = 7500k \n'
+        infoLog: '☑ It looks like the current video bitrate is 12000kbps.\n'
+          + 'Reconvert_hevc is true & the file is already HEVC, VP9 or AV1. Using HEVC specific cutoff of 6000kbps.\n'
+          + '☒ The file is still above this new cutoff! Reconverting.\n'
+          + '10 bit encode enabled. Setting Main10 Profile & 10 bit pixel format\n'
+          + 'Container for output selected as mkv.\n'
+          + 'Encode variable bitrate settings:\n'
+          + 'Target = 6000k\n'
+          + 'Minimum = 4500k\n'
+          + 'Maximum = 7500k\n'
           + '==ALERT== OS detected as MAC - This will use VIDEOTOOLBOX to encode which is NOT QSV\n'
           + 'cmds set in extra_qsv_options will be IGNORED!\n'
-          + 'File Transcoding... \n',
+          + 'File Transcoding...\n',
         container: '.mkv',
       },
     },
@@ -309,9 +301,9 @@ const tests = [
       handBrakeMode: false,
       FFmpegMode: true,
       reQueueAfter: true,
-      infoLog: '☑ It looks like the current video bitrate is 5000kbps. \n'
-        + 'Reconvert_hevc is true & the file is already HEVC, VP9 or AV1. Using HEVC specific cutoff of 6000kbps. \n'
-        + '☑ The file is NOT above this new cutoff. Exiting plugin. \n',
+      infoLog: '☑ It looks like the current video bitrate is 5000kbps.\n'
+        + 'Reconvert_hevc is true & the file is already HEVC, VP9 or AV1. Using HEVC specific cutoff of 6000kbps.\n'
+        + '☑ The file is NOT above this new cutoff. Exiting plugin.\n',
       container: '.mkv',
     },
   },
@@ -337,34 +329,32 @@ const tests = [
     output: {
       linux: {
         processFile: true,
-        preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv \n'
-          + '        -init_hw_device qsv:hw_any,child_device_type=vaapi -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -b:v 3227k -minrate 2420k -maxrate 4034k -bufsize 6454k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -map -0:3 -map -0:4 -map -0:5 -map -0:6 -f mp4 -vf hwupload=extra_hw_frames=64,format=qsv ',
+        preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv -init_hw_device qsv:hw_any,child_device_type=vaapi -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -b:v 3227k -minrate 2420k -maxrate 4034k -bufsize 6454k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -map -0:3 -map -0:4 -map -0:5 -map -0:6 -f mp4 -vf hwupload=extra_hw_frames=64,format=qsv ',
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,
-        infoLog: '☑ It looks like the current video bitrate is 6454kbps. \n'
-          + 'Container for output selected as mp4. \n'
-          + 'Encode variable bitrate settings: \n'
-          + 'Target = 3227k \n'
-          + 'Minimum = 2420k \n'
-          + 'Maximum = 4034k \n'
-          + 'File Transcoding... \n',
+        infoLog: '☑ It looks like the current video bitrate is 6454kbps.\n'
+          + 'Container for output selected as mp4.\n'
+          + 'Encode variable bitrate settings:\n'
+          + 'Target = 3227k\n'
+          + 'Minimum = 2420k\n'
+          + 'Maximum = 4034k\n'
+          + 'File Transcoding...\n',
         container: '.mp4',
       },
       win32: {
         processFile: true,
-        preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv \n'
-          + '        -init_hw_device qsv:hw,child_device_type=d3d11va -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -b:v 3227k -minrate 2420k -maxrate 4034k -bufsize 6454k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -map -0:3 -map -0:4 -map -0:5 -map -0:6 -f mp4 -vf hwupload=extra_hw_frames=64,format=qsv ',
+        preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv -init_hw_device qsv:hw,child_device_type=d3d11va -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -b:v 3227k -minrate 2420k -maxrate 4034k -bufsize 6454k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -map -0:3 -map -0:4 -map -0:5 -map -0:6 -f mp4 -vf hwupload=extra_hw_frames=64,format=qsv ',
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,
-        infoLog: '☑ It looks like the current video bitrate is 6454kbps. \n'
-          + 'Container for output selected as mp4. \n'
-          + 'Encode variable bitrate settings: \n'
-          + 'Target = 3227k \n'
-          + 'Minimum = 2420k \n'
-          + 'Maximum = 4034k \n'
-          + 'File Transcoding... \n',
+        infoLog: '☑ It looks like the current video bitrate is 6454kbps.\n'
+          + 'Container for output selected as mp4.\n'
+          + 'Encode variable bitrate settings:\n'
+          + 'Target = 3227k\n'
+          + 'Minimum = 2420k\n'
+          + 'Maximum = 4034k\n'
+          + 'File Transcoding...\n',
         container: '.mp4',
       },
       darwin: {
@@ -373,13 +363,13 @@ const tests = [
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,
-        infoLog: '☑ It looks like the current video bitrate is 6454kbps. \n'
-          + 'Container for output selected as mp4. \n'
-          + 'Encode variable bitrate settings: \n'
-          + 'Target = 3227k \n'
-          + 'Minimum = 2420k \n'
-          + 'Maximum = 4034k \n'
-          + 'File Transcoding... \n',
+        infoLog: '☑ It looks like the current video bitrate is 6454kbps.\n'
+          + 'Container for output selected as mp4.\n'
+          + 'Encode variable bitrate settings:\n'
+          + 'Target = 3227k\n'
+          + 'Minimum = 2420k\n'
+          + 'Maximum = 4034k\n'
+          + 'File Transcoding...\n',
         container: '.mp4',
       },
     },
@@ -405,34 +395,32 @@ const tests = [
     output: {
       linux: {
         processFile: true,
-        preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv \n'
-          + '        -init_hw_device qsv:hw_any,child_device_type=vaapi -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -b:v 3227k -minrate 2420k -maxrate 4034k -bufsize 6454k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -map -0:d -map -0:3 -map -0:4 -map -0:5 -f matroska -vf hwupload=extra_hw_frames=64,format=qsv ',
+        preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv -init_hw_device qsv:hw_any,child_device_type=vaapi -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -b:v 3227k -minrate 2420k -maxrate 4034k -bufsize 6454k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -map -0:d -map -0:3 -map -0:4 -map -0:5 -f matroska -vf hwupload=extra_hw_frames=64,format=qsv ',
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,
-        infoLog: '☑ It looks like the current video bitrate is 6454kbps. \n'
-          + 'Container for output selected as mkv. \n'
-          + 'Encode variable bitrate settings: \n'
-          + 'Target = 3227k \n'
-          + 'Minimum = 2420k \n'
-          + 'Maximum = 4034k \n'
-          + 'File Transcoding... \n',
+        infoLog: '☑ It looks like the current video bitrate is 6454kbps.\n'
+          + 'Container for output selected as mkv.\n'
+          + 'Encode variable bitrate settings:\n'
+          + 'Target = 3227k\n'
+          + 'Minimum = 2420k\n'
+          + 'Maximum = 4034k\n'
+          + 'File Transcoding...\n',
         container: '.mkv',
       },
       win32: {
         processFile: true,
-        preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv \n'
-          + '        -init_hw_device qsv:hw,child_device_type=d3d11va -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -b:v 3227k -minrate 2420k -maxrate 4034k -bufsize 6454k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -map -0:d -map -0:3 -map -0:4 -map -0:5 -f matroska -vf hwupload=extra_hw_frames=64,format=qsv ',
+        preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv -init_hw_device qsv:hw,child_device_type=d3d11va -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -b:v 3227k -minrate 2420k -maxrate 4034k -bufsize 6454k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -map -0:d -map -0:3 -map -0:4 -map -0:5 -f matroska -vf hwupload=extra_hw_frames=64,format=qsv ',
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,
-        infoLog: '☑ It looks like the current video bitrate is 6454kbps. \n'
-          + 'Container for output selected as mkv. \n'
-          + 'Encode variable bitrate settings: \n'
-          + 'Target = 3227k \n'
-          + 'Minimum = 2420k \n'
-          + 'Maximum = 4034k \n'
-          + 'File Transcoding... \n',
+        infoLog: '☑ It looks like the current video bitrate is 6454kbps.\n'
+          + 'Container for output selected as mkv.\n'
+          + 'Encode variable bitrate settings:\n'
+          + 'Target = 3227k\n'
+          + 'Minimum = 2420k\n'
+          + 'Maximum = 4034k\n'
+          + 'File Transcoding...\n',
         container: '.mkv',
       },
       darwin: {
@@ -441,13 +429,13 @@ const tests = [
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,
-        infoLog: '☑ It looks like the current video bitrate is 6454kbps. \n'
-          + 'Container for output selected as mkv. \n'
-          + 'Encode variable bitrate settings: \n'
-          + 'Target = 3227k \n'
-          + 'Minimum = 2420k \n'
-          + 'Maximum = 4034k \n'
-          + 'File Transcoding... \n',
+        infoLog: '☑ It looks like the current video bitrate is 6454kbps.\n'
+          + 'Container for output selected as mkv.\n'
+          + 'Encode variable bitrate settings:\n'
+          + 'Target = 3227k\n'
+          + 'Minimum = 2420k\n'
+          + 'Maximum = 4034k\n'
+          + 'File Transcoding...\n',
         container: '.mkv',
       },
     },
@@ -468,36 +456,34 @@ const tests = [
     output: {
       linux: {
         processFile: true,
-        preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv \n'
-          + '        -init_hw_device qsv:hw_any,child_device_type=vaapi -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset fast -look_ahead 1 -look_ahead_depth 100 -extbrc 1 -rdo 1 -mbbrc 1 -b_strategy 1 -adaptive_i 1 -adaptive_b 1 -vf scale_qsv=1280:-1,format=p010le,hwupload=extra_hw_frames=64,format=qsv  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f matroska -profile:v main10',
+        preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv -init_hw_device qsv:hw_any,child_device_type=vaapi -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset fast -look_ahead 1 -look_ahead_depth 100 -extbrc 1 -rdo 1 -mbbrc 1 -b_strategy 1 -adaptive_i 1 -adaptive_b 1 -vf scale_qsv=1280:-1,format=p010le,hwupload=extra_hw_frames=64,format=qsv  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f matroska -profile:v main10',
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,
-        infoLog: '☑ It looks like the current video bitrate is 1206kbps. \n'
-          + '10 bit encode enabled. Setting Main10 Profile & 10 bit pixel format \n'
-          + 'Container for output selected as mkv. \n'
-          + 'Encode variable bitrate settings: \n'
-          + 'Target = 603k \n'
-          + 'Minimum = 452k \n'
-          + 'Maximum = 754k \n'
-          + 'File Transcoding... \n',
+        infoLog: '☑ It looks like the current video bitrate is 1206kbps.\n'
+          + '10 bit encode enabled. Setting Main10 Profile & 10 bit pixel format\n'
+          + 'Container for output selected as mkv.\n'
+          + 'Encode variable bitrate settings:\n'
+          + 'Target = 603k\n'
+          + 'Minimum = 452k\n'
+          + 'Maximum = 754k\n'
+          + 'File Transcoding...\n',
         container: '.mkv',
       },
       win32: {
         processFile: true,
-        preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv \n'
-          + '        -init_hw_device qsv:hw,child_device_type=d3d11va -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset fast -look_ahead 1 -look_ahead_depth 100 -extbrc 1 -rdo 1 -mbbrc 1 -b_strategy 1 -adaptive_i 1 -adaptive_b 1 -vf scale_qsv=1280:-1,format=p010le,hwupload=extra_hw_frames=64,format=qsv  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f matroska -profile:v main10',
+        preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv -init_hw_device qsv:hw,child_device_type=d3d11va -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset fast -look_ahead 1 -look_ahead_depth 100 -extbrc 1 -rdo 1 -mbbrc 1 -b_strategy 1 -adaptive_i 1 -adaptive_b 1 -vf scale_qsv=1280:-1,format=p010le,hwupload=extra_hw_frames=64,format=qsv  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f matroska -profile:v main10',
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,
-        infoLog: '☑ It looks like the current video bitrate is 1206kbps. \n'
-          + '10 bit encode enabled. Setting Main10 Profile & 10 bit pixel format \n'
-          + 'Container for output selected as mkv. \n'
-          + 'Encode variable bitrate settings: \n'
-          + 'Target = 603k \n'
-          + 'Minimum = 452k \n'
-          + 'Maximum = 754k \n'
-          + 'File Transcoding... \n',
+        infoLog: '☑ It looks like the current video bitrate is 1206kbps.\n'
+          + '10 bit encode enabled. Setting Main10 Profile & 10 bit pixel format\n'
+          + 'Container for output selected as mkv.\n'
+          + 'Encode variable bitrate settings:\n'
+          + 'Target = 603k\n'
+          + 'Minimum = 452k\n'
+          + 'Maximum = 754k\n'
+          + 'File Transcoding...\n',
         container: '.mkv',
       },
       darwin: {
@@ -506,16 +492,16 @@ const tests = [
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,
-        infoLog: '☑ It looks like the current video bitrate is 1206kbps. \n'
-          + '10 bit encode enabled. Setting Main10 Profile & 10 bit pixel format \n'
-          + 'Container for output selected as mkv. \n'
-          + 'Encode variable bitrate settings: \n'
-          + 'Target = 603k \n'
-          + 'Minimum = 452k \n'
-          + 'Maximum = 754k \n'
+        infoLog: '☑ It looks like the current video bitrate is 1206kbps.\n'
+          + '10 bit encode enabled. Setting Main10 Profile & 10 bit pixel format\n'
+          + 'Container for output selected as mkv.\n'
+          + 'Encode variable bitrate settings:\n'
+          + 'Target = 603k\n'
+          + 'Minimum = 452k\n'
+          + 'Maximum = 754k\n'
           + '==ALERT== OS detected as MAC - This will use VIDEOTOOLBOX to encode which is NOT QSV\n'
           + 'cmds set in extra_qsv_options will be IGNORED!\n'
-          + 'File Transcoding... \n',
+          + 'File Transcoding...\n',
         container: '.mkv',
       },
     },
@@ -539,37 +525,35 @@ const tests = [
     output: {
       linux: {
         processFile: true,
-        preset: '-fflags +genpts -hwaccel_output_format qsv \n'
-          + '        -init_hw_device qsv:hw_any,child_device_type=vaapi -c:v vc1<io> -map 0 -c:v hevc_qsv -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f matroska -profile:v main10 -pix_fmt p010le ',
+        preset: '-fflags +genpts -hwaccel_output_format qsv -init_hw_device qsv:hw_any,child_device_type=vaapi -c:v vc1<io> -map 0 -c:v hevc_qsv -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f matroska -profile:v main10 -pix_fmt p010le ',
         FFmpegMode: true,
         reQueueAfter: true,
-        infoLog: '☑ It looks like the current video bitrate is 1206kbps. \n'
-          + 'Input file is vc1. Hardware Decode not supported. \n'
-          + '10 bit encode enabled. Setting Main10 Profile & 10 bit pixel format \n'
-          + 'Container for output selected as mkv. \n'
-          + 'Encode variable bitrate settings: \n'
-          + 'Target = 603k \n'
-          + 'Minimum = 452k \n'
-          + 'Maximum = 754k \n'
-          + 'File Transcoding... \n',
+        infoLog: '☑ It looks like the current video bitrate is 1206kbps.\n'
+          + 'Input file is vc1. Hardware Decode not supported.\n'
+          + '10 bit encode enabled. Setting Main10 Profile & 10 bit pixel format\n'
+          + 'Container for output selected as mkv.\n'
+          + 'Encode variable bitrate settings:\n'
+          + 'Target = 603k\n'
+          + 'Minimum = 452k\n'
+          + 'Maximum = 754k\n'
+          + 'File Transcoding...\n',
         container: '.mkv',
       },
       win32: {
         processFile: true,
-        preset: '-fflags +genpts -hwaccel_output_format qsv \n'
-          + '        -init_hw_device qsv:hw,child_device_type=d3d11va -c:v vc1<io> -map 0 -c:v hevc_qsv -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f matroska -profile:v main10 -pix_fmt p010le ',
+        preset: '-fflags +genpts -hwaccel_output_format qsv -init_hw_device qsv:hw,child_device_type=d3d11va -c:v vc1<io> -map 0 -c:v hevc_qsv -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f matroska -profile:v main10 -pix_fmt p010le ',
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,
-        infoLog: '☑ It looks like the current video bitrate is 1206kbps. \n'
-          + 'Input file is vc1. Hardware Decode not supported. \n'
-          + '10 bit encode enabled. Setting Main10 Profile & 10 bit pixel format \n'
-          + 'Container for output selected as mkv. \n'
-          + 'Encode variable bitrate settings: \n'
-          + 'Target = 603k \n'
-          + 'Minimum = 452k \n'
-          + 'Maximum = 754k \n'
-          + 'File Transcoding... \n',
+        infoLog: '☑ It looks like the current video bitrate is 1206kbps.\n'
+          + 'Input file is vc1. Hardware Decode not supported.\n'
+          + '10 bit encode enabled. Setting Main10 Profile & 10 bit pixel format\n'
+          + 'Container for output selected as mkv.\n'
+          + 'Encode variable bitrate settings:\n'
+          + 'Target = 603k\n'
+          + 'Minimum = 452k\n'
+          + 'Maximum = 754k\n'
+          + 'File Transcoding...\n',
         container: '.mkv',
       },
       darwin: {
@@ -578,16 +562,93 @@ const tests = [
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,
-        infoLog: '☑ It looks like the current video bitrate is 1206kbps. \n'
-          + '10 bit encode enabled. Setting Main10 Profile & 10 bit pixel format \n'
-          + 'Container for output selected as mkv. \n'
-          + 'Encode variable bitrate settings: \n'
-          + 'Target = 603k \n'
-          + 'Minimum = 452k \n'
-          + 'Maximum = 754k \n'
+        infoLog: '☑ It looks like the current video bitrate is 1206kbps.\n'
+          + '10 bit encode enabled. Setting Main10 Profile & 10 bit pixel format\n'
+          + 'Container for output selected as mkv.\n'
+          + 'Encode variable bitrate settings:\n'
+          + 'Target = 603k\n'
+          + 'Minimum = 452k\n'
+          + 'Maximum = 754k\n'
           + '==ALERT== OS detected as MAC - This will use VIDEOTOOLBOX to encode which is NOT QSV\n'
           + 'cmds set in extra_qsv_options will be IGNORED!\n'
-          + 'File Transcoding... \n',
+          + 'File Transcoding...\n',
+        container: '.mkv',
+      },
+    },
+  },
+  // Test 9
+  {
+    input: {
+      file: (() => {
+        const file = _.cloneDeep(require('../sampleData/media/sampleH264_1.json'));
+        file.ffProbeData.streams[0].color_space = 'bt2020nc';
+        file.ffProbeData.streams[0].color_transfer = 'smpte2084';
+        file.ffProbeData.streams[0].color_primaries = 'bt2020';
+        file.mediaInfo.track[1].BitRate = 12000000;
+        file.ffProbeData.streams[0].profile = 'Main 10';
+        return file;
+      })(),
+      librarySettings: {},
+      inputs: {
+        container: 'mkv',
+        encoder_speedpreset: 'fast',
+        reconvert_hevc: 'true',
+        hevc_max_bitrate: '6000',
+        bitrate_cutoff: '4000',
+      },
+      otherArguments: {},
+    },
+    output: {
+      linux: {
+        processFile: true,
+        preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv -init_hw_device qsv:hw_any,child_device_type=vaapi -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -b:v 6000k -minrate 4500k -maxrate 7500k -bufsize 12000k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -color_primaries bt2020 -color_trc smpte2084 -colorspace bt2020nc -f matroska -profile:v main10 -vf scale_qsv=format=p010le,hwupload=extra_hw_frames=64,format=qsv ',
+        FFmpegMode: true,
+        reQueueAfter: true,
+        infoLog: '☑ It looks like the current video bitrate is 12000kbps.\n'
+          + '==WARNING== This looks to be a HDR file. HDR is supported but correct encoding is not guaranteed.\n'
+          + '10 bit encode enabled. Setting Main10 Profile & 10 bit pixel format\n'
+          + 'Container for output selected as mkv.\n'
+          + 'Encode variable bitrate settings:\n'
+          + 'Target = 6000k\n'
+          + 'Minimum = 4500k\n'
+          + 'Maximum = 7500k\n'
+          + 'File Transcoding...\n',
+        container: '.mkv',
+      },
+      win32: {
+        processFile: true,
+        preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv -init_hw_device qsv:hw,child_device_type=d3d11va -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -b:v 6000k -minrate 4500k -maxrate 7500k -bufsize 12000k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -color_primaries bt2020 -color_trc smpte2084 -colorspace bt2020nc -f matroska -profile:v main10 -vf scale_qsv=format=p010le,hwupload=extra_hw_frames=64,format=qsv ',
+        handBrakeMode: false,
+        FFmpegMode: true,
+        reQueueAfter: true,
+        infoLog: '☑ It looks like the current video bitrate is 12000kbps.\n'
+          + '==WARNING== This looks to be a HDR file. HDR is supported but correct encoding is not guaranteed.\n'
+          + '10 bit encode enabled. Setting Main10 Profile & 10 bit pixel format\n'
+          + 'Container for output selected as mkv.\n'
+          + 'Encode variable bitrate settings:\n'
+          + 'Target = 6000k\n'
+          + 'Minimum = 4500k\n'
+          + 'Maximum = 7500k\n'
+          + 'File Transcoding...\n',
+        container: '.mkv',
+      },
+      darwin: {
+        processFile: true,
+        preset: '-fflags +genpts <io> -map 0 -c:v hevc_videotoolbox -b:v 6000k -minrate 4500k -maxrate 7500k -bufsize 12000k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -color_primaries bt2020 -color_trc smpte2084 -colorspace bt2020nc -f matroska -profile:v main10 -vf scale_qsv=format=p010le',
+        handBrakeMode: false,
+        FFmpegMode: true,
+        reQueueAfter: true,
+        infoLog: '☑ It looks like the current video bitrate is 12000kbps.\n'
+          + '==WARNING== This looks to be a HDR file. HDR is supported but correct encoding is not guaranteed.\n'
+          + '10 bit encode enabled. Setting Main10 Profile & 10 bit pixel format\n'
+          + 'Container for output selected as mkv.\n'
+          + 'Encode variable bitrate settings:\n'
+          + 'Target = 6000k\n'
+          + 'Minimum = 4500k\n'
+          + 'Maximum = 7500k\n'
+          + '==ALERT== OS detected as MAC - This will use VIDEOTOOLBOX to encode which is NOT QSV\n'
+          + 'cmds set in extra_qsv_options will be IGNORED!\n'
+          + 'File Transcoding...\n',
         container: '.mkv',
       },
     },

--- a/tests/Community/Tdarr_Plugin_bsh1_Boosh_FFMPEG_QSV_HEVC.js
+++ b/tests/Community/Tdarr_Plugin_bsh1_Boosh_FFMPEG_QSV_HEVC.js
@@ -2,7 +2,14 @@
 const _ = require('lodash');
 const run = require('../helpers/run');
 
+// Date stuff for mkvpropedit
+const intStatsDays = 7; // Use 1 week threshold for new stats
+let statsThresString = new Date(new Date().setDate(new Date().getDate() - intStatsDays)).toUTCString();
+statsThresString = `${statsThresString.slice(0, 22)}:00 GMT`;
+let datStatsString = new Date().toUTCString();
+datStatsString = `${datStatsString.slice(0, 22)}:00 GMT`;
 const tests = [
+  // Test 0
   {
     input: {
       file: _.cloneDeep(require('../sampleData/media/sampleH264_1.json')),
@@ -65,6 +72,7 @@ const tests = [
       },
     },
   },
+  // Test 1
   {
     input: {
       file: _.cloneDeep(require('../sampleData/media/sampleH264_1.json')),
@@ -134,15 +142,245 @@ const tests = [
       },
     },
   },
+  // Test 2
   {
     input: {
-      file: _.cloneDeep(require('../sampleData/media/sampleH264_1.json')),
+      file: (() => {
+        const file = _.cloneDeep(require('../sampleData/media/sampleH264_2.json'));
+        file.ffProbeData.streams[0].profile = 'High 10';
+        file.mediaInfo.track[0].extra.JBDONEDATE = new Date().toISOString();
+        return file;
+      })(),
+      librarySettings: {},
+      inputs: {
+        container: 'mkv',
+        encoder_speedpreset: 'fast',
+      },
+      otherArguments: {},
+    },
+    output: {
+      linux: {
+        processFile: true,
+        preset: '-fflags +genpts <io> -map 0 -c:v hevc_qsv -b:v 3227k -minrate 2420k -maxrate 4034k -bufsize 6454k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -profile:v main10 -pix_fmt p010le  -map_metadata:g -1 -metadata JBDONEDATE=2674800000',
+        handBrakeMode: false,
+        FFmpegMode: true,
+        reQueueAfter: true,
+        infoLog: "Checking file stats - If stats are older than 7 days we'll grab new stats.\n"
+          + '\n'
+          + `    Stats threshold: ${statsThresString}\n`
+          + '\n'
+          + `    Current stats date: ${datStatsString}\n`
+          + '☑ File stats are upto date! - Continuing...\n'
+          + '☑ It looks like the current video bitrate is 6454kbps. \n'
+          + 'Input file is 10bit using High10. Disabling hardware decoding to avoid problems. \n'
+          + '10 bit encode enabled. Setting Main10 Profile & 10 bit pixel format \n'
+          + 'Container for output selected as mkv. \n'
+          + 'Encode variable bitrate settings: \n'
+          + 'Target = 3227k \n'
+          + 'Minimum = 2420k \n'
+          + 'Maximum = 4034k \n'
+          + 'File Transcoding... \n',
+        container: '.mkv',
+      },
+      win32: {
+        processFile: true,
+        preset: '-fflags +genpts <io> -map 0 -c:v hevc_qsv -load_plugin hevc_hw -b:v 3227k -minrate 2420k -maxrate 4034k -bufsize 6454k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -profile:v main10 -pix_fmt p010le  -map_metadata:g -1 -metadata JBDONEDATE=2674800000',
+        handBrakeMode: false,
+        FFmpegMode: true,
+        reQueueAfter: true,
+        infoLog: "Checking file stats - If stats are older than 7 days we'll grab new stats.\n"
+          + '\n'
+          + `    Stats threshold: ${statsThresString}\n`
+          + '\n'
+          + `    Current stats date: ${datStatsString}\n`
+          + '☑ File stats are upto date! - Continuing...\n'
+          + '☑ It looks like the current video bitrate is 6454kbps. \n'
+          + 'Input file is 10bit using High10. Disabling hardware decoding to avoid problems. \n'
+          + '10 bit encode enabled. Setting Main10 Profile & 10 bit pixel format \n'
+          + 'Container for output selected as mkv. \n'
+          + 'Encode variable bitrate settings: \n'
+          + 'Target = 3227k \n'
+          + 'Minimum = 2420k \n'
+          + 'Maximum = 4034k \n'
+          + 'File Transcoding... \n',
+        container: '.mkv',
+      },
+      darwin: {
+        processFile: true,
+        preset: '-fflags +genpts <io> -map 0 -c:v hevc_videotoolbox -b:v 3227k -minrate 2420k -maxrate 4034k -bufsize 6454k -preset fast -c:a copy -c:s copy -profile:v main10 -pix_fmt p010le  -map_metadata:g -1 -metadata JBDONEDATE=2674800000',
+        handBrakeMode: false,
+        FFmpegMode: true,
+        reQueueAfter: true,
+        infoLog: "Checking file stats - If stats are older than 7 days we'll grab new stats.\n"
+          + '\n'
+          + `    Stats threshold: ${statsThresString}\n`
+          + '\n'
+          + `    Current stats date: ${datStatsString}\n`
+          + '☑ File stats are upto date! - Continuing...\n'
+          + '☑ It looks like the current video bitrate is 6454kbps. \n'
+          + 'Input file is 10bit using High10. Disabling hardware decoding to avoid problems. \n'
+          + '10 bit encode enabled. Setting Main10 Profile & 10 bit pixel format \n'
+          + 'Container for output selected as mkv. \n'
+          + 'Encode variable bitrate settings: \n'
+          + 'Target = 3227k \n'
+          + 'Minimum = 2420k \n'
+          + 'Maximum = 4034k \n'
+          + '==ALERT== OS detected as MAC - This will use VIDEOTOOLBOX to encode which is NOT QSV\n'
+          + 'cmds set in extra_qsv_options will be IGNORED!\n'
+          + 'File Transcoding... \n',
+        container: '.mkv',
+      },
+    },
+  },
+  // Test 3
+  {
+    input: {
+      file: (() => {
+        const file = _.cloneDeep(require('../sampleData/media/sampleH265_1.json'));
+        file.mediaInfo.track[1].BitRate = 12059590;
+        file.ffProbeData.streams[0].profile = 'Main 10';
+        file.mediaInfo.track[0].extra.JBDONEDATE = new Date().toISOString();
+        return file;
+      })(),
+      librarySettings: {},
+      inputs: {
+        container: 'mkv',
+        encoder_speedpreset: 'fast',
+        reconvert_hevc: 'true',
+        hevc_max_bitrate: '6000',
+        bitrate_cutoff: '4000',
+      },
+      otherArguments: {},
+    },
+    output: {
+      linux: {
+        processFile: true,
+        preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv \n'
+          + '      -init_hw_device qsv:hw_any,child_device_type=vaapi -c:v hevc_qsv<io> -map 0 -c:v hevc_qsv -load_plugin hevc_hw -b:v 6030k -minrate 4523k -maxrate 7538k -bufsize 12060k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -profile:v main10 -vf scale_qsv=format=p010le  -map_metadata:g -1 -metadata JBDONEDATE=2674800000',
+        FFmpegMode: true,
+        reQueueAfter: true,
+        infoLog: "Checking file stats - If stats are older than 7 days we'll grab new stats.\n"
+          + '\n'
+          + `    Stats threshold: ${statsThresString}\n`
+          + '\n'
+          + `    Current stats date: ${datStatsString}\n`
+          + '☑ File stats are upto date! - Continuing...\n'
+          + '☑ It looks like the current video bitrate is 12060kbps. \n'
+          + 'Reconvert_hevc is true & the file is already HEVC, VP9 or AV1. Using HEVC specific cutoff of 6000kbps. \n'
+          + '☒ The file is still above this new cutoff! Reconverting. \n'
+          + '10 bit encode enabled. Setting Main10 Profile & 10 bit pixel format \n'
+          + 'Container for output selected as mkv. \n'
+          + 'Encode variable bitrate settings: \n'
+          + 'Target = 6030k \n'
+          + 'Minimum = 4523k \n'
+          + 'Maximum = 7538k \n'
+          + 'File Transcoding... \n',
+        container: '.mkv',
+      },
+      win32: {
+        processFile: true,
+        preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv \n'
+          + '      -init_hw_device qsv:hw_any,child_device_type=d3d11va -c:v hevc_qsv<io> -map 0 -c:v hevc_qsv -load_plugin hevc_hw -b:v 6030k -minrate 4523k -maxrate 7538k -bufsize 12060k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -profile:v main10 -vf scale_qsv=format=p010le  -map_metadata:g -1 -metadata JBDONEDATE=2674800000',
+        handBrakeMode: false,
+        FFmpegMode: true,
+        reQueueAfter: true,
+        infoLog: "Checking file stats - If stats are older than 7 days we'll grab new stats.\n"
+          + '\n'
+          + `    Stats threshold: ${statsThresString}\n`
+          + '\n'
+          + `    Current stats date: ${datStatsString}\n`
+          + '☑ File stats are upto date! - Continuing...\n'
+          + '☑ It looks like the current video bitrate is 12060kbps. \n'
+          + 'Reconvert_hevc is true & the file is already HEVC, VP9 or AV1. Using HEVC specific cutoff of 6000kbps. \n'
+          + '☒ The file is still above this new cutoff! Reconverting. \n'
+          + '10 bit encode enabled. Setting Main10 Profile & 10 bit pixel format \n'
+          + 'Container for output selected as mkv. \n'
+          + 'Encode variable bitrate settings: \n'
+          + 'Target = 6030k \n'
+          + 'Minimum = 4523k \n'
+          + 'Maximum = 7538k \n'
+          + 'File Transcoding... \n',
+        container: '.mkv',
+      },
+      darwin: {
+        processFile: true,
+        preset: '-fflags +genpts <io> -map 0 -c:v hevc_videotoolbox -b:v 6030k -minrate 4523k -maxrate 7538k -bufsize 12060k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -profile:v main10 -vf scale_qsv=format=p010le  -map_metadata:g -1 -metadata JBDONEDATE=2674800000',
+        handBrakeMode: false,
+        FFmpegMode: true,
+        reQueueAfter: true,
+        infoLog: "Checking file stats - If stats are older than 7 days we'll grab new stats.\n"
+          + '\n'
+          + `    Stats threshold: ${statsThresString}\n`
+          + '\n'
+          + `    Current stats date: ${datStatsString}\n`
+          + '☑ File stats are upto date! - Continuing...\n'
+          + '☑ It looks like the current video bitrate is 12060kbps. \n'
+          + 'Reconvert_hevc is true & the file is already HEVC, VP9 or AV1. Using HEVC specific cutoff of 6000kbps. \n'
+          + '☒ The file is still above this new cutoff! Reconverting. \n'
+          + '10 bit encode enabled. Setting Main10 Profile & 10 bit pixel format \n'
+          + 'Container for output selected as mkv. \n'
+          + 'Encode variable bitrate settings: \n'
+          + 'Target = 6030k \n'
+          + 'Minimum = 4523k \n'
+          + 'Maximum = 7538k \n'
+          + '==ALERT== OS detected as MAC - This will use VIDEOTOOLBOX to encode which is NOT QSV\n'
+          + 'cmds set in extra_qsv_options will be IGNORED!\n'
+          + 'File Transcoding... \n',
+        container: '.mkv',
+      },
+    },
+  },
+  // Test 4
+  {
+    input: {
+      file: (() => {
+        const file = _.cloneDeep(require('../sampleData/media/sampleH265_1.json'));
+        file.mediaInfo.track[1].BitRate = 5000000;
+        file.ffProbeData.streams[0].profile = 'Main 10';
+        file.mediaInfo.track[0].extra.JBDONEDATE = new Date().toISOString();
+        return file;
+      })(),
+      librarySettings: {},
+      inputs: {
+        container: 'mkv',
+        encoder_speedpreset: 'fast',
+        reconvert_hevc: 'true',
+        hevc_max_bitrate: '6000',
+        bitrate_cutoff: '4000',
+      },
+      otherArguments: {},
+    },
+    output: {
+      processFile: false,
+      preset: '',
+      handBrakeMode: false,
+      FFmpegMode: true,
+      reQueueAfter: true,
+      infoLog: "Checking file stats - If stats are older than 7 days we'll grab new stats.\n"
+        + '\n'
+        + `    Stats threshold: ${statsThresString}\n`
+        + '\n'
+        + `    Current stats date: ${datStatsString}\n`
+        + '☑ File stats are upto date! - Continuing...\n'
+        + '☑ It looks like the current video bitrate is 5000kbps. \n'
+        + 'Reconvert_hevc is true & the file is already HEVC, VP9 or AV1. Using HEVC specific cutoff of 6000kbps. \n'
+        + '☑ The file is NOT above this new cutoff. Exiting plugin. \n',
+      container: '.mkv',
+    },
+  },
+  // Test 5
+  {
+    input: {
+      file: (() => {
+        const file = _.cloneDeep(require('../sampleData/media/sampleH265_1.json'));
+        file.container = 'mp4';
+        return file;
+      })(),
       librarySettings: {},
       inputs: {
         container: 'mp4',
         encoder_speedpreset: 'fast',
-        enable_10bit: 'true',
-        bitrate_cutoff: '2000',
+        bitrate_cutoff: '3500',
       },
       otherArguments: {},
     },
@@ -153,10 +391,185 @@ const tests = [
       FFmpegMode: true,
       reQueueAfter: true,
       infoLog: 'Input file is not MKV so cannot use mkvpropedit to get new file stats. Continuing but file stats will likely be inaccurate...\n'
-        + '☑ It looks like the current video bitrate is 1206kbps. \n'
-        + '☑ Current bitrate is below set cutoff of 2000kbps. \n'
+        + '==WARNING== Failed to get an accurate video bitrate, falling back to old method to get OVERALL file bitrate of 3059kbps. Bitrate calculations for video encode will likely be inaccurate... \n'
+        + '☑ Current bitrate is below set cutoff of 3500kbps. \n'
         + 'Cancelling plugin. \n',
       container: '.mp4',
+    },
+  },
+  // Test 6
+  {
+    input: {
+      file: (() => {
+        const file = _.cloneDeep(require('../sampleData/media/sampleH264_2.json'));
+        file.mediaInfo.track[0].extra.JBDONEDATE = new Date().toISOString();
+        file.ffProbeData.streams[3].codec_name = 'hdmv_pgs_subtitle';
+        file.ffProbeData.streams[4].codec_name = 'eia_608';
+        file.ffProbeData.streams[5].codec_name = 'subrip';
+        file.ffProbeData.streams[6].codec_name = 'timed_id3';
+        return file;
+      })(),
+      librarySettings: {},
+      inputs: {
+        container: 'mp4',
+        encoder_speedpreset: 'fast',
+        force_conform: 'true',
+      },
+      otherArguments: {},
+    },
+    output: {
+      linux: {
+        processFile: true,
+        preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv \n'
+          + '      -init_hw_device qsv:hw_any,child_device_type=vaapi -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -load_plugin hevc_hw -b:v 3227k -minrate 2420k -maxrate 4034k -bufsize 6454k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -map -0:3 -map -0:4 -map -0:5 -map -0:6  -map_metadata:g -1 -metadata JBDONEDATE=2674800000',
+        handBrakeMode: false,
+        FFmpegMode: true,
+        reQueueAfter: true,
+        infoLog: "Checking file stats - If stats are older than 7 days we'll grab new stats.\n"
+          + '\n'
+          + `    Stats threshold: ${statsThresString}\n`
+          + '\n'
+          + `    Current stats date: ${datStatsString}\n`
+          + '☑ File stats are upto date! - Continuing...\n'
+          + '☑ It looks like the current video bitrate is 6454kbps. \n'
+          + 'Container for output selected as mp4. \n'
+          + 'Encode variable bitrate settings: \n'
+          + 'Target = 3227k \n'
+          + 'Minimum = 2420k \n'
+          + 'Maximum = 4034k \n'
+          + 'File Transcoding... \n',
+        container: '.mp4',
+      },
+      win32: {
+        processFile: true,
+        preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv \n'
+          + '      -init_hw_device qsv:hw_any,child_device_type=d3d11va -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -load_plugin hevc_hw -b:v 3227k -minrate 2420k -maxrate 4034k -bufsize 6454k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -map -0:3 -map -0:4 -map -0:5 -map -0:6  -map_metadata:g -1 -metadata JBDONEDATE=2674800000',
+        handBrakeMode: false,
+        FFmpegMode: true,
+        reQueueAfter: true,
+        infoLog: "Checking file stats - If stats are older than 7 days we'll grab new stats.\n"
+          + '\n'
+          + `    Stats threshold: ${statsThresString}\n`
+          + '\n'
+          + `    Current stats date: ${datStatsString}\n`
+          + '☑ File stats are upto date! - Continuing...\n'
+          + '☑ It looks like the current video bitrate is 6454kbps. \n'
+          + 'Container for output selected as mp4. \n'
+          + 'Encode variable bitrate settings: \n'
+          + 'Target = 3227k \n'
+          + 'Minimum = 2420k \n'
+          + 'Maximum = 4034k \n'
+          + 'File Transcoding... \n',
+        container: '.mp4',
+      },
+      darwin: {
+        processFile: true,
+        preset: '-fflags +genpts -hwaccel videotoolbox<io> -map 0 -c:v hevc_videotoolbox<io> -map 0 -c:v hevc_qsv -load_plugin hevc_hw -b:v 3227k -minrate 2420k -maxrate 4034k -bufsize 6454k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -map -0:3 -map -0:4 -map -0:5 -map -0:6  -map_metadata:g -1 -metadata JBDONEDATE=2674800000',
+        handBrakeMode: false,
+        FFmpegMode: true,
+        reQueueAfter: true,
+        infoLog: "Checking file stats - If stats are older than 7 days we'll grab new stats.\n"
+          + '\n'
+          + `    Stats threshold: ${statsThresString}\n`
+          + '\n'
+          + `    Current stats date: ${datStatsString}\n`
+          + '☑ File stats are upto date! - Continuing...\n'
+          + '☑ It looks like the current video bitrate is 6454kbps. \n'
+          + 'Container for output selected as mp4. \n'
+          + 'Encode variable bitrate settings: \n'
+          + 'Target = 3227k \n'
+          + 'Minimum = 2420k \n'
+          + 'Maximum = 4034k \n'
+          + 'File Transcoding... \n',
+        container: '.mp4',
+      },
+    },
+  },
+  // Test 7
+  {
+    input: {
+      file: (() => {
+        const file = _.cloneDeep(require('../sampleData/media/sampleH264_2.json'));
+        file.mediaInfo.track[0].extra.JBDONEDATE = new Date().toISOString();
+        file.ffProbeData.streams[3].codec_name = 'mov_text';
+        file.ffProbeData.streams[4].codec_name = 'eia_608';
+        file.ffProbeData.streams[5].codec_name = 'timed_id3';
+        return file;
+      })(),
+      librarySettings: {},
+      inputs: {
+        container: 'mkv',
+        encoder_speedpreset: 'fast',
+        force_conform: 'true',
+      },
+      otherArguments: {},
+    },
+    output: {
+      linux: {
+        processFile: true,
+        preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv \n'
+          + '      -init_hw_device qsv:hw_any,child_device_type=vaapi -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -load_plugin hevc_hw -b:v 3227k -minrate 2420k -maxrate 4034k -bufsize 6454k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -map -0:d -map -0:3 -map -0:4 -map -0:5  -map_metadata:g -1 -metadata JBDONEDATE=2674800000',
+        handBrakeMode: false,
+        FFmpegMode: true,
+        reQueueAfter: true,
+        infoLog: "Checking file stats - If stats are older than 7 days we'll grab new stats.\n"
+          + '\n'
+          + `    Stats threshold: ${statsThresString}\n`
+          + '\n'
+          + `    Current stats date: ${datStatsString}\n`
+          + '☑ File stats are upto date! - Continuing...\n'
+          + '☑ It looks like the current video bitrate is 6454kbps. \n'
+          + 'Container for output selected as mkv. \n'
+          + 'Encode variable bitrate settings: \n'
+          + 'Target = 3227k \n'
+          + 'Minimum = 2420k \n'
+          + 'Maximum = 4034k \n'
+          + 'File Transcoding... \n',
+        container: '.mkv',
+      },
+      win32: {
+        processFile: true,
+        preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv \n'
+          + '      -init_hw_device qsv:hw_any,child_device_type=d3d11va -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -load_plugin hevc_hw -b:v 3227k -minrate 2420k -maxrate 4034k -bufsize 6454k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -map -0:d -map -0:3 -map -0:4 -map -0:5  -map_metadata:g -1 -metadata JBDONEDATE=2674800000',
+        handBrakeMode: false,
+        FFmpegMode: true,
+        reQueueAfter: true,
+        infoLog: "Checking file stats - If stats are older than 7 days we'll grab new stats.\n"
+          + '\n'
+          + `    Stats threshold: ${statsThresString}\n`
+          + '\n'
+          + `    Current stats date: ${datStatsString}\n`
+          + '☑ File stats are upto date! - Continuing...\n'
+          + '☑ It looks like the current video bitrate is 6454kbps. \n'
+          + 'Container for output selected as mkv. \n'
+          + 'Encode variable bitrate settings: \n'
+          + 'Target = 3227k \n'
+          + 'Minimum = 2420k \n'
+          + 'Maximum = 4034k \n'
+          + 'File Transcoding... \n',
+        container: '.mkv',
+      },
+      darwin: {
+        processFile: true,
+        preset: '-fflags +genpts -hwaccel videotoolbox<io> -map 0 -c:v hevc_videotoolbox<io> -map 0 -c:v hevc_qsv -load_plugin hevc_hw -b:v 3227k -minrate 2420k -maxrate 4034k -bufsize 6454k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -map -0:d -map -0:3 -map -0:4 -map -0:5  -map_metadata:g -1 -metadata JBDONEDATE=2674800000',
+        handBrakeMode: false,
+        FFmpegMode: true,
+        reQueueAfter: true,
+        infoLog: "Checking file stats - If stats are older than 7 days we'll grab new stats.\n"
+          + '\n'
+          + `    Stats threshold: ${statsThresString}\n`
+          + '\n'
+          + `    Current stats date: ${datStatsString}\n`
+          + '☑ File stats are upto date! - Continuing...\n'
+          + '☑ It looks like the current video bitrate is 6454kbps. \n'
+          + 'Container for output selected as mkv. \n'
+          + 'Encode variable bitrate settings: \n'
+          + 'Target = 3227k \n'
+          + 'Minimum = 2420k \n'
+          + 'Maximum = 4034k \n'
+          + 'File Transcoding... \n',
+        container: '.mkv',
+      },
     },
   },
 ];

--- a/tests/Community/Tdarr_Plugin_bsh1_Boosh_FFMPEG_QSV_HEVC.js
+++ b/tests/Community/Tdarr_Plugin_bsh1_Boosh_FFMPEG_QSV_HEVC.js
@@ -2,12 +2,6 @@
 const _ = require('lodash');
 const run = require('../helpers/run');
 
-// Date stuff for mkvpropedit
-const intStatsDays = 7; // Use 1 week threshold for new stats
-let statsThresString = new Date(new Date().setDate(new Date().getDate() - intStatsDays)).toUTCString();
-statsThresString = `${statsThresString.slice(0, 22)}:00 GMT`;
-let datStatsString = new Date().toUTCString();
-datStatsString = `${datStatsString.slice(0, 22)}:00 GMT`;
 const tests = [
   // Test 0
   {
@@ -415,12 +409,12 @@ const tests = [
         FFmpegMode: true,
         reQueueAfter: true,
         infoLog: '☑ It looks like the current video bitrate is 6454kbps. \n'
-        + 'Container for output selected as mkv. \n'
-        + 'Encode variable bitrate settings: \n'
-        + 'Target = 3227k \n'
-        + 'Minimum = 2420k \n'
-        + 'Maximum = 4034k \n'
-        + 'File Transcoding... \n',
+          + 'Container for output selected as mkv. \n'
+          + 'Encode variable bitrate settings: \n'
+          + 'Target = 3227k \n'
+          + 'Minimum = 2420k \n'
+          + 'Maximum = 4034k \n'
+          + 'File Transcoding... \n',
         container: '.mkv',
       },
       win32: {
@@ -431,12 +425,12 @@ const tests = [
         FFmpegMode: true,
         reQueueAfter: true,
         infoLog: '☑ It looks like the current video bitrate is 6454kbps. \n'
-        + 'Container for output selected as mkv. \n'
-        + 'Encode variable bitrate settings: \n'
-        + 'Target = 3227k \n'
-        + 'Minimum = 2420k \n'
-        + 'Maximum = 4034k \n'
-        + 'File Transcoding... \n',
+          + 'Container for output selected as mkv. \n'
+          + 'Encode variable bitrate settings: \n'
+          + 'Target = 3227k \n'
+          + 'Minimum = 2420k \n'
+          + 'Maximum = 4034k \n'
+          + 'File Transcoding... \n',
         container: '.mkv',
       },
       darwin: {
@@ -446,12 +440,12 @@ const tests = [
         FFmpegMode: true,
         reQueueAfter: true,
         infoLog: '☑ It looks like the current video bitrate is 6454kbps. \n'
-        + 'Container for output selected as mkv. \n'
-        + 'Encode variable bitrate settings: \n'
-        + 'Target = 3227k \n'
-        + 'Minimum = 2420k \n'
-        + 'Maximum = 4034k \n'
-        + 'File Transcoding... \n',
+          + 'Container for output selected as mkv. \n'
+          + 'Encode variable bitrate settings: \n'
+          + 'Target = 3227k \n'
+          + 'Minimum = 2420k \n'
+          + 'Maximum = 4034k \n'
+          + 'File Transcoding... \n',
         container: '.mkv',
       },
     },

--- a/tests/Community/Tdarr_Plugin_bsh1_Boosh_FFMPEG_QSV_HEVC.js
+++ b/tests/Community/Tdarr_Plugin_bsh1_Boosh_FFMPEG_QSV_HEVC.js
@@ -469,7 +469,7 @@ const tests = [
       linux: {
         processFile: true,
         preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv \n'
-          + '        -init_hw_device qsv:hw_any,child_device_type=vaapi -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset fast -look_ahead 1 -look_ahead_depth 100 -extbrc 1 -rdo 1 -mbbrc 1 -b_strategy 1 -adaptive_i 1 -adaptive_b 1 -vf scale_qsv=1280:-1:format=p010le,hwupload=extra_hw_frames=64,format=qsv  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f matroska -profile:v main10',
+          + '        -init_hw_device qsv:hw_any,child_device_type=vaapi -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset fast -look_ahead 1 -look_ahead_depth 100 -extbrc 1 -rdo 1 -mbbrc 1 -b_strategy 1 -adaptive_i 1 -adaptive_b 1 -vf scale_qsv=1280:-1,format=p010le,hwupload=extra_hw_frames=64,format=qsv  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f matroska -profile:v main10',
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,
@@ -486,7 +486,7 @@ const tests = [
       win32: {
         processFile: true,
         preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv \n'
-          + '        -init_hw_device qsv:hw,child_device_type=d3d11va -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset fast -look_ahead 1 -look_ahead_depth 100 -extbrc 1 -rdo 1 -mbbrc 1 -b_strategy 1 -adaptive_i 1 -adaptive_b 1 -vf scale_qsv=1280:-1:format=p010le,hwupload=extra_hw_frames=64,format=qsv  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f matroska -profile:v main10',
+          + '        -init_hw_device qsv:hw,child_device_type=d3d11va -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset fast -look_ahead 1 -look_ahead_depth 100 -extbrc 1 -rdo 1 -mbbrc 1 -b_strategy 1 -adaptive_i 1 -adaptive_b 1 -vf scale_qsv=1280:-1,format=p010le,hwupload=extra_hw_frames=64,format=qsv  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f matroska -profile:v main10',
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,

--- a/tests/Community/Tdarr_Plugin_bsh1_Boosh_FFMPEG_QSV_HEVC.js
+++ b/tests/Community/Tdarr_Plugin_bsh1_Boosh_FFMPEG_QSV_HEVC.js
@@ -15,7 +15,7 @@ const tests = [
       linux: {
         processFile: true,
         preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv \n'
-          + '        -init_hw_device qsv:hw_any,child_device_type=vaapi -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset slow  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f matroska -vf "hwupload=extra_hw_frames=64,format=qsv" ',
+          + '        -init_hw_device qsv:hw_any,child_device_type=vaapi -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset slow  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f matroska -vf hwupload=extra_hw_frames=64,format=qsv ',
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,
@@ -31,7 +31,7 @@ const tests = [
       win32: {
         processFile: true,
         preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv \n'
-          + '        -init_hw_device qsv:hw,child_device_type=d3d11va -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset slow  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f matroska ',
+          + '        -init_hw_device qsv:hw,child_device_type=d3d11va -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset slow  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f matroska -vf hwupload=extra_hw_frames=64,format=qsv ',
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,
@@ -79,7 +79,7 @@ const tests = [
       linux: {
         processFile: true,
         preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv \n'
-          + '        -init_hw_device qsv:hw_any,child_device_type=vaapi -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f mp4 -profile:v main10 -vf scale_qsv=format=p010le -vf "hwupload=extra_hw_frames=64,format=qsv" ',
+          + '        -init_hw_device qsv:hw_any,child_device_type=vaapi -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f mp4 -profile:v main10 -vf scale_qsv=format=p010le,hwupload=extra_hw_frames=64,format=qsv ',
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,
@@ -96,7 +96,7 @@ const tests = [
       win32: {
         processFile: true,
         preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv \n'
-          + '        -init_hw_device qsv:hw,child_device_type=d3d11va -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f mp4 -profile:v main10 -vf scale_qsv=format=p010le',
+          + '        -init_hw_device qsv:hw,child_device_type=d3d11va -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f mp4 -profile:v main10 -vf scale_qsv=format=p010le,hwupload=extra_hw_frames=64,format=qsv ',
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,
@@ -225,7 +225,7 @@ const tests = [
       linux: {
         processFile: true,
         preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv \n'
-          + '        -init_hw_device qsv:hw_any,child_device_type=vaapi -c:v hevc_qsv<io> -map 0 -c:v hevc_qsv -load_plugin hevc_hw -b:v 6000k -minrate 4500k -maxrate 7500k -bufsize 12000k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f matroska -profile:v main10 -vf scale_qsv=format=p010le -vf "hwupload=extra_hw_frames=64,format=qsv" ',
+          + '        -init_hw_device qsv:hw_any,child_device_type=vaapi -c:v hevc_qsv<io> -map 0 -c:v hevc_qsv -b:v 6000k -minrate 4500k -maxrate 7500k -bufsize 12000k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f matroska -profile:v main10 -vf scale_qsv=format=p010le,hwupload=extra_hw_frames=64,format=qsv ',
         FFmpegMode: true,
         reQueueAfter: true,
         infoLog: '☑ It looks like the current video bitrate is 12000kbps. \n'
@@ -243,7 +243,7 @@ const tests = [
       win32: {
         processFile: true,
         preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv \n'
-          + '        -init_hw_device qsv:hw,child_device_type=d3d11va -c:v hevc_qsv<io> -map 0 -c:v hevc_qsv -b:v 6000k -minrate 4500k -maxrate 7500k -bufsize 12000k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f matroska -profile:v main10 -vf scale_qsv=format=p010le ',
+          + '        -init_hw_device qsv:hw,child_device_type=d3d11va -c:v hevc_qsv<io> -map 0 -c:v hevc_qsv -b:v 6000k -minrate 4500k -maxrate 7500k -bufsize 12000k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f matroska -profile:v main10 -vf scale_qsv=format=p010le,hwupload=extra_hw_frames=64,format=qsv ',
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,
@@ -336,7 +336,7 @@ const tests = [
       linux: {
         processFile: true,
         preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv \n'
-          + '        -init_hw_device qsv:hw_any,child_device_type=vaapi -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -load_plugin hevc_hw -b:v 3227k -minrate 2420k -maxrate 4034k -bufsize 6454k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -map -0:3 -map -0:4 -map -0:5 -map -0:6 -f mp4 -vf "hwupload=extra_hw_frames=64,format=qsv" ',
+          + '        -init_hw_device qsv:hw_any,child_device_type=vaapi -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -b:v 3227k -minrate 2420k -maxrate 4034k -bufsize 6454k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -map -0:3 -map -0:4 -map -0:5 -map -0:6 -f mp4 -vf hwupload=extra_hw_frames=64,format=qsv ',
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,
@@ -352,7 +352,7 @@ const tests = [
       win32: {
         processFile: true,
         preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv \n'
-          + '        -init_hw_device qsv:hw,child_device_type=d3d11va -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -b:v 3227k -minrate 2420k -maxrate 4034k -bufsize 6454k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -map -0:3 -map -0:4 -map -0:5 -map -0:6 -f mp4 ',
+          + '        -init_hw_device qsv:hw,child_device_type=d3d11va -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -b:v 3227k -minrate 2420k -maxrate 4034k -bufsize 6454k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -map -0:3 -map -0:4 -map -0:5 -map -0:6 -f mp4 -vf hwupload=extra_hw_frames=64,format=qsv ',
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,
@@ -404,7 +404,7 @@ const tests = [
       linux: {
         processFile: true,
         preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv \n'
-          + '        -init_hw_device qsv:hw_any,child_device_type=vaapi -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -load_plugin hevc_hw -b:v 3227k -minrate 2420k -maxrate 4034k -bufsize 6454k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -map -0:d -map -0:3 -map -0:4 -map -0:5 -f matroska -vf "hwupload=extra_hw_frames=64,format=qsv" ',
+          + '        -init_hw_device qsv:hw_any,child_device_type=vaapi -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -b:v 3227k -minrate 2420k -maxrate 4034k -bufsize 6454k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -map -0:d -map -0:3 -map -0:4 -map -0:5 -f matroska -vf hwupload=extra_hw_frames=64,format=qsv ',
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,
@@ -420,7 +420,7 @@ const tests = [
       win32: {
         processFile: true,
         preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv \n'
-          + '        -init_hw_device qsv:hw,child_device_type=d3d11va -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -b:v 3227k -minrate 2420k -maxrate 4034k -bufsize 6454k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -map -0:d -map -0:3 -map -0:4 -map -0:5 -f matroska ',
+          + '        -init_hw_device qsv:hw,child_device_type=d3d11va -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -b:v 3227k -minrate 2420k -maxrate 4034k -bufsize 6454k -preset fast  -c:a copy -c:s copy -max_muxing_queue_size 9999 -map -0:d -map -0:3 -map -0:4 -map -0:5 -f matroska -vf hwupload=extra_hw_frames=64,format=qsv ',
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,
@@ -467,7 +467,7 @@ const tests = [
       linux: {
         processFile: true,
         preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv \n'
-          + '        -init_hw_device qsv:hw_any,child_device_type=vaapi -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset fast -look_ahead 1 -look_ahead_depth 100 -extbrc 1 -rdo 1 -mbbrc 1 -b_strategy 1 -adaptive_i 1 -adaptive_b 1 -vf scale_qsv=1280:-1:format=p010le  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f matroska -profile:v main10',
+          + '        -init_hw_device qsv:hw_any,child_device_type=vaapi -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset fast -look_ahead 1 -look_ahead_depth 100 -extbrc 1 -rdo 1 -mbbrc 1 -b_strategy 1 -adaptive_i 1 -adaptive_b 1 -vf scale_qsv=1280:-1:format=p010le,hwupload=extra_hw_frames=64,format=qsv  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f matroska -profile:v main10',
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,
@@ -484,7 +484,7 @@ const tests = [
       win32: {
         processFile: true,
         preset: '-fflags +genpts -hwaccel qsv -hwaccel_output_format qsv \n'
-          + '        -init_hw_device qsv:hw,child_device_type=d3d11va -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset fast -look_ahead 1 -look_ahead_depth 100 -extbrc 1 -rdo 1 -mbbrc 1 -b_strategy 1 -adaptive_i 1 -adaptive_b 1 -vf scale_qsv=1280:-1:format=p010le  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f matroska -profile:v main10',
+          + '        -init_hw_device qsv:hw,child_device_type=d3d11va -c:v h264_qsv<io> -map 0 -c:v hevc_qsv -b:v 603k -minrate 452k -maxrate 754k -bufsize 1206k -preset fast -look_ahead 1 -look_ahead_depth 100 -extbrc 1 -rdo 1 -mbbrc 1 -b_strategy 1 -adaptive_i 1 -adaptive_b 1 -vf scale_qsv=1280:-1:format=p010le,hwupload=extra_hw_frames=64,format=qsv  -c:a copy -c:s copy -max_muxing_queue_size 9999 -f matroska -profile:v main10',
         handBrakeMode: false,
         FFmpegMode: true,
         reQueueAfter: true,


### PR DESCRIPTION
Main changes
- Removed the manual remux using mkvpropedit - This is now built into Tdarr & can be enabled/disabled per user (Even in some cases where a remux really is needed, thats better as a separate plugin to do that and can be put into a flow)
- Check videoBR is a real number
- VideoBR logic inside a try block to avoid errors on problematic files
- Added -f cmd to correctly specify output format (not sure needed but seems best practice)
- Checks to ensure the incoming format is supported for 10 bit, changes 10 bit cmd
- Removed -load plugin for win32 as it doesn't seem needed anymore
- HW decode updated, VC1 & VP8 no longer supported by latest intel HW so commented out
- Added hwupload=extra_hw_frames=64,format=qsv cmd to improve hw encode & setup to try and accommodate existing -vf cmds

Tests also updated but probably needs another pass