### PR TITLE
Add Community Plugin: Remove Audio Tracks By Codec and Channels

### DIFF
--- a/Community/Tdarr_Plugin_jordy_Remove_Audio_By_Codec_Channels.js
+++ b/Community/Tdarr_Plugin_jordy_Remove_Audio_By_Codec_Channels.js
@@ -1,0 +1,208 @@
+const details = () => ({
+  id: 'Tdarr_Plugin_jordy_Remove_Audio_By_Codec_Channels',
+  Name: 'Remove Audio Tracks By Codec and Channels',
+  Type: 'Audio',
+  Operation: "Transcode",
+  Description: "This plugin will remove audio tracks from a file based on the codec, channel configuration, and language. It will only remove audio tracks that match the specified codec and channel configuration.\n\nFor example, if you specify 'aac' and '5.1', it will remove all audio tracks that are AAC and have 6 channels.\n\n",
+  Version: '1.0',
+  Tags: 'pre-processing,ffmpeg,audio only,configurable',
+  Link: "https://github.com/jordanlambrecht",
+  Inputs: [
+    {
+      name: 'codecs',
+      type: 'string',
+      defaultValue: 'aac',
+      inputUI: {
+        type: 'text',
+      },
+      tooltip: `Enter comma-separated list of audio codecs to remove.
+                        \\nExample:\\n
+                        aac
+                        
+                        \\nExample:\\n
+                        ac3,opus
+                        
+                        \\nExample:\\n
+                        aac,eac3,ac3`,
+    },
+    {
+      name: 'channels',
+      type: 'string',
+      defaultValue: '5.1',
+      inputUI: {
+        type: 'dropdown',
+        options: [
+          'Any',
+          '1',     // Mono
+          '2',     // Stereo
+          '5.1',   // 6 channels
+          '7.1'    // 8 channels
+        ],
+      },
+      tooltip: `Select the channel configuration to filter.
+                        "Any" will remove matching codecs regardless of channel count.
+                        \\nExample:\\n
+                        5.1`,
+    },
+    {
+      name: 'languages',
+      type: 'string',
+      defaultValue: '',
+      inputUI: {
+        type: 'text',
+      },
+      tooltip: `Enter comma-separated list of language tags to filter (leave blank to ignore language). Any languages listed will be removed.
+                        Must follow ISO-639-2 3 letter format. https://en.wikipedia.org/wiki/List_of_ISO_639-2_codes
+                        \\nExample:\\n
+                        eng
+                        
+                        \\nExample:\\n
+                        jpn
+                        
+                        \\nExample:\\n
+                        eng,fre,ger`,
+    }   
+  ],
+});
+
+// eslint-disable-next-line no-unused-vars
+const plugin = (file, librarySettings, inputs, otherArguments) => {
+  const lib = require('../methods/lib')();
+  inputs = lib.loadDefaultValues(inputs, details);
+
+
+  const response = {
+    processFile: false,
+    preset: '',
+    container: `.${file.container}`,
+    handBrakeMode: false,
+    FFmpegMode: true,
+    reQueueAfter: false,
+    infoLog: '',
+  };
+  
+    // Check if file is a video. If it isn't then exit plugin.
+    if (file.fileMedium !== 'video') {
+      response.processFile = false;
+      response.infoLog += '☒File is not a video. \n';
+      return response;
+    }
+
+  response.infoLog += ""
+  // Parse inputs - make sure to handle all potential input formats
+  const codecsToRemove = ((inputs.codecs || '').toLowerCase().split(',')
+  .map(codec => codec.trim())
+  .filter(codec => codec !== ''));
+
+
+  // Check if codecs input is empty (after processing)
+  if (codecsToRemove.length === 0) {
+    response.infoLog += '⚠️ No codecs specified for removal. Plugin will not process the file.\n';
+    response.processFile = false;
+    return response;
+  }
+
+
+  const channelFilter = inputs.channels || 'Any';
+
+  // Parse language tags as a comma-separated list (same handling as codecs)
+  const languagesToFilter = (inputs.languages || '').toLowerCase().split(',').map(lang => lang.trim()).filter(lang => lang !== '');
+
+  
+  
+  // Log input parameters for debugging
+  response.infoLog += `\n🔵  Parameters: Codecs=${codecsToRemove.join(',')}, Channels=${channelFilter}, Languages=${languagesToFilter.length > 0 ? languagesToFilter.join(',') : 'any'}\n`;
+  
+  // Map channel selection to actual channel count
+  const channelMap = {
+    'Any': null,  // null means any channel count
+    '1': 1,       // Mono
+    '2': 2,       // Stereo
+    '5.1': 6,     // 5.1 surround
+    '7.1': 8      // 7.1 surround
+  };
+  
+  const targetChannelCount = channelMap[channelFilter];
+  
+  let ffmpegCommandInsert = '';
+  let audioIdx = 0;
+  let tracksToRemove = 0;
+  let convert = false;
+  
+  // Get audio streams
+  const audioStreams = file.ffProbeData.streams.filter(
+    stream => stream.codec_type && stream.codec_type.toLowerCase() === 'audio'
+  );
+  
+  response.infoLog += `\n🔵 Found ${audioStreams.length} audio streams in file\n`;
+  
+  // Loop through all streams
+  for (let i = 0; i < file.ffProbeData.streams.length; i++) {
+    const stream = file.ffProbeData.streams[i];
+    
+    // Check if stream is audio
+    if (stream.codec_type && stream.codec_type.toLowerCase() === 'audio') {
+      // Get current stream properties
+      const currentCodec = stream.codec_name ? stream.codec_name.toLowerCase() : '';
+      const currentChannels = stream.channels || 0;
+      
+      // Get language
+      let currentLanguage = '';
+      try {
+        if (stream.tags && stream.tags.language) {
+          currentLanguage = stream.tags.language.toLowerCase();
+        }
+      } catch (err) {
+        // Language tag doesn't exist
+      }
+      
+      // Debug info
+      response.infoLog += `🔵 Audio track ${audioIdx}: codec=${currentCodec}, channels=${currentChannels}, language=${currentLanguage || 'undefined'}\n`;
+      
+      // Check if stream matches our removal criteria
+      const codecMatches = codecsToRemove.includes(currentCodec);
+      const channelMatches = targetChannelCount === null || currentChannels === targetChannelCount;
+
+      // Language matching: if language list is empty, match any language
+      // Otherwise, check if the current language is in our filter list
+      const languageMatches = languagesToFilter.length === 0 || 
+                            (currentLanguage && languagesToFilter.includes(currentLanguage));
+      
+      if (codecMatches && channelMatches && languageMatches) {
+        // Prepare to remove this stream
+        ffmpegCommandInsert += `-map -0:a:${audioIdx} `;
+        
+        // Log details about the track being removed
+        response.infoLog += `☒ Marking for removal: audio track ${audioIdx}\n`;
+        
+        tracksToRemove++;
+        convert = true;
+      }
+      
+      // Increment audio index counter
+      audioIdx++;
+    }
+  }
+  
+  // Safety check - make sure we don't remove all audio tracks
+  if (tracksToRemove >= audioStreams.length) {
+    response.infoLog += '\n⚠️ Cancelling plugin - all audio tracks would be removed\n';
+    response.processFile = false;
+    return response;
+  }
+  
+  // Process file if tracks need to be removed
+
+  if (convert) {
+    response.processFile = true;
+    response.preset = `, -map 0 ${ffmpegCommandInsert} -c copy`;
+    response.infoLog += `✅ Will remove ${tracksToRemove} audio track(s)\n`;
+  } else {
+    response.infoLog += '✅ No matching audio tracks to remove\n';
+  }
+  
+  return response;
+};
+
+module.exports.details = details;
+module.exports.plugin = plugin;

