### PR TITLE
Add AV1 hardware encoder support to checkNodeHardwareEncoder plugin

### DIFF
--- a/FlowPlugins/CommunityFlowPlugins/tools/checkNodeHardwareEncoder/1.0.0/index.js
+++ b/FlowPlugins/CommunityFlowPlugins/tools/checkNodeHardwareEncoder/1.0.0/index.js
@@ -9,8 +9,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 var __generator = (this && this.__generator) || function (thisArg, body) {
-    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
-    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g = Object.create((typeof Iterator === "function" ? Iterator : Object).prototype);
+    return g.next = verb(0), g["throw"] = verb(1), g["return"] = verb(2), typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
     function verb(n) { return function (v) { return step([n, v]); }; }
     function step(op) {
         if (f) throw new TypeError("Generator is already executing.");

--- a/FlowPlugins/CommunityFlowPlugins/tools/checkNodeHardwareEncoder/1.0.0/index.js
+++ b/FlowPlugins/CommunityFlowPlugins/tools/checkNodeHardwareEncoder/1.0.0/index.js
@@ -9,8 +9,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 var __generator = (this && this.__generator) || function (thisArg, body) {
-    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g = Object.create((typeof Iterator === "function" ? Iterator : Object).prototype);
-    return g.next = verb(0), g["throw"] = verb(1), g["return"] = verb(2), typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
     function verb(n) { return function (v) { return step([n, v]); }; }
     function step(op) {
         if (f) throw new TypeError("Generator is already executing.");
@@ -41,7 +41,7 @@ var hardwareUtils_1 = require("../../../../FlowHelpers/1.0.0/hardwareUtils");
 /* eslint no-plusplus: ["error", { "allowForLoopAfterthoughts": true }] */
 var details = function () { return ({
     name: 'Check Node Hardware Encoder',
-    description: "\n  Check if node hardware encoder is available. Can also be used to check for specific hardware.\n  For example:\n\n  hevc_nvenc = Nvidia\n  hevc_amf = AMD\n  hevc_vaapi = Intel\n  hevc_qsv = Intel\n  hevc_videotoolbox = Apple\n  ",
+    description: "\n  Check if node hardware encoder is available. Can also be used to check for specific hardware.\n  For example:\n\n  HEVC encoders:\n  hevc_nvenc = Nvidia\n  hevc_amf = AMD\n  hevc_vaapi = Intel\n  hevc_qsv = Intel\n  hevc_videotoolbox = Apple\n  \n  AV1 encoders:\n  av1_nvenc = Nvidia\n  av1_amf = AMD\n  av1_vaapi = Intel\n  av1_qsv = Intel\n  av1_videotoolbox = Apple\n  ",
     style: {
         borderColor: 'orange',
     },
@@ -66,6 +66,11 @@ var details = function () { return ({
                     'hevc_vaapi',
                     'hevc_qsv',
                     'hevc_videotoolbox',
+                    'av1_nvenc',
+                    'av1_amf',
+                    'av1_vaapi',
+                    'av1_qsv',
+                    'av1_videotoolbox',
                 ],
             },
             tooltip: 'Specify hardware (based on encoder) to check for',
@@ -85,7 +90,7 @@ var details = function () { return ({
 exports.details = details;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 var plugin = function (args) { return __awaiter(void 0, void 0, void 0, function () {
-    var lib, hardwareEncoder, encoderProperties, nodeHasHardware;
+    var lib, hardwareEncoder, encoderString, targetCodec, encoderProperties, nodeHasHardware;
     return __generator(this, function (_a) {
         switch (_a.label) {
             case 0:
@@ -93,16 +98,18 @@ var plugin = function (args) { return __awaiter(void 0, void 0, void 0, function
                 // eslint-disable-next-line @typescript-eslint/no-unused-vars,no-param-reassign
                 args.inputs = lib.loadDefaultValues(args.inputs, details);
                 hardwareEncoder = args.inputs.hardwareEncoder;
+                encoderString = String(hardwareEncoder);
+                targetCodec = encoderString.startsWith('av1_') ? 'av1' : 'hevc';
                 return [4 /*yield*/, (0, hardwareUtils_1.getEncoder)({
-                        targetCodec: 'hevc',
+                        targetCodec: targetCodec,
                         hardwareEncoding: true,
                         hardwareType: 'auto',
                         args: args,
                     })];
             case 1:
                 encoderProperties = _a.sent();
-                nodeHasHardware = encoderProperties.enabledDevices.some(function (row) { return row.encoder === hardwareEncoder; });
-                args.jobLog("Node has hardwareEncoder ".concat(hardwareEncoder, ": ").concat(nodeHasHardware));
+                nodeHasHardware = encoderProperties.enabledDevices.some(function (row) { return row.encoder === encoderString; });
+                args.jobLog("Node has hardwareEncoder ".concat(encoderString, ": ").concat(nodeHasHardware));
                 return [2 /*return*/, {
                         outputFileObj: args.inputFileObj,
                         outputNumber: nodeHasHardware ? 1 : 2,

--- a/FlowPluginsTs/CommunityFlowPlugins/tools/checkNodeHardwareEncoder/1.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/tools/checkNodeHardwareEncoder/1.0.0/index.ts
@@ -12,11 +12,19 @@ const details = (): IpluginDetails => ({
   Check if node hardware encoder is available. Can also be used to check for specific hardware.
   For example:
 
+  HEVC encoders:
   hevc_nvenc = Nvidia
   hevc_amf = AMD
   hevc_vaapi = Intel
   hevc_qsv = Intel
   hevc_videotoolbox = Apple
+  
+  AV1 encoders:
+  av1_nvenc = Nvidia
+  av1_amf = AMD
+  av1_vaapi = Intel
+  av1_qsv = Intel
+  av1_videotoolbox = Apple
   `,
   style: {
     borderColor: 'orange',
@@ -42,6 +50,11 @@ const details = (): IpluginDetails => ({
           'hevc_vaapi',
           'hevc_qsv',
           'hevc_videotoolbox',
+          'av1_nvenc',
+          'av1_amf',
+          'av1_vaapi',
+          'av1_qsv',
+          'av1_videotoolbox',
         ],
       },
       tooltip: 'Specify hardware (based on encoder) to check for',
@@ -67,17 +80,23 @@ const plugin = async (args: IpluginInputArgs): Promise<IpluginOutputArgs> => {
 
   const { hardwareEncoder } = args.inputs;
 
+  // Ensure hardwareEncoder is a string
+  const encoderString = String(hardwareEncoder);
+
+  // Determine target codec based on encoder selection
+  const targetCodec = encoderString.startsWith('av1_') ? 'av1' : 'hevc';
+
   // eslint-disable-next-line no-await-in-loop
   const encoderProperties = await getEncoder({
-    targetCodec: 'hevc',
+    targetCodec,
     hardwareEncoding: true,
     hardwareType: 'auto',
     args,
   });
 
-  const nodeHasHardware = encoderProperties.enabledDevices.some((row) => row.encoder === hardwareEncoder);
+  const nodeHasHardware = encoderProperties.enabledDevices.some((row) => row.encoder === encoderString);
 
-  args.jobLog(`Node has hardwareEncoder ${hardwareEncoder}: ${nodeHasHardware}`);
+  args.jobLog(`Node has hardwareEncoder ${encoderString}: ${nodeHasHardware}`);
 
   return {
     outputFileObj: args.inputFileObj,


### PR DESCRIPTION
- Add av1_nvenc, av1_amf, av1_vaapi, av1_qsv, av1_videotoolbox to dropdown options
- Update plugin logic to dynamically determine target codec (hevc/av1) based on encoder selection
- Update description with AV1 encoder examples for different hardware vendors
- Improve type safety by ensuring hardwareEncoder is treated as string