### PR TITLE
feat(flows): add GPU acceleration to runHealthCheck plugin

### DIFF
--- a/FlowPlugins/CommunityFlowPlugins/video/runHealthCheck/1.0.0/index.js
+++ b/FlowPlugins/CommunityFlowPlugins/video/runHealthCheck/1.0.0/index.js
@@ -49,8 +49,15 @@ var getHwaccelArgs = function (gpuAcceleration, isGpuWorker, args) { return __aw
             case 0:
                 // CPU worker: never use GPU, regardless of selection
                 if (!isGpuWorker) {
-                    if (gpuAcceleration !== 'none' && gpuAcceleration !== 'auto') {
-                        args.jobLog("GPU acceleration '".concat(gpuAcceleration, "' requested but running on CPU worker, skipping"));
+                    if (gpuAcceleration === 'none') {
+                        args.jobLog('GPU acceleration: none selected, using CPU');
+                    }
+                    else if (gpuAcceleration === 'auto') {
+                        args.jobLog('GPU acceleration: auto selected but worker is CPU, using CPU');
+                    }
+                    else {
+                        args.jobLog("GPU acceleration: '".concat(gpuAcceleration, "' selected but worker is CPU")
+                            + ' — GPU is only available on transcode GPU workers, using CPU');
                     }
                     return [2 /*return*/, []];
                 }
@@ -62,12 +69,14 @@ var getHwaccelArgs = function (gpuAcceleration, isGpuWorker, args) { return __aw
                     case 'auto': return [3 /*break*/, 4];
                 }
                 return [3 /*break*/, 4];
-            case 1: return [2 /*return*/, []];
+            case 1:
+                args.jobLog('GPU acceleration: none selected, using CPU');
+                return [2 /*return*/, []];
             case 2:
-                args.jobLog('Using DXVA2 GPU acceleration');
+                args.jobLog('GPU acceleration: using DXVA2 (Windows hardware decoding)');
                 return [2 /*return*/, ['-hwaccel', 'dxva2', '-hwaccel_output_format', 'dxva2_vld']];
             case 3:
-                args.jobLog('Using D3D11VA GPU acceleration');
+                args.jobLog('GPU acceleration: using D3D11VA (Windows hardware decoding)');
                 return [2 /*return*/, ['-hwaccel', 'd3d11va', '-hwaccel_output_format', 'd3d11']];
             case 4:
                 hardwareType = gpuAcceleration === 'auto' ? 'auto' : gpuAcceleration;
@@ -83,12 +92,17 @@ var getHwaccelArgs = function (gpuAcceleration, isGpuWorker, args) { return __aw
             case 6:
                 result = _b.sent();
                 if (result.isGpu && result.inputArgs.length > 0) {
-                    args.jobLog("Using ".concat(gpuAcceleration, " GPU acceleration")
+                    args.jobLog("GPU acceleration: using ".concat(gpuAcceleration)
                         + " (hwaccel: ".concat(result.inputArgs.join(' '), ")"));
                     return [2 /*return*/, result.inputArgs];
                 }
                 if (gpuAcceleration === 'auto') {
-                    args.jobLog('Auto-detection: no GPU acceleration available');
+                    args.jobLog('GPU acceleration: auto selected on GPU worker'
+                        + ' but no compatible GPU detected, falling back to CPU');
+                }
+                else {
+                    args.jobLog("GPU acceleration: '".concat(gpuAcceleration, "' selected")
+                        + ' but detection returned no GPU, falling back to CPU');
                 }
                 return [3 /*break*/, 8];
             case 7:

--- a/FlowPluginsTs/CommunityFlowPlugins/video/runHealthCheck/1.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/video/runHealthCheck/1.0.0/index.ts
@@ -18,9 +18,14 @@ const getHwaccelArgs = async (
 ): Promise<string[]> => {
   // CPU worker: never use GPU, regardless of selection
   if (!isGpuWorker) {
-    if (gpuAcceleration !== 'none' && gpuAcceleration !== 'auto') {
+    if (gpuAcceleration === 'none') {
+      args.jobLog('GPU acceleration: none selected, using CPU');
+    } else if (gpuAcceleration === 'auto') {
+      args.jobLog('GPU acceleration: auto selected but worker is CPU, using CPU');
+    } else {
       args.jobLog(
-        `GPU acceleration '${gpuAcceleration}' requested but running on CPU worker, skipping`,
+        `GPU acceleration: '${gpuAcceleration}' selected but worker is CPU`
+        + ' — GPU is only available on transcode GPU workers, using CPU',
       );
     }
     return [];
@@ -29,14 +34,15 @@ const getHwaccelArgs = async (
   // GPU worker
   switch (gpuAcceleration) {
     case 'none':
+      args.jobLog('GPU acceleration: none selected, using CPU');
       return [];
 
     case 'dxva2':
-      args.jobLog('Using DXVA2 GPU acceleration');
+      args.jobLog('GPU acceleration: using DXVA2 (Windows hardware decoding)');
       return ['-hwaccel', 'dxva2', '-hwaccel_output_format', 'dxva2_vld'];
 
     case 'd3d11va':
-      args.jobLog('Using D3D11VA GPU acceleration');
+      args.jobLog('GPU acceleration: using D3D11VA (Windows hardware decoding)');
       return ['-hwaccel', 'd3d11va', '-hwaccel_output_format', 'd3d11'];
 
     case 'auto':
@@ -53,14 +59,22 @@ const getHwaccelArgs = async (
 
         if (result.isGpu && result.inputArgs.length > 0) {
           args.jobLog(
-            `Using ${gpuAcceleration} GPU acceleration`
+            `GPU acceleration: using ${gpuAcceleration}`
             + ` (hwaccel: ${result.inputArgs.join(' ')})`,
           );
           return result.inputArgs;
         }
 
         if (gpuAcceleration === 'auto') {
-          args.jobLog('Auto-detection: no GPU acceleration available');
+          args.jobLog(
+            'GPU acceleration: auto selected on GPU worker'
+            + ' but no compatible GPU detected, falling back to CPU',
+          );
+        } else {
+          args.jobLog(
+            `GPU acceleration: '${gpuAcceleration}' selected`
+            + ' but detection returned no GPU, falling back to CPU',
+          );
         }
       } catch (err) {
         args.jobLog(

--- a/tests/FlowPlugins/CommunityFlowPlugins/video/runHealthCheck/1.0.0/index.test.ts
+++ b/tests/FlowPlugins/CommunityFlowPlugins/video/runHealthCheck/1.0.0/index.test.ts
@@ -177,7 +177,7 @@ describe('runHealthCheck Plugin', () => {
         }),
       );
       expect(baseArgs.jobLog).toHaveBeenCalledWith(
-        expect.stringContaining('auto GPU acceleration'),
+        expect.stringContaining('GPU acceleration: using auto'),
       );
     });
 
@@ -212,7 +212,7 @@ describe('runHealthCheck Plugin', () => {
         }),
       );
       expect(baseArgs.jobLog).toHaveBeenCalledWith(
-        'Auto-detection: no GPU acceleration available',
+        expect.stringContaining('auto selected on GPU worker but no compatible GPU detected'),
       );
     });
 
@@ -350,7 +350,7 @@ describe('runHealthCheck Plugin', () => {
         }),
       );
       expect(baseArgs.jobLog).toHaveBeenCalledWith(
-        'Using DXVA2 GPU acceleration',
+        'GPU acceleration: using DXVA2 (Windows hardware decoding)',
       );
     });
 
@@ -370,7 +370,7 @@ describe('runHealthCheck Plugin', () => {
         }),
       );
       expect(baseArgs.jobLog).toHaveBeenCalledWith(
-        'Using D3D11VA GPU acceleration',
+        'GPU acceleration: using D3D11VA (Windows hardware decoding)',
       );
     });
 