--- a/tests/Community/Tdarr_Plugin_jordy_Remove_Audio_By_Codec_Channels.js
+++ b/tests/Community/Tdarr_Plugin_jordy_Remove_Audio_By_Codec_Channels.js
@@ -1,0 +1,173 @@
+/* eslint max-len: 0 */
+const _ = require('lodash');
+const run = require('../helpers/run');
+
+const tests = [
+  // Test 1: No modification needed - file has no matching tracks
+  {
+    input: {
+      file: _.cloneDeep(require('../sampleData/media/sampleH264_1.json')),
+      librarySettings: {},
+      inputs: {
+        codecs: 'aac',
+        channels: '5.1',
+        languages: 'jpn'
+      },
+      otherArguments: {},
+    },
+    output: {
+      processFile: false,
+      container: '.mp4',
+      handBrakeMode: false,
+      FFmpegMode: true,
+      reQueueAfter: false,
+      infoLog: expect.stringContaining('No matching audio tracks to remove'),
+    },
+  },
+  
+  // Test 2: Remove AAC 5.1 tracks (any language)
+  {
+    input: {
+      file: _.cloneDeep(require('../sampleData/media/sampleH264_2.json')),
+      librarySettings: {},
+      inputs: {
+        codecs: 'aac',
+        channels: '5.1',
+        languages: ''
+      },
+      otherArguments: {},
+    },
+    output: {
+      processFile: true,
+      preset: expect.stringContaining('-map 0 -map -0:a:'),
+      container: '.mkv',
+      handBrakeMode: false,
+      FFmpegMode: true,
+      reQueueAfter: false,
+      infoLog: expect.stringContaining('Marking for removal'),
+    },
+  },
+  
+  // Test 3: Remove AAC tracks with Japanese language
+  {
+    input: {
+      file: (() => {
+        const file = _.cloneDeep(require('../sampleData/media/sampleH264_2.json'));
+        // Modify a stream to have Japanese language
+        if (file.ffProbeData.streams[3].tags) {
+          file.ffProbeData.streams[3].tags.language = 'jpn';
+        }
+        return file;
+      })(),
+      librarySettings: {},
+      inputs: {
+        codecs: 'aac',
+        channels: 'Any',
+        languages: 'jpn'
+      },
+      otherArguments: {},
+    },
+    output: {
+      processFile: true,
+      preset: expect.stringContaining('-map 0 -map -0:a:3'),
+      container: '.mkv',
+      handBrakeMode: false,
+      FFmpegMode: true,
+      reQueueAfter: false,
+      infoLog: expect.stringContaining('Marking for removal'),
+    },
+  },
+  
+  // Test 4: Multiple codecs and languages
+  {
+    input: {
+      file: (() => {
+        const file = _.cloneDeep(require('../sampleData/media/sampleH264_2.json'));
+        // Add variety of audio tracks with different codecs and languages
+        if (file.ffProbeData.streams[2].tags) {
+          file.ffProbeData.streams[2].codec_name = 'ac3';
+          file.ffProbeData.streams[2].tags.language = 'eng';
+        }
+        if (file.ffProbeData.streams[3].tags) {
+          file.ffProbeData.streams[3].codec_name = 'opus';
+          file.ffProbeData.streams[3].tags.language = 'kor';
+        }
+        return file;
+      })(),
+      librarySettings: {},
+      inputs: {
+        codecs: 'ac3,opus',
+        channels: '2',
+        languages: 'eng,kor'
+      },
+      otherArguments: {},
+    },
+    output: {
+      processFile: true,
+      preset: expect.stringContaining('-map 0 -map -0:a:1 -map -0:a:2'),
+      container: '.mkv',
+      handBrakeMode: false,
+      FFmpegMode: true,
+      reQueueAfter: false,
+      infoLog: expect.stringContaining('Marking for removal'),
+    },
+  },
+  
+  // Test 5: Empty codecs input
+  {
+    input: {
+      file: _.cloneDeep(require('../sampleData/media/sampleH264_1.json')),
+      librarySettings: {},
+      inputs: {
+        codecs: '',
+        channels: '5.1',
+        languages: 'eng'
+      },
+      otherArguments: {},
+    },
+    output: {
+      processFile: false,
+      container: '.mp4',
+      handBrakeMode: false,
+      FFmpegMode: true,
+      reQueueAfter: false,
+      infoLog: expect.stringContaining('No codecs specified for removal'),
+    },
+  },
+  
+  // Test 6: Safety check - would remove all audio
+  {
+    input: {
+      file: (() => {
+        const file = _.cloneDeep(require('../sampleData/media/sampleH264_1.json'));
+        // Make all audio tracks match our removal criteria
+        file.ffProbeData.streams.forEach(stream => {
+          if (stream.codec_type && stream.codec_type.toLowerCase() === 'audio') {
+            stream.codec_name = 'aac';
+            stream.channels = 2;
+            if (!stream.tags) stream.tags = {};
+            stream.tags.language = 'eng';
+          }
+        });
+        return file;
+      })(),
+      librarySettings: {},
+      inputs: {
+        codecs: 'aac',
+        channels: '2',
+        languages: 'eng'
+      },
+      otherArguments: {},
+    },
+    output: {
+      processFile: false,
+      container: '.mp4',
+      handBrakeMode: false,
+      FFmpegMode: true,
+      reQueueAfter: false,
+      infoLog: expect.stringContaining('Cancelling plugin - all audio tracks would be removed'),
+    },
+  },
+];
+
+void run(tests);


### PR DESCRIPTION
This plugin will specifically remove streams that match both an audio channel and a codec name. It saves a lot of headache if a user has multiple audio codecs on the same channel count (i.e aac 5.1 and ac3 5.1)

**Example 1:** Removing 5.1 AAC Audio Tracks
A user wants to remove all 5.1 channel AAC audio tracks from their media files while preserving other audio tracks. They would set the plugin parameters to:

Codecs: aac
Channels: 5.1
Languages: (empty)

This helps users who want to save space by removing high-bandwidth AAC surround tracks when they only need stereo audio.

**Example 2:** Removing Multiple Codec Types with Language Filtering
A user with a multilingual library wants to remove both AC3 and EAC3 stereo tracks that are in Japanese, keeping only their preferred audio formats. They would configure:

Codecs: ac3,eac3
Channels: 2
Languages: jpn

This allows for targeted audio track cleanup based on both technical and language preferences.