### PR TITLE
Take into account Dolby Vision Profiles

### DIFF
--- a/FlowPlugins/CommunityFlowPlugins/video/checkHdr/1.0.0/index.js
+++ b/FlowPlugins/CommunityFlowPlugins/video/checkHdr/1.0.0/index.js
@@ -37,10 +37,13 @@ var plugin = function (args) {
     if (Array.isArray((_b = (_a = args === null || args === void 0 ? void 0 : args.inputFileObj) === null || _a === void 0 ? void 0 : _a.ffProbeData) === null || _b === void 0 ? void 0 : _b.streams)) {
         for (var i = 0; i < args.inputFileObj.ffProbeData.streams.length; i += 1) {
             var stream = args.inputFileObj.ffProbeData.streams[i];
-            if (stream.codec_type === 'video'
-                && stream.color_transfer === 'smpte2084'
-                && stream.color_primaries === 'bt2020'
-                && stream.color_range === 'tv') {
+            if ( 
+                (stream.codec_type === 'video' && stream.color_transfer === 'smpte2084' && stream.color_primaries === 'bt2020' && stream.color_range === 'tv')  
+                || (stream.codec_type === 'video' && String(stream.codec_tag_string).includes("dvhe") ) 
+                || (stream.codec_type === 'video' && String(stream.codec_tag_string).includes("dvav") ) 
+                || (stream.codec_type === 'video' && String(stream.codec_tag_string).includes("dav1") ) 
+                || (stream.codec_type === 'video' && String(stream.codec_tag_string).includes("dvh11") ) 
+            ) { 
                 isHdr = true;
             }
         }

--- a/FlowPlugins/CommunityFlowPlugins/video/checkHdr/1.0.0/index.js
+++ b/FlowPlugins/CommunityFlowPlugins/video/checkHdr/1.0.0/index.js
@@ -29,7 +29,7 @@ var details = function () { return ({
 exports.details = details;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 var plugin = function (args) {
-    var _a, _b;
+    var _a, _b, _c, _d, _e, _f;
     var lib = require('../../../../../methods/lib')();
     // eslint-disable-next-line @typescript-eslint/no-unused-vars,no-param-reassign
     args.inputs = lib.loadDefaultValues(args.inputs, details);
@@ -37,13 +37,14 @@ var plugin = function (args) {
     if (Array.isArray((_b = (_a = args === null || args === void 0 ? void 0 : args.inputFileObj) === null || _a === void 0 ? void 0 : _a.ffProbeData) === null || _b === void 0 ? void 0 : _b.streams)) {
         for (var i = 0; i < args.inputFileObj.ffProbeData.streams.length; i += 1) {
             var stream = args.inputFileObj.ffProbeData.streams[i];
-            if ( 
-                (stream.codec_type === 'video' && stream.color_transfer === 'smpte2084' && stream.color_primaries === 'bt2020' && stream.color_range === 'tv')  
-                || (stream.codec_type === 'video' && String(stream.codec_tag_string).includes("dvhe") ) 
-                || (stream.codec_type === 'video' && String(stream.codec_tag_string).includes("dvav") ) 
-                || (stream.codec_type === 'video' && String(stream.codec_tag_string).includes("dav1") ) 
-                || (stream.codec_type === 'video' && String(stream.codec_tag_string).includes("dvh11") ) 
-            ) { 
+            if (stream.codec_type === 'video'
+                && ((stream.color_transfer === 'smpte2084'
+                    && stream.color_primaries === 'bt2020'
+                    && stream.color_range === 'tv')
+                    || ((_c = stream.codec_tag_string) === null || _c === void 0 ? void 0 : _c.includes('dvhe'))
+                    || ((_d = stream.codec_tag_string) === null || _d === void 0 ? void 0 : _d.includes('dvav'))
+                    || ((_e = stream.codec_tag_string) === null || _e === void 0 ? void 0 : _e.includes('dav1'))
+                    || ((_f = stream.codec_tag_string) === null || _f === void 0 ? void 0 : _f.includes('dvh11')))) {
                 isHdr = true;
             }
         }

--- a/FlowPluginsTs/CommunityFlowPlugins/file/checkFileNameIncludes/2.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/file/checkFileNameIncludes/2.0.0/index.ts
@@ -73,7 +73,7 @@ const plugin = (args: IpluginInputArgs): IpluginOutputArgs => {
   const { includeFileDirectory } = args.inputs;
 
   const fileName = includeFileDirectory
-    ? args.inputFileObj._id
+    ? `${String(args.originalLibraryFile.meta.Directory)}${getFileName(args.inputFileObj._id)}.${getContainer(args.inputFileObj._id)}`
     : `${getFileName(args.inputFileObj._id)}.${getContainer(args.inputFileObj._id)}`;
 
   const searchCriteriasArray = terms.trim().split(',')

--- a/FlowPluginsTs/CommunityFlowPlugins/video/checkHdr/1.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/video/checkHdr/1.0.0/index.ts
@@ -42,11 +42,17 @@ const plugin = (args: IpluginInputArgs): IpluginOutputArgs => {
     for (let i = 0; i < args.inputFileObj.ffProbeData.streams.length; i += 1) {
       const stream = args.inputFileObj.ffProbeData.streams[i];
       if (
-        stream.codec_type === 'video'
-        && stream.color_transfer === 'smpte2084'
-        && stream.color_primaries === 'bt2020'
-        && stream.color_range === 'tv'
-      ) {
+            stream.codec_type === 'video' &&
+            (
+                (stream.color_transfer === 'smpte2084' &&
+                    stream.color_primaries === 'bt2020' &&
+                    stream.color_range === 'tv') ||
+                (stream.codec_tag_string?.includes("dvhe")) ||
+                (stream.codec_tag_string?.includes("dvav")) ||
+                (stream.codec_tag_string?.includes("dav1")) ||
+                (stream.codec_tag_string?.includes("dvh11"))
+            )
+        ){
         isHdr = true;
       }
     }

--- a/FlowPluginsTs/CommunityFlowPlugins/video/checkHdr/1.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/video/checkHdr/1.0.0/index.ts
@@ -42,17 +42,17 @@ const plugin = (args: IpluginInputArgs): IpluginOutputArgs => {
     for (let i = 0; i < args.inputFileObj.ffProbeData.streams.length; i += 1) {
       const stream = args.inputFileObj.ffProbeData.streams[i];
       if (
-            stream.codec_type === 'video' &&
-            (
-                (stream.color_transfer === 'smpte2084' &&
-                    stream.color_primaries === 'bt2020' &&
-                    stream.color_range === 'tv') ||
-                (stream.codec_tag_string?.includes("dvhe")) ||
-                (stream.codec_tag_string?.includes("dvav")) ||
-                (stream.codec_tag_string?.includes("dav1")) ||
-                (stream.codec_tag_string?.includes("dvh11"))
+        stream.codec_type === 'video'
+            && (
+              (stream.color_transfer === 'smpte2084'
+                    && stream.color_primaries === 'bt2020'
+                    && stream.color_range === 'tv')
+                || (stream.codec_tag_string?.includes('dvhe'))
+                || (stream.codec_tag_string?.includes('dvav'))
+                || (stream.codec_tag_string?.includes('dav1'))
+                || (stream.codec_tag_string?.includes('dvh11'))
             )
-        ){
+      ) {
         isHdr = true;
       }
     }


### PR DESCRIPTION
Certain Dolby Vision profiles are not detected by `CheckHDR` Plugin; a check is needed of `stream.codec_tag_string` for specific Dolby codec tags as specified in the Dolby Specification:

https://professionalsupport.dolby.com/s/article/What-is-Dolby-Vision-Profile?language=en_US