### PR TITLE
Flow plugin apply radarr or sonarr naming policy v1.0.0 - Fix #738 et #826

### DIFF
--- a/FlowPlugins/CommunityFlowPlugins/tools/applyRadarrOrSonarrNamingPolicy/1.0.0/index.js
+++ b/FlowPlugins/CommunityFlowPlugins/tools/applyRadarrOrSonarrNamingPolicy/1.0.0/index.js
@@ -236,7 +236,9 @@ var plugin = function (args) { return __awaiter(void 0, void 0, void 0, function
                             buildPreviewRenameResquestUrl: function (fInfo) { return "".concat(arrHost, "/api/v3/rename?seriesId=").concat(fInfo.id, "&seasonNumber=").concat(fInfo.seasonNumber); },
                             getFileToRenameFromPreviewRenameResponse: function (previewRenameResponse, fInfo) {
                                 var _a;
-                                return (_a = previewRenameResponse.data) === null || _a === void 0 ? void 0 : _a.find(function (episodeFile) { var _a; return ((_a = episodeFile.episodeNumbers) === null || _a === void 0 ? void 0 : _a.at(0)) === fInfo.episodeNumber; });
+                                var fileToRename = (_a = previewRenameResponse.data) === null || _a === void 0 ? void 0 : _a.find(function (episodeFile) { var _a; return ((_a = episodeFile.episodeNumbers) === null || _a === void 0 ? void 0 : _a.at(0)) === fInfo.episodeNumber; });
+                                return fileToRename
+                                    ? __assign(__assign({}, fileToRename), { newPath: fileToRename.newPath.split(/[\\/]/).pop() || fileToRename.newPath }) : undefined;
                             },
                         },
                     };

--- a/FlowPluginsTs/CommunityFlowPlugins/tools/applyRadarrOrSonarrNamingPolicy/1.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/tools/applyRadarrOrSonarrNamingPolicy/1.0.0/index.ts
@@ -232,9 +232,13 @@ const plugin = async (args: IpluginInputArgs): Promise<IpluginOutputArgs> => {
           }),
         buildPreviewRenameResquestUrl:
           (fInfo) => `${arrHost}/api/v3/rename?seriesId=${fInfo.id}&seasonNumber=${fInfo.seasonNumber}`,
-        getFileToRenameFromPreviewRenameResponse:
-          (previewRenameResponse, fInfo) => previewRenameResponse.data
-            ?.find((episodeFile) => episodeFile.episodeNumbers?.at(0) === fInfo.episodeNumber),
+        getFileToRenameFromPreviewRenameResponse: (previewRenameResponse, fInfo) => {
+          const fileToRename = previewRenameResponse.data
+            ?.find((episodeFile) => episodeFile.episodeNumbers?.at(0) === fInfo.episodeNumber);
+          return fileToRename
+            ? { ...fileToRename, newPath: fileToRename.newPath.split(/[\\/]/).pop() || fileToRename.newPath }
+            : undefined;
+        },
       },
     };
 


### PR DESCRIPTION
Fixed issues (#738 & #826) that would happen when '\\' is used by Sonarr as a path separator instead of '/'.