@@ -405,7 +405,7 @@ describe('runHealthCheck Plugin', () => {
       );
     });
 
-    it('should skip GPU acceleration on CPU worker for explicit selection', async () => {
+    it('should skip GPU on CPU worker for explicit selection with clear message', async () => {
       baseArgs.inputs.type = 'thorough';
       baseArgs.inputs.gpuAcceleration = 'nvenc';
       (baseArgs as unknown as Record<string, unknown>).workerType = 'transcodecpu';
@@ -414,11 +414,11 @@ describe('runHealthCheck Plugin', () => {
 
       expect(getEncoder).not.toHaveBeenCalled();
       expect(baseArgs.jobLog).toHaveBeenCalledWith(
-        expect.stringContaining('requested but running on CPU worker, skipping'),
+        expect.stringContaining('only available on transcode GPU workers'),
       );
     });
 
-    it('should silently skip GPU on CPU worker when auto is selected', async () => {
+    it('should log CPU usage on CPU worker when auto is selected', async () => {
       baseArgs.inputs.type = 'thorough';
       baseArgs.inputs.gpuAcceleration = 'auto';
       (baseArgs as unknown as Record<string, unknown>).workerType = 'transcodecpu';
@@ -426,8 +426,8 @@ describe('runHealthCheck Plugin', () => {
       await plugin(baseArgs);
 
       expect(getEncoder).not.toHaveBeenCalled();
-      expect(baseArgs.jobLog).not.toHaveBeenCalledWith(
-        expect.stringContaining('requested but running on CPU worker'),
+      expect(baseArgs.jobLog).toHaveBeenCalledWith(
+        'GPU acceleration: auto selected but worker is CPU, using CPU',
       );
     });
 


### PR DESCRIPTION
Add GPU acceleration support for thorough health checks to reduce CPU usage. Users can now select NVIDIA (nvdec) or VAAPI hardware acceleration when running FFmpeg-based health checks, addressing issue #697.

- Add GPU acceleration dropdown input (none/nvidia/vaapi)
- Inject appropriate hwaccel flags before FFmpeg input
- Add comprehensive test coverage for GPU acceleration scenarios
Fixes https://github.com/HaveAGitGat/Tdarr_Plugins/issues/697