### PR TITLE
Flow plugin notify radarr or sonarr v3.0.0

### DIFF
--- a/FlowPlugins/CommunityFlowPlugins/tools/notifyRadarrOrSonarr/3.0.0/index.js
+++ b/FlowPlugins/CommunityFlowPlugins/tools/notifyRadarrOrSonarr/3.0.0/index.js
@@ -1,0 +1,165 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g = Object.create((typeof Iterator === "function" ? Iterator : Object).prototype);
+    return g.next = verb(0), g["throw"] = verb(1), g["return"] = verb(2), typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (g && (g = 0, op[0] && (_ = 0)), _) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.plugin = exports.details = void 0;
+var details = function () { return ({
+    name: 'Notify Radarr or Sonarr',
+    description: 'Notify Radarr or Sonarr to refresh after file change. '
+        + 'Has to be used after the "Set Flow Variables From Radarr Or Sonarr" plugin.',
+    style: {
+        borderColor: 'green',
+    },
+    tags: '',
+    isStartPlugin: false,
+    pType: '',
+    requiresVersion: '2.11.01',
+    sidebarPosition: -1,
+    icon: 'faBell',
+    inputs: [
+        {
+            label: 'Arr',
+            name: 'arr',
+            type: 'string',
+            defaultValue: 'radarr',
+            inputUI: {
+                type: 'dropdown',
+                options: ['radarr', 'sonarr'],
+            },
+            tooltip: 'Specify which arr to use',
+        },
+        {
+            label: 'Arr API Key',
+            name: 'arr_api_key',
+            type: 'string',
+            defaultValue: '',
+            inputUI: {
+                type: 'text',
+            },
+            tooltip: 'Input your arr api key here',
+        },
+        {
+            label: 'Arr Host',
+            name: 'arr_host',
+            type: 'string',
+            defaultValue: 'http://192.168.1.1:7878',
+            inputUI: {
+                type: 'text',
+            },
+            tooltip: 'Input your arr host here.'
+                + '\\nExample:\\n'
+                + 'http://192.168.1.1:7878\\n'
+                + 'http://192.168.1.1:8989\\n'
+                + 'https://radarr.domain.com\\n'
+                + 'https://sonarr.domain.com\\n',
+        },
+    ],
+    outputs: [
+        {
+            number: 1,
+            tooltip: 'Radarr or Sonarr notified',
+        },
+        {
+            number: 2,
+            tooltip: 'Radarr or Sonarr do not know this file',
+        },
+    ],
+}); };
+exports.details = details;
+var plugin = function (args) { return __awaiter(void 0, void 0, void 0, function () {
+    var lib, refreshed, arr, arr_host, arrHost, headers, arrApp, id;
+    var _a;
+    return __generator(this, function (_b) {
+        switch (_b.label) {
+            case 0:
+                lib = require('../../../../../methods/lib')();
+                // eslint-disable-next-line @typescript-eslint/no-unused-vars,no-param-reassign
+                args.inputs = lib.loadDefaultValues(args.inputs, details);
+                refreshed = false;
+                arr = String(args.inputs.arr);
+                arr_host = String(args.inputs.arr_host).trim();
+                arrHost = arr_host.endsWith('/') ? arr_host.slice(0, -1) : arr_host;
+                headers = {
+                    'Content-Type': 'application/json',
+                    'X-Api-Key': String(args.inputs.arr_api_key),
+                    Accept: 'application/json',
+                };
+                arrApp = arr === 'radarr'
+                    ? {
+                        name: arr,
+                        host: arrHost,
+                        headers: headers,
+                        content: 'Movie',
+                        delegates: {
+                            buildRefreshResquestData: function (id) { return JSON.stringify({ name: 'RefreshMovie', movieIds: [id] }); },
+                        },
+                    }
+                    : {
+                        name: arr,
+                        host: arrHost,
+                        headers: headers,
+                        content: 'Serie',
+                        delegates: {
+                            buildRefreshResquestData: function (id) { return JSON.stringify({ name: 'RefreshSeries', seriesId: id }); },
+                        },
+                    };
+                args.jobLog('Going to force scan');
+                args.jobLog("Refreshing ".concat(arrApp.name, "..."));
+                id = Number((_a = args.variables.user.ArrId) !== null && _a !== void 0 ? _a : -1);
+                if (!(id !== -1)) return [3 /*break*/, 2];
+                // Using command endpoint to queue a refresh task
+                return [4 /*yield*/, args.deps.axios({
+                        method: 'post',
+                        url: "".concat(arrApp.host, "/api/v3/command"),
+                        headers: headers,
+                        data: arrApp.delegates.buildRefreshResquestData(id),
+                    })];
+            case 1:
+                // Using command endpoint to queue a refresh task
+                _b.sent();
+                refreshed = true;
+                args.jobLog("\u2714 ".concat(arrApp.content, " '").concat(id, "' refreshed in ").concat(arrApp.name, "."));
+                _b.label = 2;
+            case 2: return [2 /*return*/, {
+                    outputFileObj: args.inputFileObj,
+                    outputNumber: refreshed ? 1 : 2,
+                    variables: args.variables,
+                }];
+        }
+    });
+}); };
+exports.plugin = plugin;

