### PR TITLE
Add tokenizer to FFmpeg custom args

### DIFF
--- a/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandCustomArguments/1.0.0/index.js
+++ b/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandCustomArguments/1.0.0/index.js
@@ -5,7 +5,7 @@ var flowUtils_1 = require("../../../../FlowHelpers/1.0.0/interfaces/flowUtils");
 /* eslint no-plusplus: ["error", { "allowForLoopAfterthoughts": true }] */
 var details = function () { return ({
     name: 'Custom Arguments',
-    description: 'Set FFmpeg custome input and output arguments',
+    description: 'Set FFmpeg custom input and output arguments',
     style: {
         borderColor: '#6efefc',
     },
@@ -45,6 +45,19 @@ var details = function () { return ({
     ],
 }); };
 exports.details = details;
+var tokenize = function (arg) {
+    var regex = /(.*?)"(.+?)"(.*)/;
+    var arr = [];
+    var unprocessedString = arg;
+    var regexResult;
+    while ((regexResult = regex.exec(unprocessedString)) !== null) {
+        arr.push.apply(arr, regexResult[1].trim().split(' '));
+        arr.push(regexResult[2]);
+        unprocessedString = regexResult[3];
+    }
+    arr.push.apply(arr, unprocessedString.trim().split(' '));
+    return arr;
+};
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 var plugin = function (args) {
     var _a, _b;
@@ -55,10 +68,10 @@ var plugin = function (args) {
     var inputArguments = String(args.inputs.inputArguments);
     var outputArguments = String(args.inputs.outputArguments);
     if (inputArguments) {
-        (_a = args.variables.ffmpegCommand.overallInputArguments).push.apply(_a, inputArguments.split(' '));
+        (_a = args.variables.ffmpegCommand.overallInputArguments).push.apply(_a, tokenize(inputArguments));
     }
     if (outputArguments) {
-        (_b = args.variables.ffmpegCommand.overallOuputArguments).push.apply(_b, outputArguments.split(' '));
+        (_b = args.variables.ffmpegCommand.overallOuputArguments).push.apply(_b, tokenize(outputArguments));
     }
     return {
         outputFileObj: args.inputFileObj,

--- a/FlowPluginsTs/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandCustomArguments/1.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandCustomArguments/1.0.0/index.ts
@@ -8,7 +8,7 @@ import {
 /* eslint no-plusplus: ["error", { "allowForLoopAfterthoughts": true }] */
 const details = () :IpluginDetails => ({
   name: 'Custom Arguments',
-  description: 'Set FFmpeg custome input and output arguments',
+  description: 'Set FFmpeg custom input and output arguments',
   style: {
     borderColor: '#6efefc',
   },
@@ -49,6 +49,25 @@ const details = () :IpluginDetails => ({
   ],
 });
 
+const tokenize = (arg: string) => {
+  const regex = /(.*?)"(.+?)"(.*)/;
+  const arr = [];
+
+  let unprocessedString = '';
+  let regexResult = regex.exec(arg);
+  while (regexResult !== null) {
+    arr.push(...regexResult[1].trim().split(' '));
+    arr.push(regexResult[2]);
+    // eslint-disable-next-line prefer-destructuring
+    unprocessedString = regexResult[3];
+    regexResult = regex.exec(unprocessedString);
+  }
+  if (unprocessedString !== '') {
+    arr.push(...unprocessedString.trim().split(' '));
+  }
+  return arr;
+};
+
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const plugin = (args:IpluginInputArgs):IpluginOutputArgs => {
   const lib = require('../../../../../methods/lib')();
@@ -61,11 +80,11 @@ const plugin = (args:IpluginInputArgs):IpluginOutputArgs => {
   const outputArguments = String(args.inputs.outputArguments);
 
   if (inputArguments) {
-    args.variables.ffmpegCommand.overallInputArguments.push(...inputArguments.split(' '));
+    args.variables.ffmpegCommand.overallInputArguments.push(...tokenize(inputArguments));
   }
 
   if (outputArguments) {
-    args.variables.ffmpegCommand.overallOuputArguments.push(...outputArguments.split(' '));
+    args.variables.ffmpegCommand.overallOuputArguments.push(...tokenize(outputArguments));
   }
 
   return {


### PR DESCRIPTION
currently when you include quotes in your args it will fail and while it looks like the command is built the right way the content of the quotes actually has to be pushed whole into the cliArg Array without the quotes.

For references refer to the "ffmpegCommandCustomArguments ignores " which leads to errors" chat in the Discord bugs-forum.