### PR TITLE
feat: add comment metadata cleaning to Migz2CleanTitle

### DIFF
--- a/Community/Tdarr_Plugin_MC93_Migz2CleanTitle.js
+++ b/Community/Tdarr_Plugin_MC93_Migz2CleanTitle.js
@@ -4,8 +4,8 @@ const details = () => ({
   Name: 'Migz Clean Title Metadata',
   Type: 'Video',
   Operation: 'Transcode',
-  Description: 'This plugin removes title metadata from video/audio/subtitles.\n\n',
-  Version: '1.9',
+  Description: 'This plugin removes title and comment metadata from video/audio/subtitles.\n\n',
+  Version: '2.0',
   Tags: 'pre-processing,ffmpeg,configurable',
   Inputs: [{
     name: 'clean_audio',
@@ -41,6 +41,26 @@ Optional. Only removes titles if they contain at least 3 '.' characters.
     tooltip: `
 Specify if subtitle titles should be checked & cleaned.
 Optional. Only removes titles if they contain at least 3 '.' characters.
+               \\nExample:\\n
+               true
+
+               \\nExample:\\n
+               false`,
+  },
+  {
+    name: 'clean_comments',
+    type: 'boolean',
+    defaultValue: false,
+    inputUI: {
+      type: 'dropdown',
+      options: [
+        'false',
+        'true',
+      ],
+    },
+    tooltip: `
+Specify if comment metadata should be checked & cleaned.
+Optional. Removes comment metadata from the file and from video/audio/subtitle streams.
                \\nExample:\\n
                true
 
@@ -121,6 +141,23 @@ const plugin = (file, librarySettings, inputs, otherArguments) => {
     }
   }
 
+  // Check if overall file metadata comment is not empty, if it's not empty set to "".
+  if (
+    inputs.clean_comments === true
+    && !(
+      typeof file.meta.Comment === 'undefined'
+        || file.meta.Comment === '""'
+        || file.meta.Comment === ''
+    )
+  ) {
+    try {
+      ffmpegCommandInsert += ' -metadata comment= ';
+      convert = true;
+    } catch (err) {
+      // Error
+    }
+  }
+
   // Go through each stream in the file.
   for (let i = 0; i < file.ffProbeData.streams.length; i += 1) {
     // Check if stream is a video.
@@ -136,6 +173,19 @@ const plugin = (file, librarySettings, inputs, otherArguments) => {
         ) {
           response.infoLog += `☒Video stream title is not empty. Removing title from stream ${i} \n`;
           ffmpegCommandInsert += ` -metadata:s:v:${videoIdx} title= `;
+          convert = true;
+        }
+        // Check if stream comment is not empty, if it's not empty set to "".
+        if (
+          inputs.clean_comments === true
+          && !(
+            typeof file.ffProbeData.streams[i].tags.comment === 'undefined'
+            || file.ffProbeData.streams[i].tags.comment === '""'
+            || file.ffProbeData.streams[i].tags.comment === ''
+          )
+        ) {
+          response.infoLog += `☒Video stream comment is not empty. Removing comment from stream ${i} \n`;
+          ffmpegCommandInsert += ` -metadata:s:v:${videoIdx} comment= `;
           convert = true;
         }
         // Increment videoIdx.
@@ -181,6 +231,19 @@ const plugin = (file, librarySettings, inputs, otherArguments) => {
             }
           }
         }
+        // Check if audio stream comment is not empty, if it's not empty set to "".
+        if (
+          inputs.clean_comments === true
+          && !(
+            typeof file.ffProbeData.streams[i].tags.comment === 'undefined'
+            || file.ffProbeData.streams[i].tags.comment === '""'
+            || file.ffProbeData.streams[i].tags.comment === ''
+          )
+        ) {
+          response.infoLog += `☒Audio stream comment is not empty. Removing comment from stream ${i} \n`;
+          ffmpegCommandInsert += ` -metadata:s:a:${audioIdx} comment= `;
+          convert = true;
+        }
         // Increment audioIdx.
         audioIdx += 1;
       } catch (err) {
@@ -224,6 +287,19 @@ const plugin = (file, librarySettings, inputs, otherArguments) => {
             }
           }
         }
+        // Check if subtitle stream comment is not empty, if it's not empty set to "".
+        if (
+          inputs.clean_comments === true
+          && !(
+            typeof file.ffProbeData.streams[i].tags.comment === 'undefined'
+            || file.ffProbeData.streams[i].tags.comment === '""'
+            || file.ffProbeData.streams[i].tags.comment === ''
+          )
+        ) {
+          response.infoLog += `☒Subtitle stream comment is not empty. Removing comment from stream ${i} \n`;
+          ffmpegCommandInsert += ` -metadata:s:s:${subtitleIdx} comment= `;
+          convert = true;
+        }
         // Increment subtitleIdx.
         subtitleIdx += 1;
       } catch (err) {
@@ -234,12 +310,12 @@ const plugin = (file, librarySettings, inputs, otherArguments) => {
 
   // Convert file if convert variable is set to true.
   if (convert === true) {
-    response.infoLog += '☒File has title metadata. Removing \n';
+    response.infoLog += '☒File has metadata to clean. Removing \n';
     response.preset = `,${ffmpegCommandInsert} -c copy -map 0 -max_muxing_queue_size 9999`;
     response.reQueueAfter = true;
     response.processFile = true;
   } else {
-    response.infoLog += '☑File has no title metadata \n';
+    response.infoLog += '☑File has no metadata to clean \n';
   }
   return response;
 };

--- a/tests/Community/Tdarr_Plugin_MC93_Migz2CleanTitle.js
+++ b/tests/Community/Tdarr_Plugin_MC93_Migz2CleanTitle.js
@@ -17,7 +17,7 @@ const tests = [
       handBrakeMode: false,
       FFmpegMode: true,
       reQueueAfter: true,
-      infoLog: '☒File has title metadata. Removing \n',
+      infoLog: '☒File has metadata to clean. Removing \n',
     },
   },
   {
@@ -38,7 +38,46 @@ const tests = [
       handBrakeMode: false,
       FFmpegMode: true,
       reQueueAfter: false,
-      infoLog: '☑File has no title metadata \n',
+      infoLog: '☑File has no metadata to clean \n',
+    },
+  },
+  {
+    input: {
+      file: _.cloneDeep(require('../sampleData/media/sampleH264_1.json')),
+      librarySettings: {},
+      inputs: { clean_comments: true },
+      otherArguments: {},
+    },
+    output: {
+      processFile: true,
+      preset: ', -metadata title=  -metadata comment=  -c copy -map 0 -max_muxing_queue_size 9999',
+      container: '.mp4',
+      handBrakeMode: false,
+      FFmpegMode: true,
+      reQueueAfter: true,
+      infoLog: '☒File has metadata to clean. Removing \n',
+    },
+  },
+  {
+    input: {
+      file: (() => {
+        const file = _.cloneDeep(require('../sampleData/media/sampleH264_1.json'));
+        file.meta.Title = undefined;
+        file.meta.Comment = undefined;
+        return file;
+      })(),
+      librarySettings: {},
+      inputs: { clean_comments: true },
+      otherArguments: {},
+    },
+    output: {
+      processFile: false,
+      preset: '',
+      container: '.mp4',
+      handBrakeMode: false,
+      FFmpegMode: true,
+      reQueueAfter: false,
+      infoLog: '☑File has no metadata to clean \n',
     },
   },
 ];


### PR DESCRIPTION
## Summary
- Adds a new `clean_comments` boolean input to `Tdarr_Plugin_MC93_Migz2CleanTitle` that clears comment metadata from files and streams

Closes #264
