### PR TITLE
Extend Check File Name Includes plugin to allow regex pattern

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -60,5 +60,8 @@ jobs:
     - run: npm i && npm i -g typescript && rm -rdf ./FlowPlugins && tsc -v && tsc
 
     - uses: stefanzweifel/git-auto-commit-action@v5
+      if: ${{ github.event.pull_request.head.repo.full_name == 'org/repo' }}
       with:
         commit_message: Apply auto-build changes
+
+    - run: (git diff --quiet HEAD -- 2>/dev/null && echo "No uncommitted changes" || (echo "Error: Uncommitted changes found." && exit 1))

--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -51,7 +51,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
       with:
-        ref: ${{ github.head_ref }}
+        ref: ${{ github.event.pull_request.head.sha }}
   
     - uses: actions/setup-node@v3
       with:

--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -64,4 +64,6 @@ jobs:
       with:
         commit_message: Apply auto-build changes
 
-    - run: (git diff --quiet HEAD -- 2>/dev/null && echo "No uncommitted changes" || (echo "Error: Uncommitted changes found." && exit 1))
+    - run: |
+        (git diff --quiet HEAD -- 2>/dev/null && echo "No uncommitted changes" \
+        || (echo "Error - Uncommitted changes found." && git --no-pager diff HEAD && exit 1))

--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -23,7 +23,10 @@ jobs:
         git config --global core.autocrlf false
         git config --global core.eol lf
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v1
       with:
@@ -46,9 +49,9 @@ jobs:
       contents: write
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v3
       with:
-        ref: ${{ github.head_ref }}
+        ref: ${{ github.event.pull_request.head.sha }}
   
     - uses: actions/setup-node@v3
       with:

--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -51,7 +51,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
       with:
-        ref: ${{ github.event.pull_request.head.sha }}
+        ref: ${{ github.head_ref }}
   
     - uses: actions/setup-node@v3
       with:

