### PR TITLE
Flow plugin apply radarr or sonarr naming policy v2.0.0

### DIFF
--- a/FlowPlugins/CommunityFlowPlugins/tools/applyRadarrOrSonarrNamingPolicy/2.0.0/index.js
+++ b/FlowPlugins/CommunityFlowPlugins/tools/applyRadarrOrSonarrNamingPolicy/2.0.0/index.js
@@ -1,0 +1,205 @@
+"use strict";
+var __assign = (this && this.__assign) || function () {
+    __assign = Object.assign || function(t) {
+        for (var s, i = 1, n = arguments.length; i < n; i++) {
+            s = arguments[i];
+            for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+                t[p] = s[p];
+        }
+        return t;
+    };
+    return __assign.apply(this, arguments);
+};
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g = Object.create((typeof Iterator === "function" ? Iterator : Object).prototype);
+    return g.next = verb(0), g["throw"] = verb(1), g["return"] = verb(2), typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (g && (g = 0, op[0] && (_ = 0)), _) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.plugin = exports.details = void 0;
+var fileMoveOrCopy_1 = __importDefault(require("../../../../FlowHelpers/1.0.0/fileMoveOrCopy"));
+var fileUtils_1 = require("../../../../FlowHelpers/1.0.0/fileUtils");
+var details = function () { return ({
+    name: 'Apply Radarr or Sonarr naming policy',
+    description: 'Apply Radarr or Sonarr naming policy to a file. Has to be used after the "Set Flow Variables From '
+        + 'Radarr Or Sonarr" plugin and after the original file has been replaced and Radarr or Sonarr has '
+        + 'been notified. Radarr or Sonarr should also be notified after this plugin.',
+    style: {
+        borderColor: 'green',
+    },
+    tags: '',
+    isStartPlugin: false,
+    pType: '',
+    requiresVersion: '2.11.01',
+    sidebarPosition: -1,
+    icon: 'faPenToSquare',
+    inputs: [
+        {
+            label: 'Arr',
+            name: 'arr',
+            type: 'string',
+            defaultValue: 'radarr',
+            inputUI: {
+                type: 'dropdown',
+                options: ['radarr', 'sonarr'],
+            },
+            tooltip: 'Specify which arr to use',
+        },
+        {
+            label: 'Arr API Key',
+            name: 'arr_api_key',
+            type: 'string',
+            defaultValue: '',
+            inputUI: {
+                type: 'text',
+            },
+            tooltip: 'Input your arr api key here',
+        },
+        {
+            label: 'Arr Host',
+            name: 'arr_host',
+            type: 'string',
+            defaultValue: 'http://192.168.1.1:7878',
+            inputUI: {
+                type: 'text',
+            },
+            tooltip: 'Input your arr host here.'
+                + '\\nExample:\\n'
+                + 'http://192.168.1.1:7878\\n'
+                + 'http://192.168.1.1:8989\\n'
+                + 'https://radarr.domain.com\\n'
+                + 'https://sonarr.domain.com\\n',
+        },
+    ],
+    outputs: [
+        {
+            number: 1,
+            tooltip: 'Radarr or Sonarr notified',
+        },
+        {
+            number: 2,
+            tooltip: 'Radarr or Sonarr do not know this file',
+        },
+    ],
+}); };
+exports.details = details;
+var plugin = function (args) { return __awaiter(void 0, void 0, void 0, function () {
+    var lib, newPath, isSuccessful, arr, arr_host, arrHost, currentFileName, headers, arrApp, fInfo, previewRenameRequestResult, fileToRename;
+    var _a, _b, _c, _d, _e;
+    return __generator(this, function (_f) {
+        switch (_f.label) {
+            case 0:
+                lib = require('../../../../../methods/lib')();
+                // eslint-disable-next-line @typescript-eslint/no-unused-vars,no-param-reassign
+                args.inputs = lib.loadDefaultValues(args.inputs, details);
+                newPath = '';
+                isSuccessful = false;
+                arr = String(args.inputs.arr);
+                arr_host = String(args.inputs.arr_host).trim();
+                arrHost = arr_host.endsWith('/') ? arr_host.slice(0, -1) : arr_host;
+                currentFileName = (_b = (_a = args.inputFileObj) === null || _a === void 0 ? void 0 : _a._id) !== null && _b !== void 0 ? _b : '';
+                headers = {
+                    'Content-Type': 'application/json',
+                    'X-Api-Key': String(args.inputs.arr_api_key),
+                    Accept: 'application/json',
+                };
+                arrApp = arr === 'radarr'
+                    ? {
+                        name: arr,
+                        host: arrHost,
+                        headers: headers,
+                        content: 'Movie',
+                        delegates: {
+                            buildPreviewRenameResquestUrl: function (fInfo) { return "".concat(arrHost, "/api/v3/rename?movieId=").concat(fInfo.id); },
+                            getFileToRenameFromPreviewRenameResponse: function (previewRenameResponse) { var _a; return (_a = previewRenameResponse.data) === null || _a === void 0 ? void 0 : _a.at(0); },
+                        },
+                    }
+                    : {
+                        name: arr,
+                        host: arrHost,
+                        headers: headers,
+                        content: 'Serie',
+                        delegates: {
+                            buildPreviewRenameResquestUrl: function (fInfo) { return "".concat(arrHost, "/api/v3/rename?seriesId=").concat(fInfo.id, "&seasonNumber=").concat(fInfo.seasonNumber); },
+                            getFileToRenameFromPreviewRenameResponse: function (previewRenameResponse, fInfo) {
+                                var _a;
+                                return (_a = previewRenameResponse.data) === null || _a === void 0 ? void 0 : _a.find(function (episodeFile) { var _a; return ((_a = episodeFile.episodeNumbers) === null || _a === void 0 ? void 0 : _a.at(0)) === fInfo.episodeNumber; });
+                            },
+                        },
+                    };
+                args.jobLog('Going to apply new name');
+                args.jobLog("Renaming ".concat(arrApp.name, "..."));
+                fInfo = {
+                    id: (_c = args.variables.user.ArrId) !== null && _c !== void 0 ? _c : '',
+                    seasonNumber: Number((_d = args.variables.user.ArrId) !== null && _d !== void 0 ? _d : -1),
+                    episodeNumber: Number((_e = args.variables.user.ArrId) !== null && _e !== void 0 ? _e : -1),
+                };
+                if (!(fInfo.id !== '-1')) return [3 /*break*/, 4];
+                return [4 /*yield*/, args.deps.axios({
+                        method: 'get',
+                        url: arrApp.delegates.buildPreviewRenameResquestUrl(fInfo),
+                        headers: headers,
+                    })];
+            case 1:
+                previewRenameRequestResult = _f.sent();
+                fileToRename = arrApp.delegates
+                    .getFileToRenameFromPreviewRenameResponse(previewRenameRequestResult, fInfo);
+                if (!(fileToRename !== undefined)) return [3 /*break*/, 3];
+                newPath = "".concat((0, fileUtils_1.getFileAbosluteDir)(currentFileName), "/").concat((0, fileUtils_1.getFileName)(fileToRename.newPath), ".").concat((0, fileUtils_1.getContainer)(fileToRename.newPath));
+                return [4 /*yield*/, (0, fileMoveOrCopy_1.default)({
+                        operation: 'move',
+                        sourcePath: currentFileName,
+                        destinationPath: newPath,
+                        args: args,
+                    })];
+            case 2:
+                isSuccessful = _f.sent();
+                return [3 /*break*/, 4];
+            case 3:
+                isSuccessful = true;
+                args.jobLog('✔ No rename necessary.');
+                _f.label = 4;
+            case 4: return [2 /*return*/, {
+                    outputFileObj: isSuccessful && newPath !== ''
+                        ? __assign(__assign({}, args.inputFileObj), { _id: newPath }) : args.inputFileObj,
+                    outputNumber: isSuccessful ? 1 : 2,
+                    variables: args.variables,
+                }];
+        }
+    });
+}); };
+exports.plugin = plugin;

