### PR TITLE
New Flow Plugin - checkFileDuration

### DIFF
--- a/FlowPlugins/CommunityFlowPlugins/file/checkFileDuration/1.0.0/index.js
+++ b/FlowPlugins/CommunityFlowPlugins/file/checkFileDuration/1.0.0/index.js
@@ -1,0 +1,86 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.plugin = exports.details = void 0;
+/* eslint no-plusplus: ["error", { "allowForLoopAfterthoughts": true }] */
+var details = function () { return ({
+    name: 'Check File Duration',
+    description: 'Check duration of file in seconds. Do something differently if above threshold.',
+    style: {
+        borderColor: 'orange',
+    },
+    tags: '',
+    isStartPlugin: false,
+    pType: '',
+    requiresVersion: '2.11.01',
+    sidebarPosition: -1,
+    icon: 'faQuestion',
+    inputs: [
+        {
+            label: 'Threshold (in seconds)',
+            name: 'thresholdSecs',
+            type: 'number',
+            defaultValue: '3900',
+            inputUI: {
+                type: 'text',
+            },
+            tooltip: 'Specify Threshold.'
+                + ' Default value is 3,900 seconds (65 minutes).',
+        },
+    ],
+    outputs: [
+        {
+            number: 1,
+            tooltip: 'Working file duration is below threshold',
+        },
+        {
+            number: 2,
+            tooltip: 'Working file duration is above threshold',
+        },
+    ],
+}); };
+exports.details = details;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+var plugin = function (args) {
+    var lib = require('../../../../../methods/lib')();
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars,no-param-reassign
+    args.inputs = lib.loadDefaultValues(args.inputs, details);
+    var getData = function (obj) {
+        var _a, _b;
+        try {
+            if ((_b = (_a = obj === null || obj === void 0 ? void 0 : obj.ffProbeData) === null || _a === void 0 ? void 0 : _a.format) === null || _b === void 0 ? void 0 : _b.duration) {
+                var dur = Number(obj.ffProbeData.format.duration);
+                if (dur > 0) {
+                    return dur;
+                }
+            }
+        }
+        catch (err) {
+            // err
+        }
+        return 0;
+    };
+    var origFileDuration = getData(args.originalLibraryFile);
+    args.jobLog("origFileDuration: ".concat(origFileDuration));
+    var thresholdSecs = Number(args.inputs.thresholdSecs);
+    var durationText = "File has duration is ".concat(origFileDuration.toFixed(3), " seconds");
+    var seriesText = 'File duration within series limits. must be a series.';
+    var filmText = 'File duration longer than series limits. must be a film.';
+    var outputNumber = 1;
+    if (origFileDuration < thresholdSecs) {
+        args.jobLog("".concat(seriesText, " ").concat(durationText, ", threshold is ").concat(thresholdSecs, " seconds"));
+        outputNumber = 1;
+    }
+    else if (origFileDuration >= thresholdSecs) {
+        args.jobLog("".concat(filmText, " ").concat(durationText, ", threshold is ").concat(thresholdSecs, " seconds"));
+        outputNumber = 2;
+    }
+    else {
+        args.jobLog(durationText);
+    }
+    return {
+        outputFileObj: args.inputFileObj,
+        outputNumber: outputNumber,
+        variables: args.variables,
+    };
+};
+exports.plugin = plugin;