--- a/FlowPlugins/CommunityFlowPlugins/file/checkFileNameIncludes/1.0.0/index.js
+++ b/FlowPlugins/CommunityFlowPlugins/file/checkFileNameIncludes/1.0.0/index.js
@@ -20,12 +20,10 @@ var details = function () { return ({
             label: 'Terms',
             name: 'terms',
             type: 'string',
-            // eslint-disable-next-line no-template-curly-in-string
             defaultValue: '_720p,_1080p',
             inputUI: {
                 type: 'text',
             },
-            // eslint-disable-next-line no-template-curly-in-string
             tooltip: 'Specify terms to check for in file name using comma seperated list e.g. _720p,_1080p',
         },
     ],

--- a/FlowPlugins/CommunityFlowPlugins/file/checkFileNameIncludes/2.0.0/index.js
+++ b/FlowPlugins/CommunityFlowPlugins/file/checkFileNameIncludes/2.0.0/index.js
@@ -1,0 +1,90 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.plugin = exports.details = void 0;
+var fileUtils_1 = require("../../../../FlowHelpers/1.0.0/fileUtils");
+/* eslint no-plusplus: ["error", { "allowForLoopAfterthoughts": true }] */
+var details = function () { return ({
+    name: 'Check File Name Includes',
+    description: 'Check if a file name includes specific terms. Only needs to match one term',
+    style: {
+        borderColor: 'orange',
+    },
+    tags: 'video',
+    isStartPlugin: false,
+    pType: '',
+    requiresVersion: '2.11.01',
+    sidebarPosition: -1,
+    icon: 'faQuestion',
+    inputs: [
+        {
+            label: 'Terms',
+            name: 'terms',
+            type: 'string',
+            // eslint-disable-next-line no-template-curly-in-string
+            defaultValue: '_720p,_1080p',
+            inputUI: {
+                type: 'text',
+            },
+            // eslint-disable-next-line no-template-curly-in-string
+            tooltip: 'Specify terms to check for in file name using comma seperated list e.g. _720p,_1080p',
+        },
+        {
+            label: 'Patterns',
+            name: 'patterns',
+            type: 'string',
+            // eslint-disable-next-line no-template-curly-in-string
+            defaultValue: '',
+            inputUI: {
+                type: 'text',
+            },
+            // eslint-disable-next-line no-template-curly-in-string
+            tooltip: 'Specify patterns (regex) to check for in file name using comma seperated list e.g. ^Pattern*\.mkv$',
+        },
+        {
+            label: 'Include file directory in check',
+            name: 'includeFileDirectory',
+            type: 'boolean',
+            // eslint-disable-next-line no-template-curly-in-string
+            defaultValue: 'false',
+            inputUI: {
+                type: 'switch',
+            },
+            // eslint-disable-next-line no-template-curly-in-string
+            tooltip: 'Should the terms and patterns be evaluated against the file directory e.g. false, true',
+        }
+    ],
+    outputs: [
+        {
+            number: 1,
+            tooltip: 'File name contains terms or patterns',
+        },
+        {
+            number: 2,
+            tooltip: 'File name does not contain any of the terms or patterns',
+        },
+    ],
+}); };
+exports.details = details;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+var plugin = function (args) {
+    var lib = require('../../../../../methods/lib')();
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars,no-param-reassign
+    args.inputs = lib.loadDefaultValues(args.inputs, details);
+    var buildArrayInput = function (arrayInput) { var _a, _b; return (_b = (_a = String(arrayInput)) === null || _a === void 0 ? void 0 : _a.trim().split(',')) !== null && _b !== void 0 ? _b : new Array(); };
+    var fileName = "".concat(Boolean(args.inputs.includeFileDirectory) ? (0, fileUtils_1.getFileAbosluteDir)(args.inputFileObj._id) + '/' : '').concat((0, fileUtils_1.getFileName)(args.inputFileObj._id), ".").concat((0, fileUtils_1.getContainer)(args.inputFileObj._id));
+    var searchCriteriasArray = buildArrayInput(args.inputs.terms)
+        .concat(buildArrayInput(args.inputs.patterns));
+    var isAMatch = false;
+    for (var i = 0; i < searchCriteriasArray.length; i++)
+        if (new RegExp(searchCriteriasArray[i]).test(fileName)) {
+            isAMatch = true;
+            args.jobLog("".concat(fileName, " includes ").concat(searchCriteriasArray[i]));
+            break;
+        }
+    return {
+        outputFileObj: args.inputFileObj,
+        outputNumber: isAMatch ? 1 : 2,
+        variables: args.variables,
+    };
+};
+exports.plugin = plugin;

--- a/FlowPlugins/CommunityFlowPlugins/file/checkFileNameIncludes/2.0.0/index.js
+++ b/FlowPlugins/CommunityFlowPlugins/file/checkFileNameIncludes/2.0.0/index.js
@@ -29,8 +29,8 @@ var details = function () { return ({
             tooltip: 'Specify terms to check for in file name using comma seperated list e.g. _720p,_1080p',
         },
         {
-            label: 'Patterns',
-            name: 'patterns',
+            label: 'Pattern (regular expression)',
+            name: 'pattern',
             type: 'string',
             // eslint-disable-next-line no-template-curly-in-string
             defaultValue: '',
@@ -38,7 +38,7 @@ var details = function () { return ({
                 type: 'text',
             },
             // eslint-disable-next-line no-template-curly-in-string
-            tooltip: 'Specify patterns (regex) to check for in file name using comma seperated list e.g. ^Pattern*\.mkv$',
+            tooltip: 'Specify the pattern (regex) to check for in file name e.g. ^Pattern*\.mkv$',
         },
         {
             label: 'Include file directory in check',
@@ -71,15 +71,16 @@ var plugin = function (args) {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars,no-param-reassign
     args.inputs = lib.loadDefaultValues(args.inputs, details);
     var buildArrayInput = function (arrayInput) { var _a, _b; return (_b = (_a = String(arrayInput)) === null || _a === void 0 ? void 0 : _a.trim().split(',')) !== null && _b !== void 0 ? _b : new Array(); };
+    var isAMatch = false;
     var fileName = "".concat(Boolean(args.inputs.includeFileDirectory) ? (0, fileUtils_1.getFileAbosluteDir)(args.inputFileObj._id) + '/' : '').concat((0, fileUtils_1.getFileName)(args.inputFileObj._id), ".").concat((0, fileUtils_1.getContainer)(args.inputFileObj._id));
     var searchCriteriasArray = buildArrayInput(args.inputs.terms)
-        .map(function (term) { return term.replace(/[\-\/\\^$*+?.()|[\]{}]/g, '\\$&'); }) // https://github.com/tc39/proposal-regex-escaping
-        .concat(buildArrayInput(args.inputs.patterns));
-    var isAMatch = false;
+        .map(function (term) { return term.replace(/[\-\/\\^$*+?.()|[\]{}]/g, '\\$&'); }); // https://github.com/tc39/proposal-regex-escaping
+    if (args.inputs.pattern)
+        searchCriteriasArray.push(String(args.inputs.pattern));
     for (var i = 0; i < searchCriteriasArray.length; i++)
         if (new RegExp(searchCriteriasArray[i]).test(fileName)) {
             isAMatch = true;
-            args.jobLog("".concat(fileName, " includes ").concat(searchCriteriasArray[i]));
+            args.jobLog("'".concat(fileName, "' includes '").concat(searchCriteriasArray[i], "'"));
             break;
         }
     return {

--- a/FlowPlugins/CommunityFlowPlugins/file/checkFileNameIncludes/2.0.0/index.js
+++ b/FlowPlugins/CommunityFlowPlugins/file/checkFileNameIncludes/2.0.0/index.js
@@ -73,6 +73,7 @@ var plugin = function (args) {
     var buildArrayInput = function (arrayInput) { var _a, _b; return (_b = (_a = String(arrayInput)) === null || _a === void 0 ? void 0 : _a.trim().split(',')) !== null && _b !== void 0 ? _b : new Array(); };
     var fileName = "".concat(Boolean(args.inputs.includeFileDirectory) ? (0, fileUtils_1.getFileAbosluteDir)(args.inputFileObj._id) + '/' : '').concat((0, fileUtils_1.getFileName)(args.inputFileObj._id), ".").concat((0, fileUtils_1.getContainer)(args.inputFileObj._id));
     var searchCriteriasArray = buildArrayInput(args.inputs.terms)
+        .map(function (term) { return term.replace(/[\-\/\\^$*+?.()|[\]{}]/g, '\\$&'); }) // https://github.com/tc39/proposal-regex-escaping
         .concat(buildArrayInput(args.inputs.patterns));
     var isAMatch = false;
     for (var i = 0; i < searchCriteriasArray.length; i++)

--- a/FlowPlugins/CommunityFlowPlugins/file/checkFileNameIncludes/2.0.0/index.js
+++ b/FlowPlugins/CommunityFlowPlugins/file/checkFileNameIncludes/2.0.0/index.js
@@ -71,20 +71,17 @@ var plugin = function (args) {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars,no-param-reassign
     args.inputs = lib.loadDefaultValues(args.inputs, details);
     var buildArrayInput = function (arrayInput) { var _a, _b; return (_b = (_a = String(arrayInput)) === null || _a === void 0 ? void 0 : _a.trim().split(',')) !== null && _b !== void 0 ? _b : []; };
-    var isAMatch = false;
     var fileName = "".concat((args.inputs.includeFileDirectory ? "".concat((0, fileUtils_1.getFileAbosluteDir)(args.inputFileObj._id), "/") : '')
         + (0, fileUtils_1.getFileName)(args.inputFileObj._id), ".").concat((0, fileUtils_1.getContainer)(args.inputFileObj._id));
     var searchCriteriasArray = buildArrayInput(args.inputs.terms)
         .map(function (term) { return term.replace(/[\\^$*+?.()|[\]{}]/g, '\\$&'); }); // https://github.com/tc39/proposal-regex-escaping
     if (args.inputs.pattern)
         searchCriteriasArray.push(String(args.inputs.pattern));
-    for (var i = 0; i < searchCriteriasArray.length; i++) {
-        if (new RegExp(searchCriteriasArray[i]).test(fileName)) {
-            isAMatch = true;
-            args.jobLog("'".concat(fileName, "' includes '").concat(searchCriteriasArray[i], "'"));
-            break;
-        }
-    }
+    var searchCriteriaMatched = searchCriteriasArray
+        .find(function (searchCriteria) { return new RegExp(searchCriteria).test(fileName); });
+    var isAMatch = searchCriteriaMatched !== undefined;
+    if (isAMatch)
+        args.jobLog("'".concat(fileName, "' includes '").concat(searchCriteriaMatched, "'"));
     return {
         outputFileObj: args.inputFileObj,
         outputNumber: isAMatch ? 1 : 2,

--- a/FlowPlugins/CommunityFlowPlugins/file/checkFileNameIncludes/2.0.0/index.js
+++ b/FlowPlugins/CommunityFlowPlugins/file/checkFileNameIncludes/2.0.0/index.js
@@ -38,7 +38,7 @@ var details = function () { return ({
                 type: 'text',
             },
             // eslint-disable-next-line no-template-curly-in-string
-            tooltip: 'Specify the pattern (regex) to check for in file name e.g. ^Pattern*\.mkv$',
+            tooltip: 'Specify the pattern (regex) to check for in file name e.g. ^Pattern.*mkv$',
         },
         {
             label: 'Include file directory in check',
@@ -51,7 +51,7 @@ var details = function () { return ({
             },
             // eslint-disable-next-line no-template-curly-in-string
             tooltip: 'Should the terms and patterns be evaluated against the file directory e.g. false, true',
-        }
+        },
     ],
     outputs: [
         {
@@ -70,19 +70,21 @@ var plugin = function (args) {
     var lib = require('../../../../../methods/lib')();
     // eslint-disable-next-line @typescript-eslint/no-unused-vars,no-param-reassign
     args.inputs = lib.loadDefaultValues(args.inputs, details);
-    var buildArrayInput = function (arrayInput) { var _a, _b; return (_b = (_a = String(arrayInput)) === null || _a === void 0 ? void 0 : _a.trim().split(',')) !== null && _b !== void 0 ? _b : new Array(); };
+    var buildArrayInput = function (arrayInput) { var _a, _b; return (_b = (_a = String(arrayInput)) === null || _a === void 0 ? void 0 : _a.trim().split(',')) !== null && _b !== void 0 ? _b : []; };
     var isAMatch = false;
-    var fileName = "".concat(Boolean(args.inputs.includeFileDirectory) ? (0, fileUtils_1.getFileAbosluteDir)(args.inputFileObj._id) + '/' : '').concat((0, fileUtils_1.getFileName)(args.inputFileObj._id), ".").concat((0, fileUtils_1.getContainer)(args.inputFileObj._id));
+    var fileName = "".concat((args.inputs.includeFileDirectory ? "".concat((0, fileUtils_1.getFileAbosluteDir)(args.inputFileObj._id), "/") : '')
+        + (0, fileUtils_1.getFileName)(args.inputFileObj._id), ".").concat((0, fileUtils_1.getContainer)(args.inputFileObj._id));
     var searchCriteriasArray = buildArrayInput(args.inputs.terms)
-        .map(function (term) { return term.replace(/[\-\/\\^$*+?.()|[\]{}]/g, '\\$&'); }); // https://github.com/tc39/proposal-regex-escaping
+        .map(function (term) { return term.replace(/[\\^$*+?.()|[\]{}]/g, '\\$&'); }); // https://github.com/tc39/proposal-regex-escaping
     if (args.inputs.pattern)
         searchCriteriasArray.push(String(args.inputs.pattern));
-    for (var i = 0; i < searchCriteriasArray.length; i++)
+    for (var i = 0; i < searchCriteriasArray.length; i++) {
         if (new RegExp(searchCriteriasArray[i]).test(fileName)) {
             isAMatch = true;
             args.jobLog("'".concat(fileName, "' includes '").concat(searchCriteriasArray[i], "'"));
             break;
         }
+    }
     return {
         outputFileObj: args.inputFileObj,
         outputNumber: isAMatch ? 1 : 2,

--- a/FlowPlugins/CommunityFlowPlugins/file/checkFileNameIncludes/2.0.0/index.js
+++ b/FlowPlugins/CommunityFlowPlugins/file/checkFileNameIncludes/2.0.0/index.js
@@ -20,36 +20,30 @@ var details = function () { return ({
             label: 'Terms',
             name: 'terms',
             type: 'string',
-            // eslint-disable-next-line no-template-curly-in-string
             defaultValue: '_720p,_1080p',
             inputUI: {
                 type: 'text',
             },
-            // eslint-disable-next-line no-template-curly-in-string
             tooltip: 'Specify terms to check for in file name using comma seperated list e.g. _720p,_1080p',
         },
         {
             label: 'Pattern (regular expression)',
             name: 'pattern',
             type: 'string',
-            // eslint-disable-next-line no-template-curly-in-string
             defaultValue: '',
             inputUI: {
                 type: 'text',
             },
-            // eslint-disable-next-line no-template-curly-in-string
             tooltip: 'Specify the pattern (regex) to check for in file name e.g. ^Pattern.*mkv$',
         },
         {
             label: 'Include file directory in check',
             name: 'includeFileDirectory',
             type: 'boolean',
-            // eslint-disable-next-line no-template-curly-in-string
             defaultValue: 'false',
             inputUI: {
                 type: 'switch',
             },
-            // eslint-disable-next-line no-template-curly-in-string
             tooltip: 'Should the terms and patterns be evaluated against the file directory e.g. false, true',
         },
     ],
@@ -70,18 +64,26 @@ var plugin = function (args) {
     var lib = require('../../../../../methods/lib')();
     // eslint-disable-next-line @typescript-eslint/no-unused-vars,no-param-reassign
     args.inputs = lib.loadDefaultValues(args.inputs, details);
-    var buildArrayInput = function (arrayInput) { var _a, _b; return (_b = (_a = String(arrayInput)) === null || _a === void 0 ? void 0 : _a.trim().split(',')) !== null && _b !== void 0 ? _b : []; };
-    var fileName = "".concat((args.inputs.includeFileDirectory ? "".concat((0, fileUtils_1.getFileAbosluteDir)(args.inputFileObj._id), "/") : '')
-        + (0, fileUtils_1.getFileName)(args.inputFileObj._id), ".").concat((0, fileUtils_1.getContainer)(args.inputFileObj._id));
-    var searchCriteriasArray = buildArrayInput(args.inputs.terms)
+    var terms = String(args.inputs.terms);
+    var pattern = String(args.inputs.pattern);
+    var includeFileDirectory = args.inputs.includeFileDirectory;
+    var fileName = includeFileDirectory
+        ? args.inputFileObj._id
+        : "".concat((0, fileUtils_1.getFileName)(args.inputFileObj._id), ".").concat((0, fileUtils_1.getContainer)(args.inputFileObj._id));
+    var searchCriteriasArray = terms.trim().split(',')
         .map(function (term) { return term.replace(/[\\^$*+?.()|[\]{}]/g, '\\$&'); }); // https://github.com/tc39/proposal-regex-escaping
-    if (args.inputs.pattern)
-        searchCriteriasArray.push(String(args.inputs.pattern));
+    if (pattern) {
+        searchCriteriasArray.push(pattern);
+    }
     var searchCriteriaMatched = searchCriteriasArray
         .find(function (searchCriteria) { return new RegExp(searchCriteria).test(fileName); });
     var isAMatch = searchCriteriaMatched !== undefined;
-    if (isAMatch)
+    if (isAMatch) {
         args.jobLog("'".concat(fileName, "' includes '").concat(searchCriteriaMatched, "'"));
+    }
+    else {
+        args.jobLog("'".concat(fileName, "' does not include any of the terms or patterns"));
+    }
     return {
         outputFileObj: args.inputFileObj,
         outputNumber: isAMatch ? 1 : 2,

--- a/FlowPluginsTs/CommunityFlowPlugins/file/checkFileNameIncludes/1.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/file/checkFileNameIncludes/1.0.0/index.ts
@@ -23,12 +23,10 @@ const details = (): IpluginDetails => ({
       label: 'Terms',
       name: 'terms',
       type: 'string',
-      // eslint-disable-next-line no-template-curly-in-string
       defaultValue: '_720p,_1080p',
       inputUI: {
         type: 'text',
       },
-      // eslint-disable-next-line no-template-curly-in-string
       tooltip: 'Specify terms to check for in file name using comma seperated list e.g. _720p,_1080p',
     },
   ],

--- a/FlowPluginsTs/CommunityFlowPlugins/file/checkFileNameIncludes/2.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/file/checkFileNameIncludes/2.0.0/index.ts
@@ -1,0 +1,101 @@
+import { getContainer, getFileAbosluteDir, getFileName } from '../../../../FlowHelpers/1.0.0/fileUtils';
+import {
+  IpluginDetails,
+  IpluginInputArgs,
+  IpluginOutputArgs,
+} from '../../../../FlowHelpers/1.0.0/interfaces/interfaces';
+
+/* eslint no-plusplus: ["error", { "allowForLoopAfterthoughts": true }] */
+const details = (): IpluginDetails => ({
+  name: 'Check File Name Includes',
+  description: 'Check if a file name includes specific terms. Only needs to match one term',
+  style: {
+    borderColor: 'orange',
+  },
+  tags: 'video',
+  isStartPlugin: false,
+  pType: '',
+  requiresVersion: '2.11.01',
+  sidebarPosition: -1,
+  icon: 'faQuestion',
+  inputs: [
+    {
+      label: 'Terms',
+      name: 'terms',
+      type: 'string',
+      // eslint-disable-next-line no-template-curly-in-string
+      defaultValue: '_720p,_1080p',
+      inputUI: {
+        type: 'text',
+      },
+      // eslint-disable-next-line no-template-curly-in-string
+      tooltip: 'Specify terms to check for in file name using comma seperated list e.g. _720p,_1080p',
+    },
+    {
+      label: 'Patterns',
+      name: 'patterns',
+      type: 'string',
+      // eslint-disable-next-line no-template-curly-in-string
+      defaultValue: '',
+      inputUI: {
+        type: 'text',
+      },
+      // eslint-disable-next-line no-template-curly-in-string
+      tooltip: 'Specify patterns (regex) to check for in file name using comma seperated list e.g. ^Pattern*\.mkv$',
+    },
+    {
+      label: 'Include file directory in check',
+      name: 'includeFileDirectory',
+      type: 'boolean',
+      // eslint-disable-next-line no-template-curly-in-string
+      defaultValue: 'false',
+      inputUI: {
+        type: 'switch',
+      },
+      // eslint-disable-next-line no-template-curly-in-string
+      tooltip: 'Should the terms and patterns be evaluated against the file directory e.g. false, true',
+    }
+  ],
+  outputs: [
+    {
+      number: 1,
+      tooltip: 'File name contains terms or patterns',
+    },
+    {
+      number: 2,
+      tooltip: 'File name does not contain any of the terms or patterns',
+    },
+  ],
+});
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const plugin = (args: IpluginInputArgs): IpluginOutputArgs => {
+  const lib = require('../../../../../methods/lib')();
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars,no-param-reassign
+  args.inputs = lib.loadDefaultValues(args.inputs, details);
+
+  const buildArrayInput = (arrayInput: any): string[] =>
+    String(arrayInput)?.trim().split(',') ?? new Array();
+
+  const fileName = `${Boolean(args.inputs.includeFileDirectory) ? getFileAbosluteDir(args.inputFileObj._id) + '/' : ''}${getFileName(args.inputFileObj._id)}.${getContainer(args.inputFileObj._id)}`;
+  const searchCriteriasArray = buildArrayInput(args.inputs.terms)
+    .concat(buildArrayInput(args.inputs.patterns));
+  let isAMatch = false;
+
+  for (let i = 0; i < searchCriteriasArray.length; i++)
+    if (new RegExp(searchCriteriasArray[i]).test(fileName)) {
+      isAMatch = true;
+      args.jobLog(`${fileName} includes ${searchCriteriasArray[i]}`);
+      break;
+    }
+
+  return {
+    outputFileObj: args.inputFileObj,
+    outputNumber: isAMatch ? 1 : 2,
+    variables: args.variables,
+  };
+};
+export {
+  details,
+  plugin,
+};

--- a/FlowPluginsTs/CommunityFlowPlugins/file/checkFileNameIncludes/2.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/file/checkFileNameIncludes/2.0.0/index.ts
@@ -32,8 +32,8 @@ const details = (): IpluginDetails => ({
       tooltip: 'Specify terms to check for in file name using comma seperated list e.g. _720p,_1080p',
     },
     {
-      label: 'Patterns',
-      name: 'patterns',
+      label: 'Pattern (regular expression)',
+      name: 'pattern',
       type: 'string',
       // eslint-disable-next-line no-template-curly-in-string
       defaultValue: '',
@@ -41,7 +41,7 @@ const details = (): IpluginDetails => ({
         type: 'text',
       },
       // eslint-disable-next-line no-template-curly-in-string
-      tooltip: 'Specify patterns (regex) to check for in file name using comma seperated list e.g. ^Pattern*\.mkv$',
+      tooltip: 'Specify the pattern (regex) to check for in file name e.g. ^Pattern*\.mkv$',
     },
     {
       label: 'Include file directory in check',
@@ -77,16 +77,17 @@ const plugin = (args: IpluginInputArgs): IpluginOutputArgs => {
   const buildArrayInput = (arrayInput: any): string[] =>
     String(arrayInput)?.trim().split(',') ?? new Array();
 
+  let isAMatch = false;
   const fileName = `${Boolean(args.inputs.includeFileDirectory) ? getFileAbosluteDir(args.inputFileObj._id) + '/' : ''}${getFileName(args.inputFileObj._id)}.${getContainer(args.inputFileObj._id)}`;
   const searchCriteriasArray = buildArrayInput(args.inputs.terms)
-    .map(term => term.replace(/[\-\/\\^$*+?.()|[\]{}]/g, '\\$&')) // https://github.com/tc39/proposal-regex-escaping
-    .concat(buildArrayInput(args.inputs.patterns));
-  let isAMatch = false;
+    .map(term => term.replace(/[\-\/\\^$*+?.()|[\]{}]/g, '\\$&')); // https://github.com/tc39/proposal-regex-escaping
+  if (args.inputs.pattern)
+    searchCriteriasArray.push(String(args.inputs.pattern));
 
   for (let i = 0; i < searchCriteriasArray.length; i++)
     if (new RegExp(searchCriteriasArray[i]).test(fileName)) {
       isAMatch = true;
-      args.jobLog(`${fileName} includes ${searchCriteriasArray[i]}`);
+      args.jobLog(`'${fileName}' includes '${searchCriteriasArray[i]}'`);
       break;
     }
 

--- a/FlowPluginsTs/CommunityFlowPlugins/file/checkFileNameIncludes/2.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/file/checkFileNameIncludes/2.0.0/index.ts
@@ -23,36 +23,30 @@ const details = (): IpluginDetails => ({
       label: 'Terms',
       name: 'terms',
       type: 'string',
-      // eslint-disable-next-line no-template-curly-in-string
       defaultValue: '_720p,_1080p',
       inputUI: {
         type: 'text',
       },
-      // eslint-disable-next-line no-template-curly-in-string
       tooltip: 'Specify terms to check for in file name using comma seperated list e.g. _720p,_1080p',
     },
     {
       label: 'Pattern (regular expression)',
       name: 'pattern',
       type: 'string',
-      // eslint-disable-next-line no-template-curly-in-string
       defaultValue: '',
       inputUI: {
         type: 'text',
       },
-      // eslint-disable-next-line no-template-curly-in-string
       tooltip: 'Specify the pattern (regex) to check for in file name e.g. ^Pattern.*mkv$',
     },
     {
       label: 'Include file directory in check',
       name: 'includeFileDirectory',
       type: 'boolean',
-      // eslint-disable-next-line no-template-curly-in-string
       defaultValue: 'false',
       inputUI: {
         type: 'switch',
       },
-      // eslint-disable-next-line no-template-curly-in-string
       tooltip: 'Should the terms and patterns be evaluated against the file directory e.g. false, true',
     },
   ],

--- a/FlowPluginsTs/CommunityFlowPlugins/file/checkFileNameIncludes/2.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/file/checkFileNameIncludes/2.0.0/index.ts
@@ -79,6 +79,7 @@ const plugin = (args: IpluginInputArgs): IpluginOutputArgs => {
 
   const fileName = `${Boolean(args.inputs.includeFileDirectory) ? getFileAbosluteDir(args.inputFileObj._id) + '/' : ''}${getFileName(args.inputFileObj._id)}.${getContainer(args.inputFileObj._id)}`;
   const searchCriteriasArray = buildArrayInput(args.inputs.terms)
+    .map(term => term.replace(/[\-\/\\^$*+?.()|[\]{}]/g, '\\$&')) // https://github.com/tc39/proposal-regex-escaping
     .concat(buildArrayInput(args.inputs.patterns));
   let isAMatch = false;
 

--- a/FlowPluginsTs/CommunityFlowPlugins/file/checkFileNameIncludes/2.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/file/checkFileNameIncludes/2.0.0/index.ts
@@ -76,7 +76,6 @@ const plugin = (args: IpluginInputArgs): IpluginOutputArgs => {
 
   const buildArrayInput = (arrayInput: unknown): string[] => String(arrayInput)?.trim().split(',') ?? [];
 
-  let isAMatch = false;
   const fileName = `${(args.inputs.includeFileDirectory ? `${getFileAbosluteDir(args.inputFileObj._id)}/` : '')
     + getFileName(args.inputFileObj._id)
   }.${getContainer(args.inputFileObj._id)}`;
@@ -84,13 +83,10 @@ const plugin = (args: IpluginInputArgs): IpluginOutputArgs => {
     .map((term) => term.replace(/[\\^$*+?.()|[\]{}]/g, '\\$&')); // https://github.com/tc39/proposal-regex-escaping
   if (args.inputs.pattern) searchCriteriasArray.push(String(args.inputs.pattern));
 
-  for (let i = 0; i < searchCriteriasArray.length; i++) {
-    if (new RegExp(searchCriteriasArray[i]).test(fileName)) {
-      isAMatch = true;
-      args.jobLog(`'${fileName}' includes '${searchCriteriasArray[i]}'`);
-      break;
-    }
-  }
+  const searchCriteriaMatched = searchCriteriasArray
+    .find((searchCriteria) => new RegExp(searchCriteria).test(fileName));
+  const isAMatch = searchCriteriaMatched !== undefined;
+  if (isAMatch) args.jobLog(`'${fileName}' includes '${searchCriteriaMatched}'`);
 
   return {
     outputFileObj: args.inputFileObj,


### PR DESCRIPTION
Hello there,

Resolves #606. This is my proposal for : 

1. Using regex patterns in the "Check file name includes" flow plugin
2. Having the possibility to check in the file directory too

![image](https://github.com/HaveAGitGat/Tdarr_Plugins/assets/11569431/46680c81-ab3c-4af8-ba42-58a71f687e76)

![image](https://github.com/HaveAGitGat/Tdarr_Plugins/assets/11569431/d762c186-47e8-4b67-a020-38bd981b6aa8)
![image](https://github.com/HaveAGitGat/Tdarr_Plugins/assets/11569431/cb3c3f53-03f5-4980-ad57-f1bda2a6fcd0)
![image](https://github.com/HaveAGitGat/Tdarr_Plugins/assets/11569431/ffc77f28-84dc-48a7-89bc-d24851debbee)
