### PR TITLE
Fix: Ensure attachments are mapped when processing 076a and 076b

### DIFF
--- a/Community/Tdarr_Plugin_076a_re_order_audio_streams.js
+++ b/Community/Tdarr_Plugin_076a_re_order_audio_streams.js
@@ -126,7 +126,7 @@ const plugin = (file, librarySettings, inputs, otherArguments) => {
     }
   }
 
-  ffmpegCommand += ` -map 0:s? -map 0:d? `;
+  ffmpegCommand += ` -map 0:s? -map 0:d? -map 0:t? `;
 
   response.processFile = true;
   response.preset = ffmpegCommand;

--- a/Community/Tdarr_Plugin_076b_re_order_subtitle_streams.js
+++ b/Community/Tdarr_Plugin_076b_re_order_subtitle_streams.js
@@ -131,7 +131,7 @@ const plugin = (file, librarySettings, inputs, otherArguments) => {
     }
   }
 
-  ffmpegCommand += ` -map 0:d? `;
+  ffmpegCommand += ` -map 0:d? -map 0:t? `;
 
   response.processFile = true;
   response.preset = ffmpegCommand;

--- a/tests/Community/Tdarr_Plugin_076a_re_order_audio_streams.js
+++ b/tests/Community/Tdarr_Plugin_076a_re_order_audio_streams.js
@@ -31,7 +31,7 @@ const tests = [
     },
     output: {
       processFile: true,
-      preset: ', -c copy -map 0:v?  -map 0:a:3 -disposition:a:0 default -map 0:a:0  -map 0:a:1  -disposition:a:1 0  -map 0:a:2  -disposition:a:2 0  -disposition:a:3 0  -map 0:a:4  -disposition:a:4 0  -map 0:s? -map 0:d? ',
+      preset: ', -c copy -map 0:v?  -map 0:a:3 -disposition:a:0 default -map 0:a:0  -map 0:a:1  -disposition:a:1 0  -map 0:a:2  -disposition:a:2 0  -disposition:a:3 0  -map 0:a:4  -disposition:a:4 0  -map 0:s? -map 0:d? -map 0:t? ',
       container: '.mkv',
       handBrakeMode: false,
       FFmpegMode: true,
@@ -77,7 +77,7 @@ const tests = [
     },
     output: {
       processFile: true,
-      preset: ', -c copy -map 0:v?  -map 0:a:1 -disposition:a:0 default -map 0:a:0  -disposition:a:1 0  -map 0:a:2  -disposition:a:2 0  -map 0:a:3  -disposition:a:3 0  -map 0:a:4  -disposition:a:4 0  -map 0:a:5  -disposition:a:5 0  -map 0:s? -map 0:d? ',
+      preset: ', -c copy -map 0:v?  -map 0:a:1 -disposition:a:0 default -map 0:a:0  -disposition:a:1 0  -map 0:a:2  -disposition:a:2 0  -map 0:a:3  -disposition:a:3 0  -map 0:a:4  -disposition:a:4 0  -map 0:a:5  -disposition:a:5 0  -map 0:s? -map 0:d? -map 0:t? ',
       container: '.mkv',
       handBrakeMode: false,
       FFmpegMode: true,

--- a/tests/Community/Tdarr_Plugin_076b_re_order_subtitle_streams.js
+++ b/tests/Community/Tdarr_Plugin_076b_re_order_subtitle_streams.js
@@ -49,7 +49,7 @@ const tests = [
     },
     output: {
       processFile: true,
-      preset: ', -c copy  -map 0:v -map 0:a  -map 0:s:1 -disposition:s:0 default -map 0:s:0  -disposition:s:1 0  -map 0:d? ',
+      preset: ', -c copy  -map 0:v -map 0:a  -map 0:s:1 -disposition:s:0 default -map 0:s:0  -disposition:s:1 0  -map 0:d? -map 0:t? ',
       container: '.mkv',
       handBrakeMode: false,
       FFmpegMode: true,


### PR DESCRIPTION
Adds `-map 0:t? ` in Tdarr_Plugin_076a_re_order_audio_streams and Tdarr_Plugin_076b_re_order_subtitle_streams to ensure attachments are mapped when processing files. 
Current behavior leaves attachments unmapped, leading to missing fonts when processing files with ASS/SSA subtitles.
Fixes #792 