--- a/FlowPluginsTs/CommunityFlowPlugins/tools/notifyRadarrOrSonarr/3.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/tools/notifyRadarrOrSonarr/3.0.0/index.ts
@@ -1,0 +1,149 @@
+import {
+  IpluginDetails,
+  IpluginInputArgs,
+  IpluginOutputArgs,
+} from '../../../../FlowHelpers/1.0.0/interfaces/interfaces';
+
+const details = (): IpluginDetails => ({
+  name: 'Notify Radarr or Sonarr',
+  description: 'Notify Radarr or Sonarr to refresh after file change. '
+    + 'Has to be used after the "Set Flow Variables From Radarr Or Sonarr" plugin.',
+  style: {
+    borderColor: 'green',
+  },
+  tags: '',
+  isStartPlugin: false,
+  pType: '',
+  requiresVersion: '2.11.01',
+  sidebarPosition: -1,
+  icon: 'faBell',
+  inputs: [
+    {
+      label: 'Arr',
+      name: 'arr',
+      type: 'string',
+      defaultValue: 'radarr',
+      inputUI: {
+        type: 'dropdown',
+        options: ['radarr', 'sonarr'],
+      },
+      tooltip: 'Specify which arr to use',
+    },
+    {
+      label: 'Arr API Key',
+      name: 'arr_api_key',
+      type: 'string',
+      defaultValue: '',
+      inputUI: {
+        type: 'text',
+      },
+      tooltip: 'Input your arr api key here',
+    },
+    {
+      label: 'Arr Host',
+      name: 'arr_host',
+      type: 'string',
+      defaultValue: 'http://192.168.1.1:7878',
+      inputUI: {
+        type: 'text',
+      },
+      tooltip: 'Input your arr host here.'
+        + '\\nExample:\\n'
+        + 'http://192.168.1.1:7878\\n'
+        + 'http://192.168.1.1:8989\\n'
+        + 'https://radarr.domain.com\\n'
+        + 'https://sonarr.domain.com\\n',
+    },
+  ],
+  outputs: [
+    {
+      number: 1,
+      tooltip: 'Radarr or Sonarr notified',
+    },
+    {
+      number: 2,
+      tooltip: 'Radarr or Sonarr do not know this file',
+    },
+  ],
+});
+
+interface IHTTPHeaders {
+  'Content-Type': string,
+  'X-Api-Key': string,
+  Accept: string,
+}
+interface IArrApp {
+  name: string,
+  host: string,
+  headers: IHTTPHeaders,
+  content: string,
+  delegates: {
+    buildRefreshResquestData: (id: number) => string
+  }
+}
+
+const plugin = async (args: IpluginInputArgs): Promise<IpluginOutputArgs> => {
+  const lib = require('../../../../../methods/lib')();
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars,no-param-reassign
+  args.inputs = lib.loadDefaultValues(args.inputs, details);
+
+  // Variables initialization
+  let refreshed = false;
+  const arr = String(args.inputs.arr);
+  const arr_host = String(args.inputs.arr_host).trim();
+  const arrHost = arr_host.endsWith('/') ? arr_host.slice(0, -1) : arr_host;
+  const headers: IHTTPHeaders = {
+    'Content-Type': 'application/json',
+    'X-Api-Key': String(args.inputs.arr_api_key),
+    Accept: 'application/json',
+  };
+  const arrApp: IArrApp = arr === 'radarr'
+    ? {
+      name: arr,
+      host: arrHost,
+      headers,
+      content: 'Movie',
+      delegates: {
+        buildRefreshResquestData:
+          (id) => JSON.stringify({ name: 'RefreshMovie', movieIds: [id] }),
+      },
+    }
+    : {
+      name: arr,
+      host: arrHost,
+      headers,
+      content: 'Serie',
+      delegates: {
+        buildRefreshResquestData:
+          (id) => JSON.stringify({ name: 'RefreshSeries', seriesId: id }),
+      },
+    };
+
+  args.jobLog('Going to force scan');
+  args.jobLog(`Refreshing ${arrApp.name}...`);
+
+  const id = Number(args.variables.user.ArrId ?? -1);
+  if (id !== -1) {
+    // Using command endpoint to queue a refresh task
+    await args.deps.axios({
+      method: 'post',
+      url: `${arrApp.host}/api/v3/command`,
+      headers,
+      data: arrApp.delegates.buildRefreshResquestData(id),
+    });
+
+    refreshed = true;
+    args.jobLog(`✔ ${arrApp.content} '${id}' refreshed in ${arrApp.name}.`);
+  }
+
+  return {
+    outputFileObj: args.inputFileObj,
+    outputNumber: refreshed ? 1 : 2,
+    variables: args.variables,
+  };
+};
+
+export {
+  details,
+  plugin,
+};


### PR DESCRIPTION
Hi,

I made a V3.0.0 of this plugin (I'm the author of the v2.0.0), that uses the Radarr or Sonarr variables made by the setFlowVariablesFromRadarrOrSonarr plugin (https://github.com/HaveAGitGat/Tdarr_Plugins/pull/742). See https://github.com/HaveAGitGat/Tdarr_Plugins/issues/741 for more details.

Still used the same way as the V2.0.0. It's mostly more effective and performant if you also use applyRadarrOrSonarrNamingPolicy and the setDefaultAudioStream/setDefaultSubtitleStream plugins. This plugin makes use of the Radarr or Sonarr variables made by the setFlowVariablesFromRadarrOrSnarr, so it needs to be called after it.