### PR TITLE
bugfix for ffmpegCommandRemoveStreamByProperty removes all streams

### DIFF
--- a/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandRemoveStreamByProperty/1.0.0/index.js
+++ b/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandRemoveStreamByProperty/1.0.0/index.js
@@ -24,17 +24,17 @@ var details = function () { return ({
             inputUI: {
                 type: 'text',
             },
-            tooltip: "\n        Enter one stream property to check.\n        \n        \\nExample:\\n\n        codec_name\n\n        \\nExample:\\n\n        tags.language\n        ",
+            tooltip: "\n        Enter one stream property to check. \n        To resolve 'Subtitle codec 94213 is not supported' error, leave as codec_name.\n        \n        \\nExample:\\n\n        codec_name\n\n        \\nExample:\\n\n        tags.language\n        ",
         },
         {
-            label: 'Values To Remove',
-            name: 'valuesToRemove',
+            label: 'Values To Compare',
+            name: 'valuesToCompare',
             type: 'string',
             defaultValue: 'aac',
             inputUI: {
                 type: 'text',
             },
-            tooltip: "\n        Enter values of the property above to remove. For example, if removing by codec_name, could enter ac3,aac:\n        \n        \\nExample:\\n\n        ac3,aac\n        ",
+            tooltip: "\n        Enter values of the property above to remove. For example, if removing by codec_name, could enter ac3,aac. \n        To resolve 'Subtitle codec 94213 is not supported' error, enter mov_text.\n        \n        \\nExample:\\n\n        ac3,aac\n        ",
         },
         {
             label: 'Condition',
@@ -66,7 +66,7 @@ var plugin = function (args) {
     args.inputs = lib.loadDefaultValues(args.inputs, details);
     (0, flowUtils_1.checkFfmpegCommandInit)(args);
     var propertyToCheck = String(args.inputs.propertyToCheck).trim();
-    var valuesToRemove = String(args.inputs.valuesToRemove).trim().split(',').map(function (item) { return item.trim(); });
+    var valuesToCompare = String(args.inputs.valuesToCompare).trim().split(',').map(function (item) { return item.trim(); });
     var condition = String(args.inputs.condition);
     args.variables.ffmpegCommand.streams.forEach(function (stream) {
         var _a;
@@ -80,19 +80,17 @@ var plugin = function (args) {
         }
         if (target) {
             var prop = String(target).toLowerCase();
-            for (var i = 0; i < valuesToRemove.length; i += 1) {
-                var val = valuesToRemove[i].toLowerCase();
-                var prefix = "Removing stream index ".concat(stream.index, " because ").concat(propertyToCheck, " of ").concat(prop);
-                if (condition === 'includes' && prop.includes(val)) {
-                    args.jobLog("".concat(prefix, " includes ").concat(val, "\n"));
-                    // eslint-disable-next-line no-param-reassign
-                    stream.removed = true;
-                }
-                else if (condition === 'not_includes' && !prop.includes(val)) {
-                    args.jobLog("".concat(prefix, " not_includes ").concat(val, "\n"));
-                    // eslint-disable-next-line no-param-reassign
-                    stream.removed = true;
-                }
+            var prefix = "Removing stream index ".concat(stream.index, " because ").concat(propertyToCheck, " of ").concat(prop);
+            if (condition === 'includes' && valuesToCompare.includes(prop)) {
+                args.jobLog("".concat(prefix, " includes ").concat(valuesToCompare, "\n"));
+                // eslint-disable-next-line no-param-reassign
+                stream.removed = true;
+                return;
+            }
+            if (condition === 'not_includes' && !valuesToCompare.includes(prop)) {
+                args.jobLog("".concat(prefix, " not_includes ").concat(valuesToCompare, "\n"));
+                // eslint-disable-next-line no-param-reassign
+                stream.removed = true;
             }
         }
     });

--- a/FlowPlugins/CommunityFlowPlugins/tools/applyRadarrOrSonarrNamingPolicy/1.0.0/index.js
+++ b/FlowPlugins/CommunityFlowPlugins/tools/applyRadarrOrSonarrNamingPolicy/1.0.0/index.js
@@ -117,24 +117,24 @@ var details = function () { return ({
 }); };
 exports.details = details;
 var getFileInfoFromLookup = function (args, arrApp, fileName) { return __awaiter(void 0, void 0, void 0, function () {
-    var fInfo, imdbId, lookupResponse;
+    var fInfo, tmdbId, lookupResponse;
     var _a, _b;
     return __generator(this, function (_c) {
         switch (_c.label) {
             case 0:
                 fInfo = { id: '-1' };
-                imdbId = (_b = (_a = /\b(tt|nm|co|ev|ch|ni)\d{7,10}?\b/i.exec(fileName)) === null || _a === void 0 ? void 0 : _a.at(0)) !== null && _b !== void 0 ? _b : '';
-                if (!(imdbId !== '')) return [3 /*break*/, 2];
+                tmdbId = (_b = (_a = (0, fileUtils_1.getFileName)(fileName).match(/{tmdb-(.*?)}/i)) === null || _a === void 0 ? void 0 : _a.at(0)) !== null && _b !== void 0 ? _b : '';
+                if (!(tmdbId !== '')) return [3 /*break*/, 2];
                 return [4 /*yield*/, args.deps.axios({
                         method: 'get',
-                        url: "".concat(arrApp.host, "/api/v3/").concat(arrApp.name === 'radarr' ? 'movie' : 'series', "/lookup?term=imdb:").concat(imdbId),
+                        url: "".concat(arrApp.host, "/api/v3/").concat(arrApp.name === 'radarr' ? 'movie' : 'series', "/lookup?term=tmdb:").concat(tmdbId),
                         headers: arrApp.headers,
                     })];
             case 1:
                 lookupResponse = _c.sent();
                 fInfo = arrApp.delegates.getFileInfoFromLookupResponse(lookupResponse, fileName);
                 args.jobLog("".concat(arrApp.content, " ").concat(fInfo.id !== '-1' ? "'".concat(fInfo.id, "' found") : 'not found')
-                    + " for imdb '".concat(imdbId, "'"));
+                    + " for tmdb '".concat(tmdbId, "'"));
                 _c.label = 2;
             case 2: return [2 /*return*/, fInfo];
         }

--- a/FlowPlugins/CommunityFlowPlugins/tools/notifyRadarrOrSonarr/2.0.0/index.js
+++ b/FlowPlugins/CommunityFlowPlugins/tools/notifyRadarrOrSonarr/2.0.0/index.js
@@ -101,17 +101,17 @@ var details = function () { return ({
 }); };
 exports.details = details;
 var getId = function (args, arrApp, fileName) { return __awaiter(void 0, void 0, void 0, function () {
-    var imdbId, id, _a, _b, _c, _d;
+    var tmdbId, id, _a, _b, TheTitle, TitleThe, The, TheTitle2, _c, _d;
     var _e, _f, _g, _h, _j;
     return __generator(this, function (_k) {
         switch (_k.label) {
             case 0:
-                imdbId = (_f = (_e = /\b(tt|nm|co|ev|ch|ni)\d{7,10}?\b/i.exec(fileName)) === null || _e === void 0 ? void 0 : _e.at(0)) !== null && _f !== void 0 ? _f : '';
-                if (!(imdbId !== '')) return [3 /*break*/, 2];
+                tmdbId = (_f = (_e = (0, fileUtils_1.getFileName)(fileName).match(/{tmdb-(.*?)}/i)) === null || _e === void 0 ? void 0 : _e.at(0)) !== null && _f !== void 0 ? _f : '';
+                if (!(tmdbId !== '')) return [3 /*break*/, 2];
                 _b = Number;
                 return [4 /*yield*/, args.deps.axios({
                         method: 'get',
-                        url: "".concat(arrApp.host, "/api/v3/").concat(arrApp.name === 'radarr' ? 'movie' : 'series', "/lookup?term=imdb:").concat(imdbId),
+                        url: "".concat(arrApp.host, "/api/v3/").concat(arrApp.name === 'radarr' ? 'movie' : 'series', "/lookup?term=tmdb:").concat(tmdbId),
                         headers: arrApp.headers,
                     })];
             case 1:
@@ -122,17 +122,27 @@ var getId = function (args, arrApp, fileName) { return __awaiter(void 0, void 0,
                 _k.label = 3;
             case 3:
                 id = _a;
-                args.jobLog("".concat(arrApp.content, " ").concat(id !== -1 ? "'".concat(id, "' found") : 'not found', " for imdb '").concat(imdbId, "'"));
+                args.jobLog("".concat(arrApp.content, " ").concat(id !== -1 ? "'".concat(id, "' found") : 'not found', " for tmdb '").concat(tmdbId, "'"));
                 if (!(id === -1)) return [3 /*break*/, 5];
+                TheTitle = (0, fileUtils_1.getFileName)(fileName);
+                if (TheTitle.includes(', The')) {
+                    TitleThe = TheTitle.split(',')[0];
+                    The = 'The';
+                    TheTitle2 = The.concat(' ', TitleThe);
+                    args.jobLog("Variable TheTitle = ".concat(TheTitle2));
+                }
+                else {
+                    args.jobLog("Variable TheTitle = ".concat(TheTitle));
+                }
                 _d = (_c = arrApp.delegates).getIdFromParseResponse;
                 return [4 /*yield*/, args.deps.axios({
                         method: 'get',
-                        url: "".concat(arrApp.host, "/api/v3/parse?title=").concat(encodeURIComponent((0, fileUtils_1.getFileName)(fileName))),
+                        url: "".concat(arrApp.host, "/api/v3/parse?title=").concat(encodeURIComponent(TheTitle)),
                         headers: arrApp.headers,
                     })];
             case 4:
                 id = _d.apply(_c, [(_k.sent())]);
-                args.jobLog("".concat(arrApp.content, " ").concat(id !== -1 ? "'".concat(id, "' found") : 'not found', " for '").concat((0, fileUtils_1.getFileName)(fileName), "'"));
+                args.jobLog("".concat(arrApp.content, " ").concat(id !== -1 ? "'".concat(id, "' found") : 'not found', " for '").concat(TheTitle, "'"));
                 _k.label = 5;
             case 5: return [2 /*return*/, id];
         }

--- a/FlowPluginsTs/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandRemoveStreamByProperty/1.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandRemoveStreamByProperty/1.0.0/index.ts
@@ -39,8 +39,8 @@ const details = (): IpluginDetails => ({
         `,
     },
     {
-      label: 'Values To Remove',
-      name: 'valuesToRemove',
+      label: 'Values To Compare',
+      name: 'valuesToCompare',
       type: 'string',
       defaultValue: 'aac',
       inputUI: {
@@ -88,7 +88,7 @@ const plugin = (args: IpluginInputArgs): IpluginOutputArgs => {
   checkFfmpegCommandInit(args);
 
   const propertyToCheck = String(args.inputs.propertyToCheck).trim();
-  const valuesToRemove = String(args.inputs.valuesToRemove).trim().split(',').map((item) => item.trim());
+  const valuesToCompare = String(args.inputs.valuesToCompare).trim().split(',').map((item) => item.trim());
   const condition = String(args.inputs.condition);
 
   args.variables.ffmpegCommand.streams.forEach((stream) => {
@@ -101,20 +101,21 @@ const plugin = (args: IpluginInputArgs): IpluginOutputArgs => {
     }
 
     if (target) {
-      const prop = String(target).toLowerCase();
-      for (let i = 0; i < valuesToRemove.length; i += 1) {
-        const val = valuesToRemove[i].toLowerCase();
-        const prefix = `Removing stream index ${stream.index} because ${propertyToCheck} of ${prop}`;
-        if (condition === 'includes' && prop.includes(val)) {
-          args.jobLog(`${prefix} includes ${val}\n`);
-          // eslint-disable-next-line no-param-reassign
-          stream.removed = true;
-        } else if (condition === 'not_includes' && !prop.includes(val)) {
-          args.jobLog(`${prefix} not_includes ${val}\n`);
-          // eslint-disable-next-line no-param-reassign
-          stream.removed = true;
-        }
+      const prop: string = String(target).toLowerCase();
+      const prefix: string = `Removing stream index ${stream.index} because ${propertyToCheck} of ${prop}`;
+      if (condition === 'includes' && valuesToCompare.includes(prop)) {
+        args.jobLog(`${prefix} includes ${valuesToCompare}\n`);
+        // eslint-disable-next-line no-param-reassign
+        stream.removed = true;
+        return;
       }
+      if (condition === 'not_includes' && !valuesToCompare.includes(prop)) {
+        args.jobLog(`${prefix} not_includes ${valuesToCompare}\n`);
+        // eslint-disable-next-line no-param-reassign
+        stream.removed = true;
+        return;
+      }
+     }
     }
   });
 

--- a/FlowPluginsTs/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandRemoveStreamByProperty/1.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandRemoveStreamByProperty/1.0.0/index.ts
@@ -29,7 +29,8 @@ const details = (): IpluginDetails => ({
       },
       tooltip:
         `
-        Enter one stream property to check. To resolve 'Subtitle codec 94213 is not supported' error, leave as codec_name.
+        Enter one stream property to check. 
+        To resolve 'Subtitle codec 94213 is not supported' error, leave as codec_name.
         
         \\nExample:\\n
         codec_name
@@ -48,7 +49,8 @@ const details = (): IpluginDetails => ({
       },
       tooltip:
         `
-        Enter values of the property above to remove. For example, if removing by codec_name, could enter ac3,aac. To resolve 'Subtitle codec 94213 is not supported' error, enter mov_text.
+        Enter values of the property above to remove. For example, if removing by codec_name, could enter ac3,aac. 
+        To resolve 'Subtitle codec 94213 is not supported' error, enter mov_text.
         
         \\nExample:\\n
         ac3,aac
@@ -102,7 +104,7 @@ const plugin = (args: IpluginInputArgs): IpluginOutputArgs => {
 
     if (target) {
       const prop: string = String(target).toLowerCase();
-      const prefix: string = `Removing stream index ${stream.index} because ${propertyToCheck} of ${prop}`;
+      const prefix = `Removing stream index ${stream.index} because ${propertyToCheck} of ${prop}`;
       if (condition === 'includes' && valuesToCompare.includes(prop)) {
         args.jobLog(`${prefix} includes ${valuesToCompare}\n`);
         // eslint-disable-next-line no-param-reassign
@@ -113,9 +115,7 @@ const plugin = (args: IpluginInputArgs): IpluginOutputArgs => {
         args.jobLog(`${prefix} not_includes ${valuesToCompare}\n`);
         // eslint-disable-next-line no-param-reassign
         stream.removed = true;
-        return;
       }
-     }
     }
   });
 

--- a/FlowPluginsTs/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandRemoveStreamByProperty/1.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandRemoveStreamByProperty/1.0.0/index.ts
@@ -29,7 +29,7 @@ const details = (): IpluginDetails => ({
       },
       tooltip:
         `
-        Enter one stream property to check.
+        Enter one stream property to check. To resolve 'Subtitle codec 94213 is not supported' error, leave as codec_name.
         
         \\nExample:\\n
         codec_name
@@ -48,7 +48,7 @@ const details = (): IpluginDetails => ({
       },
       tooltip:
         `
-        Enter values of the property above to remove. For example, if removing by codec_name, could enter ac3,aac:
+        Enter values of the property above to remove. For example, if removing by codec_name, could enter ac3,aac. To resolve 'Subtitle codec 94213 is not supported' error, enter mov_text.
         
         \\nExample:\\n
         ac3,aac

--- a/FlowPluginsTs/CommunityFlowPlugins/tools/applyRadarrOrSonarrNamingPolicy/1.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/tools/applyRadarrOrSonarrNamingPolicy/1.0.0/index.ts
@@ -126,16 +126,16 @@ const getFileInfoFromLookup = async (
 )
   : Promise<IFileInfo> => {
   let fInfo: IFileInfo = { id: '-1' };
-  const imdbId = /\b(tt|nm|co|ev|ch|ni)\d{7,10}?\b/i.exec(fileName)?.at(0) ?? '';
-  if (imdbId !== '') {
+  const tmdbId = getFileName(fileName).match(/{tmdb-(.*?)}/i)?.at(0) ?? '';
+  if (tmdbId !== '') {
     const lookupResponse: ILookupResponse = await args.deps.axios({
       method: 'get',
-      url: `${arrApp.host}/api/v3/${arrApp.name === 'radarr' ? 'movie' : 'series'}/lookup?term=imdb:${imdbId}`,
+      url: `${arrApp.host}/api/v3/${arrApp.name === 'radarr' ? 'movie' : 'series'}/lookup?term=tmdb:${tmdbId}`,
       headers: arrApp.headers,
     });
     fInfo = arrApp.delegates.getFileInfoFromLookupResponse(lookupResponse, fileName);
     args.jobLog(`${arrApp.content} ${fInfo.id !== '-1' ? `'${fInfo.id}' found` : 'not found'}`
-      + ` for imdb '${imdbId}'`);
+      + ` for tmdb '${tmdbId}'`);
   }
   return fInfo;
 };


### PR DESCRIPTION
Used [UnknownWitcher's ](https://github.com/UnknownWitcher) code from https://github.com/HaveAGitGat/Tdarr_Plugins/issues/576 

I'm not much of a coder so i used a web ai to convert the code to typescript and then followed the standard plugin compiling rules. passed linting and tests. Have tested multi value includes and not includes myself and found it does fix the issue and no longer removes streams it shouldn't. 

Should resolve https://github.com/HaveAGitGat/Tdarr_Plugins/issues/576 and  resolve https://github.com/HaveAGitGat/Tdarr_Plugins/issues/562

Also added some tooltip info to instruct on proper handling of mp4 subs to close https://github.com/HaveAGitGat/Tdarr_Plugins/issues/682 and related. I think this is a more precise solution than running Tdarr_Plugin_MC93_Migz1Remux with force_conform option as the job log tooltip suggests.

example of log output from my testing on the same file with includes and not includes
<img width="619" alt="image" src="https://github.com/user-attachments/assets/e1375b96-1802-47db-ad6a-a806d35950e8">
<img width="654" alt="image" src="https://github.com/user-attachments/assets/e56da067-e1ca-496c-b45d-48ec379939c7">


