### PR TITLE
fix(flows): ffmpegCommandSetVideoEncoder should not process mjpeg codec

### DIFF
--- a/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandSetVideoEncoder/1.0.0/index.js
+++ b/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandSetVideoEncoder/1.0.0/index.js
@@ -228,7 +228,7 @@ var plugin = function (args) { return __awaiter(void 0, void 0, void 0, function
             case 1:
                 if (!(i < args.variables.ffmpegCommand.streams.length)) return [3 /*break*/, 4];
                 stream = args.variables.ffmpegCommand.streams[i];
-                if (!(stream.codec_type === 'video')) return [3 /*break*/, 3];
+                if (!(stream.codec_type === 'video' && stream.codec_name !== 'mjpeg')) return [3 /*break*/, 3];
                 targetCodec = String(args.inputs.outputCodec);
                 _a = args.inputs, ffmpegPresetEnabled = _a.ffmpegPresetEnabled, ffmpegQualityEnabled = _a.ffmpegQualityEnabled;
                 ffmpegPreset = String(args.inputs.ffmpegPreset);

--- a/FlowPluginsTs/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandSetVideoEncoder/1.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandSetVideoEncoder/1.0.0/index.ts
@@ -192,7 +192,7 @@ const plugin = async (args: IpluginInputArgs): Promise<IpluginOutputArgs> => {
   for (let i = 0; i < args.variables.ffmpegCommand.streams.length; i += 1) {
     const stream = args.variables.ffmpegCommand.streams[i];
 
-    if (stream.codec_type === 'video') {
+    if (stream.codec_type === 'video' && stream.codec_name !== 'mjpeg') {
       const targetCodec = String(args.inputs.outputCodec);
       const { ffmpegPresetEnabled, ffmpegQualityEnabled } = args.inputs;
       const ffmpegPreset = String(args.inputs.ffmpegPreset);

--- a/FlowPluginsTs/FlowHelpers/1.0.0/fileUtils.ts
+++ b/FlowPluginsTs/FlowHelpers/1.0.0/fileUtils.ts
@@ -172,7 +172,7 @@ export const hashFile = (filePath: string, algorithm = 'sha256'): Promise<string
     const stream = fs.createReadStream(filePath);
 
     stream.on('data', (data) => {
-      hash.update(data);
+      hash.update(data as Buffer);
     });
 
     stream.on('end', () => {

--- a/FlowPluginsTs/FlowHelpers/1.0.0/fileUtils.ts
+++ b/FlowPluginsTs/FlowHelpers/1.0.0/fileUtils.ts
@@ -172,7 +172,7 @@ export const hashFile = (filePath: string, algorithm = 'sha256'): Promise<string
     const stream = fs.createReadStream(filePath);
 
     stream.on('data', (data) => {
-      hash.update(data as Buffer);
+      hash.update(data as string | NodeJS.ArrayBufferView);
     });
 
     stream.on('end', () => {

--- a/tests/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandSetVideoEncoder/1.0.0/index.test.ts
+++ b/tests/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandSetVideoEncoder/1.0.0/index.test.ts
@@ -358,6 +358,27 @@ describe('ffmpegCommandSetVideoEncoder Plugin', () => {
       expect(videoStream2.outputArgs.length).toBeGreaterThan(0);
     });
 
+    it('should not handle video stream with mjpeg codec_name', async () => {
+      baseArgs.variables.ffmpegCommand.streams.push({
+        index: 2,
+        codec_name: 'mjpeg',
+        codec_type: 'video',
+        removed: false,
+        forceEncoding: false,
+        inputArgs: [],
+        outputArgs: [],
+        mapArgs: ['-map', '0:2'],
+      });
+
+      const result = await plugin(baseArgs);
+
+      // Only the first stream should be processed
+      const videoStream1 = result.variables.ffmpegCommand.streams[0];
+      const videoStream2 = result.variables.ffmpegCommand.streams[2];
+      expect(videoStream1.outputArgs.length).toBeGreaterThan(0);
+      expect(videoStream2.outputArgs.length).toBe(0);
+    });
+
     it('should handle files with only audio streams', async () => {
       // Remove video stream, keep only audio
       baseArgs.variables.ffmpegCommand.streams = [

--- a/tests/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandSetVideoEncoder/1.0.0/index.test.ts
+++ b/tests/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandSetVideoEncoder/1.0.0/index.test.ts
@@ -358,7 +358,7 @@ describe('ffmpegCommandSetVideoEncoder Plugin', () => {
       expect(videoStream2.outputArgs.length).toBeGreaterThan(0);
     });
 
-    it('should not handle video stream with mjpeg codec_name', async () => {
+    it('should not handle video stream with mjpeg codec_name in', async () => {
       baseArgs.variables.ffmpegCommand.streams.push({
         index: 2,
         codec_name: 'mjpeg',


### PR DESCRIPTION
This fixes problem that causes ffmpeg command to run indefinitely
because mjpeg codec can't be transcoded (at least with my hardware)