--- a/FlowPluginsTs/CommunityFlowPlugins/file/checkFileDuration/1.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/file/checkFileDuration/1.0.0/index.ts
@@ -1,97 +1,97 @@
 import {
-    IpluginDetails,
-    IpluginInputArgs,
-    IpluginOutputArgs,
-  } from '../../../../FlowHelpers/1.0.0/interfaces/interfaces';
-  import { IFileObject } from '../../../../FlowHelpers/1.0.0/interfaces/synced/IFileObject';
+  IpluginDetails,
+  IpluginInputArgs,
+  IpluginOutputArgs,
+} from '../../../../FlowHelpers/1.0.0/interfaces/interfaces';
+import { IFileObject } from '../../../../FlowHelpers/1.0.0/interfaces/synced/IFileObject';
 
 /* eslint no-plusplus: ["error", { "allowForLoopAfterthoughts": true }] */
 const details = (): IpluginDetails => ({
-    name: 'Check File Duration',
-    description: 'Check duration of file in seconds. Do something differently if above threshold.',
-    style: {
-        borderColor: 'orange',
+  name: 'Check File Duration',
+  description: 'Check duration of file in seconds. Do something differently if above threshold.',
+  style: {
+    borderColor: 'orange',
+  },
+  tags: '',
+  isStartPlugin: false,
+  pType: '',
+  requiresVersion: '2.11.01',
+  sidebarPosition: -1,
+  icon: 'faQuestion',
+  inputs: [
+    {
+      label: 'Threshold (in seconds)',
+      name: 'thresholdSecs',
+      type: 'number',
+      defaultValue: '3900',
+      inputUI: {
+        type: 'text',
+      },
+      tooltip: 'Specify Threshold.'
+                + ' Default value is 3,900 seconds (65 minutes).',
     },
-    tags: '',
-    isStartPlugin: false,
-    pType: '',
-    requiresVersion: '2.11.01',
-    sidebarPosition: -1,
-    icon: 'faQuestion',
-    inputs: [
-        {
-            label: 'Threshold (in seconds)',
-            name: 'thresholdSecs',
-            type: 'number',
-            defaultValue: '3900',
-            inputUI: {
-                type: 'text',
-            },
-            tooltip: 'Specify Threshold.' +
-                ' Default value is 3,900 seconds (65 minutes); durations longer than this will be assumed as feature length / Films and processed via Output 2, otherwise Output 1 is selected.',
-        },
-    ],
-    outputs: [
-        {
-            number: 1,
-            tooltip: 'Working file duration is below threshold',
-        },
-        {
-            number: 2,
-            tooltip: 'Working file duration is above threshold',
-        },
-    ],
+  ],
+  outputs: [
+    {
+      number: 1,
+      tooltip: 'Working file duration is below threshold',
+    },
+    {
+      number: 2,
+      tooltip: 'Working file duration is above threshold',
+    },
+  ],
 });
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const plugin = (args: IpluginInputArgs): IpluginOutputArgs => {
-    const lib = require('../../../../../methods/lib')();
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars,no-param-reassign
-    args.inputs = lib.loadDefaultValues(args.inputs, details);
-  
-    const getData = (obj:IFileObject) => {
-      try {
-        if (obj?.ffProbeData?.format?.duration) {
-          const dur = Number(obj.ffProbeData.format.duration);
-  
-          if (dur > 0) {
-            return dur;
-          }
+  const lib = require('../../../../../methods/lib')();
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars,no-param-reassign
+  args.inputs = lib.loadDefaultValues(args.inputs, details);
+
+  const getData = (obj:IFileObject) => {
+    try {
+      if (obj?.ffProbeData?.format?.duration) {
+        const dur = Number(obj.ffProbeData.format.duration);
+
+        if (dur > 0) {
+          return dur;
         }
-      } catch (err) {
-        // err
       }
-      return 0;
-    };
-
-    const origFileDuration: number = getData(args.originalLibraryFile);
-    
-    args.jobLog(`origFileDuration: ${origFileDuration}`);
-
-    const thresholdSecs: number = Number(args.inputs.thresholdSecs);
-    const durationText: string = `File has duration is ${origFileDuration.toFixed(3)} seconds`;
-    const seriesText: string = 'File duration within series limits. must be a series.';
-    const filmText: string = 'File duration longer than series limits. must be a film.';
-
-    let outputNumber: number = 1;
-
-    if (origFileDuration < thresholdSecs) {
-        args.jobLog(`${seriesText} ${durationText}, threshold is ${thresholdSecs} seconds`);
-        outputNumber = 1;
-    } else if (origFileDuration >= thresholdSecs) {
-        args.jobLog(`${filmText} ${durationText}, threshold is ${thresholdSecs} seconds`);
-        outputNumber = 2;
-    } else {
-        args.jobLog(durationText);
+    } catch (err) {
+      // err
     }
+    return 0;
+  };
 
-    return {
-        outputFileObj: args.inputFileObj,
-        outputNumber,
-        variables: args.variables,
-    };
+  const origFileDuration: number = getData(args.originalLibraryFile);
+
+  args.jobLog(`origFileDuration: ${origFileDuration}`);
+
+  const thresholdSecs = Number(args.inputs.thresholdSecs);
+  const durationText = `File has duration is ${origFileDuration.toFixed(3)} seconds`;
+  const seriesText = 'File duration within series limits. must be a series.';
+  const filmText = 'File duration longer than series limits. must be a film.';
+
+  let outputNumber = 1;
+
+  if (origFileDuration < thresholdSecs) {
+    args.jobLog(`${seriesText} ${durationText}, threshold is ${thresholdSecs} seconds`);
+    outputNumber = 1;
+  } else if (origFileDuration >= thresholdSecs) {
+    args.jobLog(`${filmText} ${durationText}, threshold is ${thresholdSecs} seconds`);
+    outputNumber = 2;
+  } else {
+    args.jobLog(durationText);
+  }
+
+  return {
+    outputFileObj: args.inputFileObj,
+    outputNumber,
+    variables: args.variables,
+  };
 };
 export {
-    details,
-    plugin,
+  details,
+  plugin,
 };

--- a/FlowPluginsTs/CommunityFlowPlugins/file/checkFileDuration/1.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/file/checkFileDuration/1.0.0/index.ts
@@ -1,0 +1,97 @@
+import {
+    IpluginDetails,
+    IpluginInputArgs,
+    IpluginOutputArgs,
+  } from '../../../../FlowHelpers/1.0.0/interfaces/interfaces';
+  import { IFileObject } from '../../../../FlowHelpers/1.0.0/interfaces/synced/IFileObject';
+
+/* eslint no-plusplus: ["error", { "allowForLoopAfterthoughts": true }] */
+const details = (): IpluginDetails => ({
+    name: 'Check File Duration',
+    description: 'Check duration of file in seconds. Do something differently if above threshold.',
+    style: {
+        borderColor: 'orange',
+    },
+    tags: '',
+    isStartPlugin: false,
+    pType: '',
+    requiresVersion: '2.11.01',
+    sidebarPosition: -1,
+    icon: 'faQuestion',
+    inputs: [
+        {
+            label: 'Threshold (in seconds)',
+            name: 'thresholdSecs',
+            type: 'number',
+            defaultValue: '3900',
+            inputUI: {
+                type: 'text',
+            },
+            tooltip: 'Specify Threshold.' +
+                ' Default value is 3,900 seconds (65 minutes); durations longer than this will be assumed as feature length / Films and processed via Output 2, otherwise Output 1 is selected.',
+        },
+    ],
+    outputs: [
+        {
+            number: 1,
+            tooltip: 'Working file duration is below threshold',
+        },
+        {
+            number: 2,
+            tooltip: 'Working file duration is above threshold',
+        },
+    ],
+});
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const plugin = (args: IpluginInputArgs): IpluginOutputArgs => {
+    const lib = require('../../../../../methods/lib')();
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars,no-param-reassign
+    args.inputs = lib.loadDefaultValues(args.inputs, details);
+  
+    const getData = (obj:IFileObject) => {
+      try {
+        if (obj?.ffProbeData?.format?.duration) {
+          const dur = Number(obj.ffProbeData.format.duration);
+  
+          if (dur > 0) {
+            return dur;
+          }
+        }
+      } catch (err) {
+        // err
+      }
+      return 0;
+    };
+
+    const origFileDuration: number = getData(args.originalLibraryFile);
+    
+    args.jobLog(`origFileDuration: ${origFileDuration}`);
+
+    const thresholdSecs: number = Number(args.inputs.thresholdSecs);
+    const durationText: string = `File has duration is ${origFileDuration.toFixed(3)} seconds`;
+    const seriesText: string = 'File duration within series limits. must be a series.';
+    const filmText: string = 'File duration longer than series limits. must be a film.';
+
+    let outputNumber: number = 1;
+
+    if (origFileDuration < thresholdSecs) {
+        args.jobLog(`${seriesText} ${durationText}, threshold is ${thresholdSecs} seconds`);
+        outputNumber = 1;
+    } else if (origFileDuration >= thresholdSecs) {
+        args.jobLog(`${filmText} ${durationText}, threshold is ${thresholdSecs} seconds`);
+        outputNumber = 2;
+    } else {
+        args.jobLog(durationText);
+    }
+
+    return {
+        outputFileObj: args.inputFileObj,
+        outputNumber,
+        variables: args.variables,
+    };
+};
+export {
+    details,
+    plugin,
+};


### PR DESCRIPTION
The new flow plugin determines the original file duration and allows a decision output if it is over a threshold number of seconds.

**Configuration Example:**
![image](https://github.com/user-attachments/assets/af0d8593-9ab0-429a-861c-483041aa4208)

**Flow Example**
![image](https://github.com/user-attachments/assets/462a76ed-f5f6-44dd-a943-42a6858632a2)
