### PR TITLE
add rkmpp support

### DIFF
--- a/Community/Tdarr_Plugin_00td_action_transcode.js
+++ b/Community/Tdarr_Plugin_00td_action_transcode.js
@@ -298,6 +298,10 @@ const getEncoder = async ({
         filter: '-vf format=nv12,hwupload',
       },
       {
+        encoder: 'hevc_rkmpp',
+        enabled: false,
+      },
+      {
         encoder: 'hevc_qsv',
         enabled: false,
       },
@@ -308,6 +312,10 @@ const getEncoder = async ({
 
       {
         encoder: 'h264_nvenc',
+        enabled: false,
+      },
+      {
+        encoder: 'h264_rkmpp',
         enabled: false,
       },
       {

--- a/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandSetVideoEncoder/1.0.0/index.js
+++ b/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandSetVideoEncoder/1.0.0/index.js
@@ -172,6 +172,7 @@ var details = function () { return ({
                 options: [
                     'auto',
                     'nvenc',
+                    'rkmpp',
                     'qsv',
                     'vaapi',
                     'videotoolbox',

--- a/FlowPlugins/CommunityFlowPlugins/tools/checkNodeHardwareEncoder/1.0.0/index.js
+++ b/FlowPlugins/CommunityFlowPlugins/tools/checkNodeHardwareEncoder/1.0.0/index.js
@@ -62,6 +62,7 @@ var details = function () { return ({
                 options: [
                     'hevc_nvenc',
                     'hevc_amf',
+                    'hevc_rkmpp',
                     'hevc_vaapi',
                     'hevc_qsv',
                     'hevc_videotoolbox',

--- a/FlowPlugins/FlowHelpers/1.0.0/hardwareUtils.js
+++ b/FlowPlugins/FlowHelpers/1.0.0/hardwareUtils.js
@@ -227,6 +227,16 @@ var getEncoder = function (_a) { return __awaiter(void 0, [_a], void 0, function
                         filter: '',
                     },
                     {
+                        encoder: 'hevc_rkmpp',
+                        enabled: false,
+                        inputArgs: [
+                            '-hwaccel',
+                            'rkmpp',
+                        ],
+                        outputArgs: [],
+                        filter: '',
+                    },
+                    {
                         encoder: 'hevc_amf',
                         enabled: false,
                         inputArgs: [],
@@ -291,6 +301,16 @@ var getEncoder = function (_a) { return __awaiter(void 0, [_a], void 0, function
                         inputArgs: [
                             '-hwaccel',
                             'qsv',
+                        ],
+                        outputArgs: [],
+                        filter: '',
+                    },
+                    {
+                        encoder: 'h264_rkmpp',
+                        enabled: false,
+                        inputArgs: [
+                            '-hwaccel',
+                            'rkmpp',
                         ],
                         outputArgs: [],
                         filter: '',

--- a/FlowPluginsTs/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandSetVideoEncoder/1.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandSetVideoEncoder/1.0.0/index.ts
@@ -140,6 +140,7 @@ const details = (): IpluginDetails => ({
         options: [
           'auto',
           'nvenc',
+          'rkmpp',
           'qsv',
           'vaapi',
           'videotoolbox',

--- a/FlowPluginsTs/CommunityFlowPlugins/tools/checkNodeHardwareEncoder/1.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/tools/checkNodeHardwareEncoder/1.0.0/index.ts
@@ -38,6 +38,7 @@ const details = (): IpluginDetails => ({
         options: [
           'hevc_nvenc',
           'hevc_amf',
+          'hevc_rkmpp',
           'hevc_vaapi',
           'hevc_qsv',
           'hevc_videotoolbox',

--- a/FlowPluginsTs/FlowHelpers/1.0.0/hardwareUtils.ts
+++ b/FlowPluginsTs/FlowHelpers/1.0.0/hardwareUtils.ts
@@ -204,6 +204,16 @@ export const getEncoder = async ({
         filter: '',
       },
       {
+        encoder: 'hevc_rkmpp',
+        enabled: false,
+        inputArgs: [
+          '-hwaccel',
+          'rkmpp',
+        ],
+        outputArgs: [],
+        filter: '',
+      },
+      {
         encoder: 'hevc_amf',
         enabled: false,
         inputArgs: [],
@@ -271,6 +281,16 @@ export const getEncoder = async ({
         inputArgs: [
           '-hwaccel',
           'qsv',
+        ],
+        outputArgs: [],
+        filter: '',
+      },
+      {
+        encoder: 'h264_rkmpp',
+        enabled: false,
+        inputArgs: [
+          '-hwaccel',
+          'rkmpp',
         ],
         outputArgs: [],
         filter: '',


### PR DESCRIPTION
This adds support for RKMPP, included in some Rockwell ARM chips like RK3588S. Requires an ffmpeg built with RKMPP support. See https://github.com/nyanmisaka/ffmpeg-rockchip which is the ffmpeg that I’m using. 