### PR TITLE
Flow Plugin - RemoveStreamByProperty: extend to filter by codec_type

### DIFF
--- a/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandRemoveStreamByProperty/1.0.0/index.js
+++ b/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandRemoveStreamByProperty/1.0.0/index.js
@@ -17,6 +17,22 @@ var details = function () { return ({
     icon: '',
     inputs: [
         {
+            label: 'Codec Type',
+            name: 'codecType',
+            type: 'string',
+            defaultValue: 'all',
+            inputUI: {
+                type: 'dropdown',
+                options: [
+                    'audio',
+                    'video',
+                    'subtitle',
+                    'any',
+                ],
+            },
+            tooltip: "\n      Stream Codec Type to check against the property.\n        ",
+        },
+        {
             label: 'Property To Check',
             name: 'propertyToCheck',
             type: 'string',
@@ -65,10 +81,13 @@ var plugin = function (args) {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars,no-param-reassign
     args.inputs = lib.loadDefaultValues(args.inputs, details);
     (0, flowUtils_1.checkFfmpegCommandInit)(args);
+    var codecType = String(args.inputs.codecType).trim();
     var propertyToCheck = String(args.inputs.propertyToCheck).trim();
     var valuesToRemove = String(args.inputs.valuesToRemove).trim().split(',').map(function (item) { return item.trim(); });
     var condition = String(args.inputs.condition);
-    args.variables.ffmpegCommand.streams.forEach(function (stream) {
+    args.variables.ffmpegCommand.streams
+        .filter(function (stream) { return codecType === 'any' || stream.codec_type === codecType; })
+        .forEach(function (stream) {
         var _a;
         var target = '';
         if (propertyToCheck.includes('.')) {

--- a/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandRemoveStreamByProperty/1.0.0/index.js
+++ b/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandRemoveStreamByProperty/1.0.0/index.js
@@ -98,20 +98,16 @@ var plugin = function (args) {
             target = stream[propertyToCheck];
         }
         if (target) {
-            var prop = String(target).toLowerCase();
-            for (var i = 0; i < valuesToRemove.length; i += 1) {
-                var val = valuesToRemove[i].toLowerCase();
-                var prefix = "Removing stream index ".concat(stream.index, " because ").concat(propertyToCheck, " of ").concat(prop);
-                if (condition === 'includes' && prop.includes(val)) {
-                    args.jobLog("".concat(prefix, " includes ").concat(val, "\n"));
-                    // eslint-disable-next-line no-param-reassign
-                    stream.removed = true;
-                }
-                else if (condition === 'not_includes' && !prop.includes(val)) {
-                    args.jobLog("".concat(prefix, " not_includes ").concat(val, "\n"));
-                    // eslint-disable-next-line no-param-reassign
-                    stream.removed = true;
-                }
+            var prop_1 = String(target).toLowerCase();
+            // For includes: remove if the property includes ANY of the values
+            // For not_includes: remove if the property doesn't include ALL of the values
+            var shouldRemove = condition === 'includes'
+                ? valuesToRemove.some(function (val) { return prop_1.includes(val.toLowerCase()); })
+                : !valuesToRemove.some(function (val) { return prop_1.includes(val.toLowerCase()); });
+            if (shouldRemove) {
+                var valuesStr = valuesToRemove.join(', ');
+                args.jobLog("Removing stream index ".concat(stream.index, " because ").concat(propertyToCheck, " of ").concat(prop_1, " ").concat(condition, " ").concat(valuesStr, "\n"));
+                stream.removed = true;
             }
         }
     });

--- a/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandRemoveStreamByProperty/1.0.0/index.js
+++ b/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandRemoveStreamByProperty/1.0.0/index.js
@@ -100,7 +100,7 @@ var plugin = function (args) {
         if (target) {
             var prop_1 = String(target).toLowerCase();
             // For includes: remove if the property includes ANY of the values
-            // For not_includes: remove if the property doesn't include ALL of the values
+            // For not_includes: remove if the property doesn't include ANY of the values
             var shouldRemove = condition === 'includes'
                 ? valuesToRemove.some(function (val) { return prop_1.includes(val.toLowerCase()); })
                 : !valuesToRemove.some(function (val) { return prop_1.includes(val.toLowerCase()); });
@@ -108,6 +108,9 @@ var plugin = function (args) {
                 var valuesStr = valuesToRemove.join(', ');
                 args.jobLog("Removing stream index ".concat(stream.index, " because ").concat(propertyToCheck, " of ").concat(prop_1, " ").concat(condition, " ").concat(valuesStr, "\n"));
                 stream.removed = true;
+            }
+            else {
+                args.jobLog("Keep stream index ".concat(stream.index, " because ").concat(propertyToCheck, " of ").concat(prop_1, " ").concat(condition, " ").concat(valuesStr, "\n"));
             }
         }
     });

--- a/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandSetVdeoResolution/1.0.0/index.js
+++ b/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandSetVdeoResolution/1.0.0/index.js
@@ -42,6 +42,25 @@ var details = function () { return ({
     ],
 }); };
 exports.details = details;
+var getQsvVfScale = function (targetResolution) {
+    switch (targetResolution) {
+        case '480p':
+            return ['-vf', 'vpp_qsv=w=720:h=480'];
+        case '576p':
+            return ['-vf', 'vpp_qsv=w=720:h=576'];
+        case '720p':
+            return ['-vf', 'vpp_qsv=w=1280:h=720'];
+        case '1080p':
+            return ['-vf', 'vpp_qsv=w=1920:h=1080'];
+        case '1440p':
+            return ['-vf', 'vpp_qsv=w=2560:h=1440'];
+        case '4KUHD':
+            return ['-vf', 'vpp_qsv=w=3840:h=2160'];
+        default:
+            return ['-vf', 'vpp_qsv=w=1920:h=1080'];
+    }
+    ;
+};
 var getVfScale = function (targetResolution) {
     switch (targetResolution) {
         case '480p':
@@ -69,12 +88,13 @@ var plugin = function (args) {
     (0, flowUtils_1.checkFfmpegCommandInit)(args);
     for (var i = 0; i < args.variables.ffmpegCommand.streams.length; i += 1) {
         var stream = args.variables.ffmpegCommand.streams[i];
+        var usedQSV = stream.outputArgs.some(function (row) { return row.includes('qsv'); });
         if (stream.codec_type === 'video') {
             var targetResolution = String(args.inputs.targetResolution);
             if (targetResolution !== args.inputFileObj.video_resolution) {
                 // eslint-disable-next-line no-param-reassign
                 args.variables.ffmpegCommand.shouldProcess = true;
-                var scaleArgs = getVfScale(targetResolution);
+                var scaleArgs = usedQSV ? getQsvVfScale(targetResolution) : getVfScale(targetResolution);
                 (_a = stream.outputArgs).push.apply(_a, scaleArgs);
             }
         }

--- a/FlowPluginsTs/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandRemoveStreamByProperty/1.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandRemoveStreamByProperty/1.0.0/index.ts
@@ -111,7 +111,7 @@ const plugin = (args: IpluginInputArgs): IpluginOutputArgs => {
   const condition = String(args.inputs.condition);
 
   args.variables.ffmpegCommand.streams
-  .filter(stream => codecType === 'any' || stream.codec_type === codecType)
+  .filter((stream) => codecType === 'any' || stream.codec_type === codecType)
   .forEach((stream) => {
     let target = '';
     if (propertyToCheck.includes('.')) {

--- a/FlowPluginsTs/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandRemoveStreamByProperty/1.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandRemoveStreamByProperty/1.0.0/index.ts
@@ -28,12 +28,13 @@ const details = (): IpluginDetails => ({
         options: [
           'audio',
           'video',
+          'subtitle',
           'any',
         ],
       },
       tooltip:
         `
-      Stream Codec Type to check against the property: audio, video or any.
+      Stream Codec Type to check against the property.
         `,
     },
 

--- a/FlowPluginsTs/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandRemoveStreamByProperty/1.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandRemoveStreamByProperty/1.0.0/index.ts
@@ -19,6 +19,26 @@ const details = (): IpluginDetails => ({
   icon: '',
   inputs: [
     {
+      label: 'Codec Type',
+      name: 'codecType',
+      type: 'string',
+      defaultValue: 'all',
+      inputUI: {
+        type: 'dropdown',
+        options: [
+          'audio',
+          'video',
+          'any',
+        ],
+      },
+      tooltip:
+        `
+      Codec Type audio, video or any
+        `,
+    },
+
+
+    {
       label: 'Property To Check',
       name: 'propertyToCheck',
       type: 'string',
@@ -84,11 +104,14 @@ const plugin = (args: IpluginInputArgs): IpluginOutputArgs => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars,no-param-reassign
   args.inputs = lib.loadDefaultValues(args.inputs, details);
 
+  const codecType = String(args.inputs.codecType).trim();
   const propertyToCheck = String(args.inputs.propertyToCheck).trim();
   const valuesToRemove = String(args.inputs.valuesToRemove).trim().split(',');
   const condition = String(args.inputs.condition);
 
-  args.variables.ffmpegCommand.streams.forEach((stream) => {
+  args.variables.ffmpegCommand.streams
+  .filter(stream => codecType === 'any' || stream.codec_type === codecType)
+  .forEach((stream) => {
     let target = '';
     if (propertyToCheck.includes('.')) {
       const parts = propertyToCheck.split('.');

--- a/FlowPluginsTs/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandRemoveStreamByProperty/1.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandRemoveStreamByProperty/1.0.0/index.ts
@@ -126,18 +126,19 @@ const plugin = (args: IpluginInputArgs): IpluginOutputArgs => {
 
     if (target) {
       const prop = String(target).toLowerCase();
-      for (let i = 0; i < valuesToRemove.length; i += 1) {
-        const val = valuesToRemove[i].toLowerCase();
-        const prefix = `Removing stream index ${stream.index} because ${propertyToCheck} of ${prop}`;
-        if (condition === 'includes' && prop.includes(val)) {
-          args.jobLog(`${prefix} includes ${val}\n`);
-          // eslint-disable-next-line no-param-reassign
-          stream.removed = true;
-        } else if (condition === 'not_includes' && !prop.includes(val)) {
-          args.jobLog(`${prefix} not_includes ${val}\n`);
-          // eslint-disable-next-line no-param-reassign
-          stream.removed = true;
-        }
+      
+      // For includes: remove if the property includes ANY of the values
+      // For not_includes: remove if the property doesn't include ANY of the values
+      const shouldRemove = condition === 'includes' 
+        ? valuesToRemove.some(val => prop.includes(val.toLowerCase()))
+        : !valuesToRemove.some(val => prop.includes(val.toLowerCase()));
+
+      if (shouldRemove) {
+        const valuesStr = valuesToRemove.join(', ');
+        args.jobLog(`Removing stream index ${stream.index} because ${propertyToCheck} of ${prop} ${condition} ${valuesStr}\n`);
+        stream.removed = true;
+      }else{
+        args.jobLog(`Keep stream index ${stream.index} because ${propertyToCheck} of ${prop} ${condition} ${valuesStr}\n`);
       }
     }
   });

--- a/FlowPluginsTs/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandRemoveStreamByProperty/1.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandRemoveStreamByProperty/1.0.0/index.ts
@@ -127,8 +127,8 @@ const plugin = (args: IpluginInputArgs): IpluginOutputArgs => {
     if (target) {
       const prop = String(target).toLowerCase();
       
-      // For includes: remove if the property includes ANY of the values
-      // For not_includes: remove if the property doesn't include ANY of the values
+      // For includes:      remove if the property includes ANY of the values
+      // For not_includes:  remove if the property includes NONE of the values
       const shouldRemove = condition === 'includes' 
         ? valuesToRemove.some(val => prop.includes(val.toLowerCase()))
         : !valuesToRemove.some(val => prop.includes(val.toLowerCase()));

--- a/FlowPluginsTs/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandRemoveStreamByProperty/1.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandRemoveStreamByProperty/1.0.0/index.ts
@@ -33,7 +33,7 @@ const details = (): IpluginDetails => ({
       },
       tooltip:
         `
-      Codec Type audio, video or any
+      Codec Type to check against the property: audio, video or any.
         `,
     },
 

--- a/FlowPluginsTs/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandRemoveStreamByProperty/1.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandRemoveStreamByProperty/1.0.0/index.ts
@@ -33,7 +33,7 @@ const details = (): IpluginDetails => ({
       },
       tooltip:
         `
-      Codec Type to check against the property: audio, video or any.
+      Stream Codec Type to check against the property: audio, video or any.
         `,
     },
 

--- a/FlowPluginsTs/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandSetVdeoResolution/1.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandSetVdeoResolution/1.0.0/index.ts
@@ -6,7 +6,7 @@ import {
 } from '../../../../FlowHelpers/1.0.0/interfaces/interfaces';
 
 /* eslint no-plusplus: ["error", { "allowForLoopAfterthoughts": true }] */
-const details = () :IpluginDetails => ({
+const details = (): IpluginDetails => ({
   name: 'Set Video Resolution',
   description: 'Change video resolution',
   style: {
@@ -45,65 +45,94 @@ const details = () :IpluginDetails => ({
   ],
 });
 
+const getQsvVfScale = (
+  targetResolution: string,
+): string[] => {
+
+  switch (targetResolution) {
+    case '480p':
+      return ['-vf', 'vpp_qsv=w=720:h=480'];
+
+    case '576p':
+      return ['-vf', 'vpp_qsv=w=720:h=576'];
+
+    case '720p':
+      return ['-vf', 'vpp_qsv=w=1280:h=720'];
+
+    case '1080p':
+      return ['-vf', 'vpp_qsv=w=1920:h=1080'];
+
+    case '1440p':
+      return ['-vf', 'vpp_qsv=w=2560:h=1440'];
+
+    case '4KUHD':
+      return ['-vf', 'vpp_qsv=w=3840:h=2160'];
+
+    default:
+      return ['-vf', 'vpp_qsv=w=1920:h=1080'];
+
+  };
+}
+
 const getVfScale = (
   targetResolution: string,
 ):string[] => {
-  switch (targetResolution) {
-    case '480p':
-      return ['-vf', 'scale=720:-2'];
+    switch (targetResolution) {
+      case '480p':
+        return ['-vf', 'scale=720:-2'];
 
-    case '576p':
-      return ['-vf', 'scale=720:-2'];
+      case '576p':
+        return ['-vf', 'scale=720:-2'];
 
-    case '720p':
-      return ['-vf', 'scale=1280:-2'];
+      case '720p':
+        return ['-vf', 'scale=1280:-2'];
 
-    case '1080p':
-      return ['-vf', 'scale=1920:-2'];
+      case '1080p':
+        return ['-vf', 'scale=1920:-2'];
 
-    case '1440p':
-      return ['-vf', 'scale=2560:-2'];
+      case '1440p':
+        return ['-vf', 'scale=2560:-2'];
 
-    case '4KUHD':
-      return ['-vf', 'scale=3840:-2'];
+      case '4KUHD':
+        return ['-vf', 'scale=3840:-2'];
 
-    default:
-      return ['-vf', 'scale=1920:-2'];
-  }
-};
+      default:
+        return ['-vf', 'scale=1920:-2'];
+    }
+  };
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const plugin = (args:IpluginInputArgs):IpluginOutputArgs => {
-  const lib = require('../../../../../methods/lib')();
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars,no-param-reassign
-  args.inputs = lib.loadDefaultValues(args.inputs, details);
+    const lib = require('../../../../../methods/lib')();
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars,no-param-reassign
+    args.inputs = lib.loadDefaultValues(args.inputs, details);
 
-  checkFfmpegCommandInit(args);
+    checkFfmpegCommandInit(args);
 
-  for (let i = 0; i < args.variables.ffmpegCommand.streams.length; i += 1) {
-    const stream = args.variables.ffmpegCommand.streams[i];
+    for (let i = 0; i < args.variables.ffmpegCommand.streams.length; i += 1) {
+      const stream = args.variables.ffmpegCommand.streams[i];
+      const usedQSV = stream.outputArgs.some((row) => row.includes('qsv'));
+      if (stream.codec_type === 'video') {
+        const targetResolution = String(args.inputs.targetResolution);
 
-    if (stream.codec_type === 'video') {
-      const targetResolution = String(args.inputs.targetResolution);
-
-      if (
-        targetResolution !== args.inputFileObj.video_resolution
-      ) {
-        // eslint-disable-next-line no-param-reassign
-        args.variables.ffmpegCommand.shouldProcess = true;
-        const scaleArgs = getVfScale(targetResolution);
-        stream.outputArgs.push(...scaleArgs);
+        if (
+          targetResolution !== args.inputFileObj.video_resolution
+        ) {
+          // eslint-disable-next-line no-param-reassign
+          args.variables.ffmpegCommand.shouldProcess = true;
+          const scaleArgs = usedQSV ? getQsvVfScale(targetResolution) : getVfScale(targetResolution);
+          stream.outputArgs.push(...scaleArgs);
+        }
       }
     }
-  }
 
-  return {
-    outputFileObj: args.inputFileObj,
-    outputNumber: 1,
-    variables: args.variables,
+    return {
+      outputFileObj: args.inputFileObj,
+      outputNumber: 1,
+      variables: args.variables,
+    };
   };
-};
-export {
-  details,
-  plugin,
-};
+  export {
+    details,
+    plugin,
+  };

--- a/tdarrIgnore.txt
+++ b/tdarrIgnore.txt
@@ -1,0 +1,2 @@
+.git
+node_modules


### PR DESCRIPTION
I extended the FlowPlugin RemoveStreamByProperty to specify the codec-type _(audio, video, any)._ My use-case was to ensure the audio streams matching the language property are no longer included in the container as I'm going to encode them in my process. 

Without this change the plugin also removes the video stream when the language property matched. 

This change should be backwards compatible as the default is set to _any_.

**Flow Example:**
<img width="221" alt="image" src="https://github.com/HaveAGitGat/Tdarr_Plugins/assets/5336841/d64a866f-4cdc-4619-9f8e-42a24b3663cd">


**Plugin Configuration:**
<img width="524" alt="image" src="https://github.com/HaveAGitGat/Tdarr_Plugins/assets/5336841/7f7a6733-9bc5-43e8-8c43-4536c0c84b22">
