### PR TITLE
updated Tdarr_Plugin_a9hd_FFMPEG_Transcode_Specific_Audio_Stream_Codecs

### DIFF
--- a/Community/Tdarr_Plugin_a9hd_FFMPEG_Transcode_Specific_Audio_Stream_Codecs.js
+++ b/Community/Tdarr_Plugin_a9hd_FFMPEG_Transcode_Specific_Audio_Stream_Codecs.js
@@ -1,12 +1,12 @@
 /* eslint-disable */
 const details = () => {
   return {
-    id: "Tdarr_Plugin_a9hd_FFMPEG_Transcode_Specific_Audio_Stream_Codecs",
+    id: "Filter_transcode_audio_tracks_by_codec_and_channel_count",
     Stage: "Pre-processing",
-    Name: "Transcode Specific Audio Stream Codecs",
+    Name: "Filter Transcode audio tracks by codec",
     Type: "Audio",
     Operation: "Transcode",
-    Description: `[Contains built-in filter] Transcode audio streams with specific codecs into another codec.  \n\n`,
+    Description: `[Contains built-in filter] based on Tdarr_Plugin_a9hd_FFMPEG_Transcode_Specific_Audio_Stream_Codecs but allows for any kind of bitrate argument`,
     Version: "1.00",
     Tags: "pre-processing,audio only,ffmpeg,configurable",
     Inputs: [
@@ -37,7 +37,7 @@ const details = () => {
         \\n eac3
         \\n dts
         \\n flac
-        \\n mp2
+        \\n libfdk_aac
         \\n mp3
         \\n truehd
         \\nExample:\\n
@@ -45,19 +45,70 @@ const details = () => {
  
         `,
       },
-      {
-        name: "bitrate",
+	  {
+        name: "encoder",
         type: 'string',
         defaultValue: '',
         inputUI: {
           type: 'text',
         },
+        tooltip: `(optional) Specifiy the encoder to use for the transcode, codec parameter will be used when this is empty 
+		example: for aac you can input 'libfdk_aac' or 'aac_at'
+		for mp3 'libmp3lame'
+		
+		typically when there is only 1 encoder, the encoder name is the same as the codec name
+        `,
+      },
+    {
+      name: 'transcodeSelf',
+      type: 'boolean',
+      defaultValue: false,
+      inputUI: {
+        type: 'dropdown',
+        options: [
+          'true',
+          'false',
+        ],
+      },
+      tooltip:
+        'whether to encode audio that is already of the desired codec',
+    },
+      {
+        name: "bitrate",
+        type: 'string',
+        defaultValue: '-b:a 320k',
+        inputUI: {
+          type: 'text',
+        },
         tooltip: `Specify the transcoded audio bitrate (optional):
-        \\n 384k
-        \\n 640k
-        \\nExample:\\n
-        640k
+        \\n -b:a 320k
+        \\n -vbr 5
+		\\n any ffmpeg argument is welcome here
  
+        `,
+      },
+      {
+        name: "channels",
+        type: 'string',
+        defaultValue: 'All',
+        inputUI: {
+            type: 'dropdown',
+            options: [
+            'Stereo',
+            'MultiChannel',
+            'All',
+            ],
+        },
+        tooltip: `Specify which audio tracks, by channel count, will be transcoded, (The stereo option includes Mono as well)`,
+      },
+            {
+        name: "extra_args",
+        type: 'string',
+        defaultValue: '',
+        inputUI: {
+          type: 'text',
+        },
+        tooltip: ` extra arguments to pass onto ffmpeg
         `,
       },
     ],
@@ -88,38 +139,49 @@ const plugin = (file, librarySettings, inputs, otherArguments) => {
     return response;
   }
 
-  var encoder = inputs.codec;
-
-  if (encoder == "mp3") {
-    encoder = `libmp3lame`;
-  } else if (encoder == "dts") {
-    encoder = `dca`;
-  }
+  var encoder = inputs.encoder === null || inputs.encoder === undefined || inputs.encoder === "" ? inputs.codec : inputs.encoder;
+      response.infoLog += encoder + '\n';
 
   var codecs_to_transcode = inputs.codecs_to_transcode.split(",");
   var hasStreamsToTranscode = false;
 
   var ffmpegCommand = `, -c copy  -map 0:v `;
+    response.infoLog += inputs.channels + '\n';
 
   for (var i = 0; i < file.ffProbeData.streams.length; i++) {
+    response.infoLog += 'Stream ' + i + ': \n';
+    if(file.ffProbeData.streams[i].channels)
+    {
+        response.infoLog += 'Stream has ' + file.ffProbeData.streams[i].channels + ' channels \n';
+    }
+
     if (
       file.ffProbeData.streams[i].codec_type.toLowerCase() == "audio" &&
       file.ffProbeData.streams[i].codec_name &&
-      codecs_to_transcode.includes(
-        file.ffProbeData.streams[i].codec_name.toLowerCase()
-      )
+
+      ((codecs_to_transcode.includes(file.ffProbeData.streams[i].codec_name.toLowerCase()) || codecs_to_transcode.includes('*')) 
+      && (file.ffProbeData.streams[i].codec_name.toLowerCase() !== inputs.codec || inputs.transcodeSelf )) && 
+
+      (file.ffProbeData.streams[i].channels && 
+      ((inputs.channels === 'MultiChannel' && parseInt(file.ffProbeData.streams[i].channels) > 2) || 
+      (inputs.channels === 'Stereo' && parseInt(file.ffProbeData.streams[i].channels) <= 2) || 
+      (inputs.channels === 'All')))
     ) {
-      ffmpegCommand += `  -map 0:${i} -c:${i} ${encoder} `;
-      if (inputs.bitrate !== '') {
-        ffmpegCommand += `-b:a ${inputs.bitrate} `;
-      }
-      hasStreamsToTranscode = true;
-    } else if (file.ffProbeData.streams[i].codec_type.toLowerCase() == "audio") {
-      ffmpegCommand += `  -map 0:${i}`;
+        response.infoLog += 'stream ' + i + ' will be processed';
+        ffmpegCommand += `  -map 0:${i} -c:${i} ${encoder} `;
+        if (inputs.bitrate !== '') {
+            ffmpegCommand += `${inputs.bitrate} `;
+        }
+        hasStreamsToTranscode = true;
+    } 
+    else if 
+    (
+        file.ffProbeData.streams[i].codec_type.toLowerCase() == "audio") {
+        ffmpegCommand += `  -map 0:${i}`;
     }
   }
 
-  ffmpegCommand += ` -map 0:s? -map 0:d? -max_muxing_queue_size 9999`;
+  ffmpegCommand += ` -map 0:s? -map 0:d? -max_muxing_queue_size 9999 ` + inputs.extra_args;
 
   if (hasStreamsToTranscode == false) {
     response.processFile = false;


### PR DESCRIPTION
More fine grained control:

- Ability to specify the encoder of a codec
- Whether to transcode itself
- more specific bitrate input, for example some codecs take variable bitrate presets rather than simple -b
- ability to add generic extra arguments


Some caveats: 
- I did rename the plugin internally but didn't change the filename yet, so it's easier to compare
- I realize I didn't write a test for this update
- But I have been using this as a local plugin for a while and haven't had any issues so far

Feel free to use this as you please, personally I would just appreciate having this plugin be available without having to meddle with local installs.