### PR TITLE
Use correct stream for calculating video bitrate

### DIFF
--- a/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandSetVideoBitrate/1.0.0/index.js
+++ b/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandSetVideoBitrate/1.0.0/index.js
@@ -122,14 +122,14 @@ var plugin = function (args) {
     var fallbackBitrate = String(args.inputs.fallbackBitrate);
     var bitrate = String(args.inputs.bitrate);
     args.variables.ffmpegCommand.streams.forEach(function (stream) {
-        var _a, _b, _c, _d;
+        var _a, _b, _c;
         if (stream.codec_type === 'video') {
             var ffType = (0, fileUtils_1.getFfType)(stream.codec_type);
             if (useInputBitrate) {
                 args.jobLog('Attempting to use % of input bitrate as output bitrate');
                 // check if input bitrate is available
-                var mediainfoIndex = stream.index + 1;
-                var inputBitrate = (_d = (_c = (_b = (_a = args === null || args === void 0 ? void 0 : args.inputFileObj) === null || _a === void 0 ? void 0 : _a.mediaInfo) === null || _b === void 0 ? void 0 : _b.track) === null || _c === void 0 ? void 0 : _c[mediainfoIndex]) === null || _d === void 0 ? void 0 : _d.BitRate;
+                var tracks = (_b = (_a = args === null || args === void 0 ? void 0 : args.inputFileObj) === null || _a === void 0 ? void 0 : _a.mediaInfo) === null || _b === void 0 ? void 0 : _b.track;
+                var inputBitrate = (_c = tracks === null || tracks === void 0 ? void 0 : tracks.find(function (x) { return x.StreamOrder === stream.index.toString(); })) === null || _c === void 0 ? void 0 : _c.BitRate;
                 if (inputBitrate) {
                     args.jobLog("Found input bitrate: ".concat(inputBitrate));
                     // @ts-expect-error type

--- a/FlowPluginsTs/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandSetVideoBitrate/1.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandSetVideoBitrate/1.0.0/index.ts
@@ -134,9 +134,9 @@ const plugin = (args: IpluginInputArgs): IpluginOutputArgs => {
       if (useInputBitrate) {
         args.jobLog('Attempting to use % of input bitrate as output bitrate');
         // check if input bitrate is available
-        const mediainfoIndex = stream.index + 1;
+        const tracks = args?.inputFileObj?.mediaInfo?.track;
+        let inputBitrate = tracks?.find((x) => x.StreamOrder === stream.index.toString())?.BitRate;
 
-        let inputBitrate = args?.inputFileObj?.mediaInfo?.track?.[mediainfoIndex]?.BitRate;
         if (inputBitrate) {
           args.jobLog(`Found input bitrate: ${inputBitrate}`);
           // @ts-expect-error type

--- a/FlowPluginsTs/FlowHelpers/1.0.0/interfaces/synced/IFileObject.ts
+++ b/FlowPluginsTs/FlowHelpers/1.0.0/interfaces/synced/IFileObject.ts
@@ -121,6 +121,7 @@ export interface Imeta {
 export interface ImediaInfo {
   track?: [{
     '@type': string,
+    'StreamOrder': string,
     'UniqueID': string,
     'VideoCount': string,
     'AudioCount': string,


### PR DESCRIPTION
Tracks in mediaInfo are not in the same order as ffmpeg's streams Use StreamIndex to find the correct object instead

Fixes #801