--- a/FlowPlugins/CommunityFlowPlugins/tools/applyRadarrOrSonarrNamingPolicy/2.0.0/index.js
+++ b/FlowPlugins/CommunityFlowPlugins/tools/applyRadarrOrSonarrNamingPolicy/2.0.0/index.js
@@ -51,6 +51,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.plugin = exports.details = void 0;
+var path_1 = __importDefault(require("path"));
 var fileMoveOrCopy_1 = __importDefault(require("../../../../FlowHelpers/1.0.0/fileMoveOrCopy"));
 var fileUtils_1 = require("../../../../FlowHelpers/1.0.0/fileUtils");
 var details = function () { return ({
@@ -139,7 +140,7 @@ var buildNewPath = function (currentFileName, fileToRename) {
     var directory = (0, fileUtils_1.getFileAbosluteDir)(currentFileName);
     var fileName = (0, fileUtils_1.getFileName)(fileToRename.newPath);
     var container = (0, fileUtils_1.getContainer)(fileToRename.newPath);
-    return "".concat(directory, "/").concat(fileName, ".").concat(container);
+    return path_1.default.join(directory, fileName, container);
 };
 var previewRename = function (args, host, headers, fileInfo, config) { return __awaiter(void 0, void 0, void 0, function () {
     var response, error_1;

--- a/FlowPluginsTs/CommunityFlowPlugins/tools/applyRadarrOrSonarrNamingPolicy/2.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/tools/applyRadarrOrSonarrNamingPolicy/2.0.0/index.ts
@@ -1,6 +1,8 @@
 import fileMoveOrCopy from '../../../../FlowHelpers/1.0.0/fileMoveOrCopy';
 import {
-  getContainer, getFileAbosluteDir, getFileName,
+  getContainer,
+  getFileAbosluteDir,
+  getFileName,
 } from '../../../../FlowHelpers/1.0.0/fileUtils';
 import {
   IpluginDetails,
@@ -10,8 +12,7 @@ import {
 
 const details = (): IpluginDetails => ({
   name: 'Apply Radarr or Sonarr naming policy',
-  description:
-    'Apply Radarr or Sonarr naming policy to a file. Has to be used after the "Set Flow Variables From '
+  description: 'Apply Radarr or Sonarr naming policy to a file. Has to be used after the "Set Flow Variables From '
     + 'Radarr Or Sonarr" plugin and after the original file has been replaced and Radarr or Sonarr has '
     + 'been notified. Radarr or Sonarr should also be notified after this plugin.',
   style: {
@@ -53,150 +54,172 @@ const details = (): IpluginDetails => ({
       inputUI: {
         type: 'text',
       },
-      tooltip: 'Input your arr host here.'
-        + '\\nExample:\\n'
-        + 'http://192.168.1.1:7878\\n'
-        + 'http://192.168.1.1:8989\\n'
-        + 'https://radarr.domain.com\\n'
-        + 'https://sonarr.domain.com\\n',
+      tooltip: 'Input your arr host here.\nExample:\n'
+        + 'http://192.168.1.1:7878\n'
+        + 'http://192.168.1.1:8989\n'
+        + 'https://radarr.domain.com\n'
+        + 'https://sonarr.domain.com',
     },
   ],
   outputs: [
-    {
-      number: 1,
-      tooltip: 'Radarr or Sonarr notified',
-    },
-    {
-      number: 2,
-      tooltip: 'Radarr or Sonarr do not know this file',
-    },
+    { number: 1, tooltip: 'Radarr or Sonarr notified' },
+    { number: 2, tooltip: 'Radarr or Sonarr do not know this file' },
   ],
 });
 
 interface IHTTPHeaders {
-  'Content-Type': string,
-  'X-Api-Key': string,
-  Accept: string,
+  'Content-Type': string;
+  'X-Api-Key': string;
+  Accept: string;
 }
+
 interface IFileInfo {
-  id: string,
-  seasonNumber?: number,
-  episodeNumber?: number
+  id: string;
+  seasonNumber?: number;
+  episodeNumber?: number;
 }
+
 interface IFileToRename {
-  newPath: string,
-  episodeNumbers?: number[]
+  newPath: string;
+  episodeNumbers?: number[];
 }
+
 interface IPreviewRenameResponse {
-  data: IFileToRename[]
+  data: IFileToRename[];
 }
-interface IArrApp {
-  name: string,
+
+interface IArrConfig {
+  content: string;
+  buildPreviewRenameUrl: (fileInfo: IFileInfo, host: string) => string;
+  getFileToRename: (response: IPreviewRenameResponse, fileInfo: IFileInfo) => IFileToRename | undefined;
+}
+
+const API_VERSION = 'v3';
+const CONTENT_TYPE = 'application/json';
+
+const arrConfigs: Record<'radarr' | 'sonarr', IArrConfig> = {
+  radarr: {
+    content: 'Movie',
+    buildPreviewRenameUrl: (fileInfo, host) => `${host}/api/${API_VERSION}/rename?movieId=${fileInfo.id}`,
+    getFileToRename: (response) => response.data?.at(0),
+  },
+  sonarr: {
+    content: 'Serie',
+    // eslint-disable-next-line max-len
+    buildPreviewRenameUrl: (fileInfo, host) => `${host}/api/${API_VERSION}/rename?seriesId=${fileInfo.id}&seasonNumber=${fileInfo.seasonNumber}`,
+    // eslint-disable-next-line max-len
+    getFileToRename: (response, fileInfo) => response.data?.find((file) => file.episodeNumbers?.at(0) === fileInfo.episodeNumber),
+  },
+} as const;
+
+const normalizeHost = (host: string): string => {
+  const trimmedHost = host.trim();
+  return trimmedHost.endsWith('/') ? trimmedHost.slice(0, -1) : trimmedHost;
+};
+
+const createHeaders = (apiKey: string): IHTTPHeaders => ({
+  'Content-Type': CONTENT_TYPE,
+  'X-Api-Key': apiKey,
+  Accept: CONTENT_TYPE,
+});
+
+const buildNewPath = (currentFileName: string, fileToRename: IFileToRename): string => {
+  const directory = getFileAbosluteDir(currentFileName);
+  const fileName = getFileName(fileToRename.newPath);
+  const container = getContainer(fileToRename.newPath);
+  return `${directory}/${fileName}.${container}`;
+};
+
+const previewRename = async (
+  args: IpluginInputArgs,
   host: string,
   headers: IHTTPHeaders,
-  content: string,
-  delegates: {
-    buildPreviewRenameResquestUrl:
-    (fileInfo: IFileInfo) => string,
-    getFileToRenameFromPreviewRenameResponse:
-    (previewRenameResponse: IPreviewRenameResponse, fileInfo: IFileInfo) => IFileToRename | undefined
+  fileInfo: IFileInfo,
+  config: IArrConfig,
+): Promise<IFileToRename | undefined> => {
+  try {
+    const response = await args.deps.axios({
+      method: 'get',
+      url: config.buildPreviewRenameUrl(fileInfo, host),
+      headers,
+    });
+
+    return config.getFileToRename(response.data, fileInfo);
+  } catch (error) {
+    throw new Error(`Failed to preview rename: ${(error as Error).message}`);
   }
-}
+};
 
 const plugin = async (args: IpluginInputArgs): Promise<IpluginOutputArgs> => {
   const lib = require('../../../../../methods/lib')();
   // eslint-disable-next-line @typescript-eslint/no-unused-vars,no-param-reassign
   args.inputs = lib.loadDefaultValues(args.inputs, details);
 
-  let newPath = '';
-  let isSuccessful = false;
-  const arr = String(args.inputs.arr);
-  const arr_host = String(args.inputs.arr_host).trim();
-  const arrHost = arr_host.endsWith('/') ? arr_host.slice(0, -1) : arr_host;
-  const currentFileName = args.inputFileObj?._id ?? '';
-  const headers = {
-    'Content-Type': 'application/json',
-    'X-Api-Key': String(args.inputs.arr_api_key),
-    Accept: 'application/json',
+  const { arr, arr_api_key, arr_host } = args.inputs as {
+    arr: 'radarr' | 'sonarr';
+    arr_api_key: string;
+    arr_host: string;
   };
-
-  const arrApp: IArrApp = arr === 'radarr'
-    ? {
-      name: arr,
-      host: arrHost,
-      headers,
-      content: 'Movie',
-      delegates: {
-        buildPreviewRenameResquestUrl:
-          (fInfo) => `${arrHost}/api/v3/rename?movieId=${fInfo.id}`,
-        getFileToRenameFromPreviewRenameResponse:
-          (previewRenameResponse) => previewRenameResponse.data?.at(0),
-      },
-    }
-    : {
-      name: arr,
-      host: arrHost,
-      headers,
-      content: 'Serie',
-      delegates: {
-        buildPreviewRenameResquestUrl:
-          (fInfo) => `${arrHost}/api/v3/rename?seriesId=${fInfo.id}&seasonNumber=${fInfo.seasonNumber}`,
-        getFileToRenameFromPreviewRenameResponse:
-          (previewRenameResponse, fInfo) => previewRenameResponse.data
-            ?.find((episodeFile) => episodeFile.episodeNumbers?.at(0) === fInfo.episodeNumber),
-      },
-    };
+  const host = normalizeHost(arr_host);
+  const headers = createHeaders(arr_api_key);
+  const config = arrConfigs[arr];
+  const currentFileName = args.inputFileObj?._id ?? '';
 
   args.jobLog('Going to apply new name');
-  args.jobLog(`Renaming ${arrApp.name}...`);
+  args.jobLog(`Renaming ${arr}...`);
 
-  // Retrieving movie or serie id, plus season and episode number for serie
-  const fInfo: IFileInfo = {
-    id: args.variables.user.ArrId ?? '',
-    seasonNumber: Number(args.variables.user.ArrId ?? -1),
-    episodeNumber: Number(args.variables.user.ArrId ?? -1),
-  };
+  let newPath = '';
+  let isSuccessful = false;
 
-  // Checking that the file has been found
-  if (fInfo.id !== '-1') {
-    // Using rename endpoint to get ids of all the files that need renaming
-    const previewRenameRequestResult = await args.deps.axios({
-      method: 'get',
-      url: arrApp.delegates.buildPreviewRenameResquestUrl(fInfo),
-      headers,
-    });
-    const fileToRename = arrApp.delegates
-      .getFileToRenameFromPreviewRenameResponse(previewRenameRequestResult, fInfo);
+  try {
+    const fileInfo = {
+      id: args.variables.user.ArrId ?? '',
+      seasonNumber: Number(args.variables.user.ArrSeasonNumber ?? -1),
+      episodeNumber: Number(args.variables.user.ArrEpisodeNumber ?? -1),
+    };
+    args.jobLog(`ArrId ${fileInfo.id} read from flow variables`);
+    args.jobLog(`ArrSeasonNumber ${fileInfo.seasonNumber} read from flow variables`);
+    args.jobLog(`ArrEpisodeNumber ${fileInfo.episodeNumber} read from flow variables`);
 
-    // Only if there is a rename to execute
-    if (fileToRename !== undefined) {
-      newPath = `${getFileAbosluteDir(currentFileName)
-      }/${getFileName(fileToRename.newPath)
-      }.${getContainer(fileToRename.newPath)}`;
+    if (fileInfo.id === '-1') {
+      args.jobLog('❌ Invalid file ID');
+      return {
+        outputFileObj: args.inputFileObj,
+        outputNumber: 2,
+        variables: args.variables,
+      };
+    }
 
+    const fileToRename = await previewRename(args, host, headers, fileInfo, config);
+
+    if (!fileToRename) {
+      args.jobLog('✔ No rename necessary.');
+      isSuccessful = true;
+    } else {
+      newPath = buildNewPath(currentFileName, fileToRename);
       isSuccessful = await fileMoveOrCopy({
         operation: 'move',
         sourcePath: currentFileName,
         destinationPath: newPath,
         args,
       });
-    } else {
-      isSuccessful = true;
-      args.jobLog('✔ No rename necessary.');
+
+      if (isSuccessful) {
+        args.jobLog(`✔ File renamed to: ${newPath}`);
+      }
     }
+  } catch (error) {
+    args.jobLog(`❌ Error during rename: ${(error as Error).message}`);
+    isSuccessful = false;
   }
 
   return {
-    outputFileObj:
-      isSuccessful && newPath !== ''
-        ? { ...args.inputFileObj, _id: newPath }
-        : args.inputFileObj,
+    outputFileObj: isSuccessful && newPath !== ''
+      ? { ...args.inputFileObj, _id: newPath }
+      : args.inputFileObj,
     outputNumber: isSuccessful ? 1 : 2,
     variables: args.variables,
   };
 };
 
-export {
-  details,
-  plugin,
-};
+export { details, plugin };

--- a/FlowPluginsTs/CommunityFlowPlugins/tools/applyRadarrOrSonarrNamingPolicy/2.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/tools/applyRadarrOrSonarrNamingPolicy/2.0.0/index.ts
@@ -1,0 +1,202 @@
+import fileMoveOrCopy from '../../../../FlowHelpers/1.0.0/fileMoveOrCopy';
+import {
+  getContainer, getFileAbosluteDir, getFileName,
+} from '../../../../FlowHelpers/1.0.0/fileUtils';
+import {
+  IpluginDetails,
+  IpluginInputArgs,
+  IpluginOutputArgs,
+} from '../../../../FlowHelpers/1.0.0/interfaces/interfaces';
+
+const details = (): IpluginDetails => ({
+  name: 'Apply Radarr or Sonarr naming policy',
+  description:
+    'Apply Radarr or Sonarr naming policy to a file. Has to be used after the "Set Flow Variables From '
+    + 'Radarr Or Sonarr" plugin and after the original file has been replaced and Radarr or Sonarr has '
+    + 'been notified. Radarr or Sonarr should also be notified after this plugin.',
+  style: {
+    borderColor: 'green',
+  },
+  tags: '',
+  isStartPlugin: false,
+  pType: '',
+  requiresVersion: '2.11.01',
+  sidebarPosition: -1,
+  icon: 'faPenToSquare',
+  inputs: [
+    {
+      label: 'Arr',
+      name: 'arr',
+      type: 'string',
+      defaultValue: 'radarr',
+      inputUI: {
+        type: 'dropdown',
+        options: ['radarr', 'sonarr'],
+      },
+      tooltip: 'Specify which arr to use',
+    },
+    {
+      label: 'Arr API Key',
+      name: 'arr_api_key',
+      type: 'string',
+      defaultValue: '',
+      inputUI: {
+        type: 'text',
+      },
+      tooltip: 'Input your arr api key here',
+    },
+    {
+      label: 'Arr Host',
+      name: 'arr_host',
+      type: 'string',
+      defaultValue: 'http://192.168.1.1:7878',
+      inputUI: {
+        type: 'text',
+      },
+      tooltip: 'Input your arr host here.'
+        + '\\nExample:\\n'
+        + 'http://192.168.1.1:7878\\n'
+        + 'http://192.168.1.1:8989\\n'
+        + 'https://radarr.domain.com\\n'
+        + 'https://sonarr.domain.com\\n',
+    },
+  ],
+  outputs: [
+    {
+      number: 1,
+      tooltip: 'Radarr or Sonarr notified',
+    },
+    {
+      number: 2,
+      tooltip: 'Radarr or Sonarr do not know this file',
+    },
+  ],
+});
+
+interface IHTTPHeaders {
+  'Content-Type': string,
+  'X-Api-Key': string,
+  Accept: string,
+}
+interface IFileInfo {
+  id: string,
+  seasonNumber?: number,
+  episodeNumber?: number
+}
+interface IFileToRename {
+  newPath: string,
+  episodeNumbers?: number[]
+}
+interface IPreviewRenameResponse {
+  data: IFileToRename[]
+}
+interface IArrApp {
+  name: string,
+  host: string,
+  headers: IHTTPHeaders,
+  content: string,
+  delegates: {
+    buildPreviewRenameResquestUrl:
+    (fileInfo: IFileInfo) => string,
+    getFileToRenameFromPreviewRenameResponse:
+    (previewRenameResponse: IPreviewRenameResponse, fileInfo: IFileInfo) => IFileToRename | undefined
+  }
+}
+
+const plugin = async (args: IpluginInputArgs): Promise<IpluginOutputArgs> => {
+  const lib = require('../../../../../methods/lib')();
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars,no-param-reassign
+  args.inputs = lib.loadDefaultValues(args.inputs, details);
+
+  let newPath = '';
+  let isSuccessful = false;
+  const arr = String(args.inputs.arr);
+  const arr_host = String(args.inputs.arr_host).trim();
+  const arrHost = arr_host.endsWith('/') ? arr_host.slice(0, -1) : arr_host;
+  const currentFileName = args.inputFileObj?._id ?? '';
+  const headers = {
+    'Content-Type': 'application/json',
+    'X-Api-Key': String(args.inputs.arr_api_key),
+    Accept: 'application/json',
+  };
+
+  const arrApp: IArrApp = arr === 'radarr'
+    ? {
+      name: arr,
+      host: arrHost,
+      headers,
+      content: 'Movie',
+      delegates: {
+        buildPreviewRenameResquestUrl:
+          (fInfo) => `${arrHost}/api/v3/rename?movieId=${fInfo.id}`,
+        getFileToRenameFromPreviewRenameResponse:
+          (previewRenameResponse) => previewRenameResponse.data?.at(0),
+      },
+    }
+    : {
+      name: arr,
+      host: arrHost,
+      headers,
+      content: 'Serie',
+      delegates: {
+        buildPreviewRenameResquestUrl:
+          (fInfo) => `${arrHost}/api/v3/rename?seriesId=${fInfo.id}&seasonNumber=${fInfo.seasonNumber}`,
+        getFileToRenameFromPreviewRenameResponse:
+          (previewRenameResponse, fInfo) => previewRenameResponse.data
+            ?.find((episodeFile) => episodeFile.episodeNumbers?.at(0) === fInfo.episodeNumber),
+      },
+    };
+
+  args.jobLog('Going to apply new name');
+  args.jobLog(`Renaming ${arrApp.name}...`);
+
+  // Retrieving movie or serie id, plus season and episode number for serie
+  const fInfo: IFileInfo = {
+    id: args.variables.user.ArrId ?? '',
+    seasonNumber: Number(args.variables.user.ArrId ?? -1),
+    episodeNumber: Number(args.variables.user.ArrId ?? -1),
+  };
+
+  // Checking that the file has been found
+  if (fInfo.id !== '-1') {
+    // Using rename endpoint to get ids of all the files that need renaming
+    const previewRenameRequestResult = await args.deps.axios({
+      method: 'get',
+      url: arrApp.delegates.buildPreviewRenameResquestUrl(fInfo),
+      headers,
+    });
+    const fileToRename = arrApp.delegates
+      .getFileToRenameFromPreviewRenameResponse(previewRenameRequestResult, fInfo);
+
+    // Only if there is a rename to execute
+    if (fileToRename !== undefined) {
+      newPath = `${getFileAbosluteDir(currentFileName)
+      }/${getFileName(fileToRename.newPath)
+      }.${getContainer(fileToRename.newPath)}`;
+
+      isSuccessful = await fileMoveOrCopy({
+        operation: 'move',
+        sourcePath: currentFileName,
+        destinationPath: newPath,
+        args,
+      });
+    } else {
+      isSuccessful = true;
+      args.jobLog('✔ No rename necessary.');
+    }
+  }
+
+  return {
+    outputFileObj:
+      isSuccessful && newPath !== ''
+        ? { ...args.inputFileObj, _id: newPath }
+        : args.inputFileObj,
+    outputNumber: isSuccessful ? 1 : 2,
+    variables: args.variables,
+  };
+};
+
+export {
+  details,
+  plugin,
+};

--- a/FlowPluginsTs/CommunityFlowPlugins/tools/applyRadarrOrSonarrNamingPolicy/2.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/tools/applyRadarrOrSonarrNamingPolicy/2.0.0/index.ts
@@ -1,3 +1,4 @@
+import path from 'path';
 import fileMoveOrCopy from '../../../../FlowHelpers/1.0.0/fileMoveOrCopy';
 import {
   getContainer,
@@ -127,7 +128,7 @@ const buildNewPath = (currentFileName: string, fileToRename: IFileToRename): str
   const directory = getFileAbosluteDir(currentFileName);
   const fileName = getFileName(fileToRename.newPath);
   const container = getContainer(fileToRename.newPath);
-  return `${directory}/${fileName}.${container}`;
+  return path.join(directory, fileName, container);
 };
 
 const previewRename = async (


### PR DESCRIPTION
Hi,

I made a V2.0.0 of this plugin (I'm the author), that uses the Radarr or Sonarr variables made by the setFlowVariablesFromRadarrOrSonarr plugin (https://github.com/HaveAGitGat/Tdarr_Plugins/pull/742). See https://github.com/HaveAGitGat/Tdarr_Plugins/issues/741 for more details.

Still used the same way as the V1.0.0. It's mostly more effective and performant if you also use notifyRadarrOrSonarr and the setDefaultAudioStream/setDefaultSubtitleStream plugins. It also contains a modification to make the file paths it uses system agnostic.