### PR TITLE
Added QSV specific logic for the setVideoEncoder flow plugin

### DIFF
--- a/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandSetVideoEncoder/1.0.0/index.js
+++ b/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandSetVideoEncoder/1.0.0/index.js
@@ -130,6 +130,31 @@ var details = function () { return ({
             tooltip: 'Specify whether to set crf (or qp for GPU encoding)',
         },
         {
+            label: 'Enable QSV global_quality (instead of qp)',
+            name: 'qsvGlobalQuality',
+            type: 'boolean',
+            defaultValue: 'false',
+            inputUI: {
+                type: 'switch',
+                displayConditions: {
+                    logic: 'AND',
+                    sets: [
+                        {
+                            logic: 'AND',
+                            inputs: [
+                                {
+                                    name: 'hardwareType',
+                                    value: 'qsv',
+                                    condition: '===',
+                                },
+                            ],
+                        },
+                    ],
+                },
+            },
+            tooltip: 'For QSV encoders, use -global_quality instead of -qp for quality-based rate control',
+        },
+        {
             label: 'FFmpeg Quality',
             name: 'ffmpegQuality',
             type: 'number',
@@ -155,6 +180,129 @@ var details = function () { return ({
             tooltip: 'Specify ffmpeg quality crf (or qp for GPU encoding)',
         },
         {
+            label: 'QSV Global Quality',
+            name: 'qsvGlobalQualityValue',
+            type: 'number',
+            defaultValue: '25',
+            inputUI: {
+                type: 'slider',
+                sliderOptions: {
+                    min: 1,
+                    max: 51,
+                },
+                displayConditions: {
+                    logic: 'AND',
+                    sets: [
+                        {
+                            logic: 'AND',
+                            inputs: [
+                                {
+                                    name: 'qsvGlobalQuality',
+                                    value: 'true',
+                                    condition: '===',
+                                },
+                                {
+                                    name: 'hardwareType',
+                                    value: 'qsv',
+                                    condition: '===',
+                                },
+                            ],
+                        },
+                    ],
+                },
+            },
+            tooltip: 'When using QSV encoders with global_quality, this sets the global_quality value instead of qp',
+        },
+        {
+            label: 'QSV Look Ahead',
+            name: 'qsvLookAhead',
+            type: 'boolean',
+            defaultValue: 'false',
+            inputUI: {
+                type: 'switch',
+                displayConditions: {
+                    logic: 'AND',
+                    sets: [
+                        {
+                            logic: 'AND',
+                            inputs: [
+                                {
+                                    name: 'hardwareType',
+                                    value: 'qsv',
+                                    condition: '===',
+                                },
+                            ],
+                        },
+                    ],
+                },
+            },
+            tooltip: 'Enable QSV look_ahead by setting this to 1',
+        },
+        {
+            label: 'QSV Extended Bitrate Control',
+            name: 'qsvExtBrc',
+            type: 'boolean',
+            defaultValue: 'false',
+            inputUI: {
+                type: 'switch',
+                displayConditions: {
+                    logic: 'AND',
+                    sets: [
+                        {
+                            logic: 'AND',
+                            inputs: [
+                                {
+                                    name: 'hardwareType',
+                                    value: 'qsv',
+                                    condition: '===',
+                                },
+                            ],
+                        },
+                    ],
+                },
+            },
+            tooltip: 'Enable QSV extbrc. Required for look_ahead_depth on supported QSV encoders',
+        },
+        {
+            label: 'QSV Look Ahead Depth',
+            name: 'qsvLookAheadDepth',
+            type: 'number',
+            defaultValue: '0',
+            inputUI: {
+                type: 'slider',
+                sliderOptions: {
+                    min: 0,
+                    max: 100,
+                },
+                displayConditions: {
+                    logic: 'AND',
+                    sets: [
+                        {
+                            logic: 'AND',
+                            inputs: [
+                                {
+                                    name: 'hardwareType',
+                                    value: 'qsv',
+                                    condition: '===',
+                                },
+                                {
+                                    name: 'qsvLookAhead',
+                                    value: 'true',
+                                    condition: '===',
+                                },
+                                {
+                                    name: 'qsvExtBrc',
+                                    value: 'true',
+                                    condition: '===',
+                                },
+                            ],
+                        },
+                    ],
+                },
+            },
+            tooltip: 'Set QSV look_ahead_depth when look_ahead and extbrc are enabled',
+        },
+        {
             label: 'Hardware Encoding',
             name: 'hardwareEncoding',
             type: 'boolean',
@@ -171,14 +319,7 @@ var details = function () { return ({
             defaultValue: 'auto',
             inputUI: {
                 type: 'dropdown',
-                options: [
-                    'auto',
-                    'nvenc',
-                    'rkmpp',
-                    'qsv',
-                    'vaapi',
-                    'videotoolbox',
-                ],
+                options: ['auto', 'nvenc', 'rkmpp', 'qsv', 'vaapi', 'videotoolbox'],
             },
             tooltip: 'Specify codec of the output file',
         },
@@ -211,9 +352,8 @@ var details = function () { return ({
     ],
 }); };
 exports.details = details;
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 var plugin = function (args) { return __awaiter(void 0, void 0, void 0, function () {
-    var lib, hardwareDecoding, hardwareType, i, stream, targetCodec, _a, ffmpegPresetEnabled, ffmpegQualityEnabled, ffmpegPreset, ffmpegQuality, forceEncoding, hardwarEncoding, encoderProperties, presetToUse, nvencPresetMap, amfPresetMap;
+    var lib, hardwareDecoding, hardwareType, i, stream, targetCodec, _a, ffmpegPresetEnabled, ffmpegQualityEnabled, ffmpegPreset, ffmpegQuality, qsvGlobalQuality, qsvGlobalQualityValue, qsvLookAhead, qsvExtBrc, qsvLookAheadDepth, forceEncoding, hardwareEncoding, encoderProperties, presetToUse, nvencPresetMap, amfPresetMap;
     var _b, _c;
     return __generator(this, function (_d) {
         switch (_d.label) {
@@ -235,14 +375,18 @@ var plugin = function (args) { return __awaiter(void 0, void 0, void 0, function
                 _a = args.inputs, ffmpegPresetEnabled = _a.ffmpegPresetEnabled, ffmpegQualityEnabled = _a.ffmpegQualityEnabled;
                 ffmpegPreset = String(args.inputs.ffmpegPreset);
                 ffmpegQuality = String(args.inputs.ffmpegQuality);
+                qsvGlobalQuality = args.inputs.qsvGlobalQuality === true;
+                qsvGlobalQualityValue = String(args.inputs.qsvGlobalQualityValue);
+                qsvLookAhead = args.inputs.qsvLookAhead === true;
+                qsvExtBrc = args.inputs.qsvExtBrc === true;
+                qsvLookAheadDepth = Number(args.inputs.qsvLookAheadDepth);
                 forceEncoding = args.inputs.forceEncoding === true;
-                hardwarEncoding = args.inputs.hardwareEncoding === true;
-                if (!(forceEncoding
-                    || stream.codec_name !== targetCodec)) return [3 /*break*/, 3];
+                hardwareEncoding = args.inputs.hardwareEncoding === true;
+                if (!(forceEncoding || stream.codec_name !== targetCodec)) return [3 /*break*/, 3];
                 args.variables.ffmpegCommand.shouldProcess = true;
                 return [4 /*yield*/, (0, hardwareUtils_1.getEncoder)({
                         targetCodec: targetCodec,
-                        hardwareEncoding: hardwarEncoding,
+                        hardwareEncoding: hardwareEncoding,
                         hardwareType: hardwareType,
                         args: args,
                     })];
@@ -251,8 +395,8 @@ var plugin = function (args) { return __awaiter(void 0, void 0, void 0, function
                 stream.outputArgs.push('-c:{outputIndex}', encoderProperties.encoder);
                 if (ffmpegQualityEnabled) {
                     if (encoderProperties.isGpu) {
-                        if (encoderProperties.encoder === 'hevc_qsv') {
-                            stream.outputArgs.push('-global_quality', ffmpegQuality);
+                        if (encoderProperties.encoder.includes('qsv') && qsvGlobalQuality) {
+                            stream.outputArgs.push('-global_quality', qsvGlobalQualityValue);
                         }
                         else {
                             stream.outputArgs.push('-qp', ffmpegQuality);
@@ -262,8 +406,19 @@ var plugin = function (args) { return __awaiter(void 0, void 0, void 0, function
                         stream.outputArgs.push('-crf', ffmpegQuality);
                     }
                 }
+                if (encoderProperties.encoder.includes('qsv')) {
+                    if (qsvExtBrc) {
+                        stream.outputArgs.push('-extbrc', '1');
+                    }
+                    if (qsvLookAhead) {
+                        stream.outputArgs.push('-look_ahead', '1');
+                        if (qsvExtBrc && qsvLookAheadDepth > 0) {
+                            stream.outputArgs.push('-look_ahead_depth', String(qsvLookAheadDepth));
+                        }
+                    }
+                }
                 if (ffmpegPresetEnabled) {
-                    if (targetCodec !== 'av1' && ffmpegPreset) {
+                    if (ffmpegPreset) {
                         presetToUse = ffmpegPreset;
                         // Convert CPU preset names to GPU-specific presets for hardware encoders
                         if (encoderProperties.isGpu) {

--- a/FlowPlugins/FlowHelpers/1.0.0/hardwareUtils.js
+++ b/FlowPlugins/FlowHelpers/1.0.0/hardwareUtils.js
@@ -190,7 +190,8 @@ var getBestNvencDevice = function (_a) {
                 try {
                     var cmd_gpu = "nvidia-smi --query-gpu=utilization.gpu --format=csv,noheader,nounits -i ".concat(gpui);
                     result_util = parseInt(execSync(cmd_gpu), 10);
-                    if (!Number.isNaN(result_util)) { // != "No devices were found") {
+                    if (!Number.isNaN(result_util)) {
+                        // != "No devices were found") {
                         args.jobLog("GPU ".concat(gpui, " : Utilization ").concat(result_util, "%\n"));
                         if (result_util < lowest_gpu_util) {
                             gpu_num = gpui;
@@ -214,7 +215,8 @@ var getBestNvencDevice = function (_a) {
 };
 exports.getBestNvencDevice = getBestNvencDevice;
 var encoderFilter = function (encoder, targetCodec) {
-    if (targetCodec === 'hevc' && (encoder.includes('hevc') || encoder.includes('h265'))) {
+    if (targetCodec === 'hevc'
+        && (encoder.includes('hevc') || encoder.includes('h265'))) {
         return true;
     }
     if (targetCodec === 'h264' && encoder.includes('h264')) {
@@ -226,7 +228,7 @@ var encoderFilter = function (encoder, targetCodec) {
     return false;
 };
 var getEncoder = function (_a) { return __awaiter(void 0, [_a], void 0, function (_b) {
-    var supportedGpuEncoders, vaapiDevice, vaapiInputArgs, vaapiFilter, gpuEncoders, filteredGpuEncoders, idx, _i, filteredGpuEncoders_1, gpuEncoder, _c, enabledDevices, res;
+    var supportedGpuEncoders, qsvInputArgs, vaapiDevice, vaapiInputArgs, vaapiFilter, gpuEncoders, filteredGpuEncoders, idx, _i, filteredGpuEncoders_1, gpuEncoder, _c, enabledDevices, res;
     var targetCodec = _b.targetCodec, hardwareEncoding = _b.hardwareEncoding, hardwareType = _b.hardwareType, args = _b.args;
     return __generator(this, function (_d) {
         switch (_d.label) {
@@ -234,7 +236,9 @@ var getEncoder = function (_a) { return __awaiter(void 0, [_a], void 0, function
                 supportedGpuEncoders = ['hevc', 'h264', 'av1'];
                 if (!(args.workerType
                     && args.workerType.includes('gpu')
-                    && hardwareEncoding && (supportedGpuEncoders.includes(targetCodec)))) return [3 /*break*/, 5];
+                    && hardwareEncoding
+                    && supportedGpuEncoders.includes(targetCodec))) return [3 /*break*/, 5];
+                qsvInputArgs = ['-hwaccel', 'qsv', '-hwaccel_output_format', 'qsv'];
                 vaapiDevice = getVaapiRenderDevice();
                 vaapiInputArgs = [
                     '-hwaccel',
@@ -249,20 +253,14 @@ var getEncoder = function (_a) { return __awaiter(void 0, [_a], void 0, function
                     {
                         encoder: 'hevc_nvenc',
                         enabled: false,
-                        inputArgs: [
-                            '-hwaccel',
-                            'cuda',
-                        ],
+                        inputArgs: ['-hwaccel', 'cuda'],
                         outputArgs: [],
                         filter: '',
                     },
                     {
                         encoder: 'hevc_rkmpp',
                         enabled: false,
-                        inputArgs: [
-                            '-hwaccel',
-                            'rkmpp',
-                        ],
+                        inputArgs: ['-hwaccel', 'rkmpp'],
                         outputArgs: [],
                         filter: '',
                     },
@@ -276,10 +274,8 @@ var getEncoder = function (_a) { return __awaiter(void 0, [_a], void 0, function
                     {
                         encoder: 'hevc_qsv',
                         enabled: false,
-                        inputArgs: [
-                            '-hwaccel',
-                            'qsv',
-                        ],
+                        inputArgs: qsvInputArgs,
+                        probeInputArgs: ['-hwaccel', 'qsv'],
                         outputArgs: __spreadArray([], (os_1.default.platform() === 'win32' ? ['-load_plugin', 'hevc_hw'] : []), true),
                         filter: '',
                     },
@@ -293,10 +289,7 @@ var getEncoder = function (_a) { return __awaiter(void 0, [_a], void 0, function
                     {
                         encoder: 'hevc_videotoolbox',
                         enabled: false,
-                        inputArgs: [
-                            '-hwaccel',
-                            'videotoolbox',
-                        ],
+                        inputArgs: ['-hwaccel', 'videotoolbox'],
                         outputArgs: [],
                         filter: '',
                     },
@@ -304,10 +297,7 @@ var getEncoder = function (_a) { return __awaiter(void 0, [_a], void 0, function
                     {
                         encoder: 'h264_nvenc',
                         enabled: false,
-                        inputArgs: [
-                            '-hwaccel',
-                            'cuda',
-                        ],
+                        inputArgs: ['-hwaccel', 'cuda'],
                         outputArgs: [],
                         filter: '',
                     },
@@ -321,30 +311,22 @@ var getEncoder = function (_a) { return __awaiter(void 0, [_a], void 0, function
                     {
                         encoder: 'h264_qsv',
                         enabled: false,
-                        inputArgs: [
-                            '-hwaccel',
-                            'qsv',
-                        ],
+                        inputArgs: qsvInputArgs,
+                        probeInputArgs: ['-hwaccel', 'qsv'],
                         outputArgs: [],
                         filter: '',
                     },
                     {
                         encoder: 'h264_rkmpp',
                         enabled: false,
-                        inputArgs: [
-                            '-hwaccel',
-                            'rkmpp',
-                        ],
+                        inputArgs: ['-hwaccel', 'rkmpp'],
                         outputArgs: [],
                         filter: '',
                     },
                     {
                         encoder: 'h264_videotoolbox',
                         enabled: false,
-                        inputArgs: [
-                            '-hwaccel',
-                            'videotoolbox',
-                        ],
+                        inputArgs: ['-hwaccel', 'videotoolbox'],
                         outputArgs: [],
                         filter: '',
                     },
@@ -366,7 +348,8 @@ var getEncoder = function (_a) { return __awaiter(void 0, [_a], void 0, function
                     {
                         encoder: 'av1_qsv',
                         enabled: false,
-                        inputArgs: [],
+                        inputArgs: qsvInputArgs,
+                        probeInputArgs: ['-hwaccel', 'qsv'],
                         outputArgs: [],
                         filter: '',
                     },
@@ -397,7 +380,7 @@ var getEncoder = function (_a) { return __awaiter(void 0, [_a], void 0, function
                 return [4 /*yield*/, (0, exports.hasEncoder)({
                         ffmpegPath: args.ffmpegPath,
                         encoder: gpuEncoder.encoder,
-                        inputArgs: gpuEncoder.inputArgs,
+                        inputArgs: gpuEncoder.probeInputArgs || gpuEncoder.inputArgs,
                         outputArgs: gpuEncoder.outputArgs,
                         filter: gpuEncoder.filter,
                         args: args,

--- a/FlowPluginsTs/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandSetVideoEncoder/1.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandSetVideoEncoder/1.0.0/index.ts
@@ -83,7 +83,8 @@ const details = (): IpluginDetails => ({
           ],
         },
       },
-      tooltip: 'FFmpeg preset. Auto-converts for GPU encoders: NVENC uses p1-p7,'
+      tooltip:
+        'FFmpeg preset. Auto-converts for GPU encoders: NVENC uses p1-p7,'
         + ' AMF uses quality/balanced/speed, QSV uses CPU names directly.'
         + ' Ignored for VAAPI/rkmpp/videotoolbox.',
     },
@@ -96,6 +97,32 @@ const details = (): IpluginDetails => ({
         type: 'switch',
       },
       tooltip: 'Specify whether to set crf (or qp for GPU encoding)',
+    },
+    {
+      label: 'Enable QSV global_quality (instead of qp)',
+      name: 'qsvGlobalQuality',
+      type: 'boolean',
+      defaultValue: 'false',
+      inputUI: {
+        type: 'switch',
+        displayConditions: {
+          logic: 'AND',
+          sets: [
+            {
+              logic: 'AND',
+              inputs: [
+                {
+                  name: 'hardwareType',
+                  value: 'qsv',
+                  condition: '===',
+                },
+              ],
+            },
+          ],
+        },
+      },
+      tooltip:
+        'For QSV encoders, use -global_quality instead of -qp for quality-based rate control',
     },
     {
       label: 'FFmpeg Quality',
@@ -123,6 +150,132 @@ const details = (): IpluginDetails => ({
       tooltip: 'Specify ffmpeg quality crf (or qp for GPU encoding)',
     },
     {
+      label: 'QSV Global Quality',
+      name: 'qsvGlobalQualityValue',
+      type: 'number',
+      defaultValue: '25',
+      inputUI: {
+        type: 'slider',
+        sliderOptions: {
+          min: 1,
+          max: 51,
+        },
+        displayConditions: {
+          logic: 'AND',
+          sets: [
+            {
+              logic: 'AND',
+              inputs: [
+                {
+                  name: 'qsvGlobalQuality',
+                  value: 'true',
+                  condition: '===',
+                },
+                {
+                  name: 'hardwareType',
+                  value: 'qsv',
+                  condition: '===',
+                },
+              ],
+            },
+          ],
+        },
+      },
+      tooltip:
+        'When using QSV encoders with global_quality, this sets the global_quality value instead of qp',
+    },
+    {
+      label: 'QSV Look Ahead',
+      name: 'qsvLookAhead',
+      type: 'boolean',
+      defaultValue: 'false',
+      inputUI: {
+        type: 'switch',
+        displayConditions: {
+          logic: 'AND',
+          sets: [
+            {
+              logic: 'AND',
+              inputs: [
+                {
+                  name: 'hardwareType',
+                  value: 'qsv',
+                  condition: '===',
+                },
+              ],
+            },
+          ],
+        },
+      },
+      tooltip: 'Enable QSV look_ahead by setting this to 1',
+    },
+    {
+      label: 'QSV Extended Bitrate Control',
+      name: 'qsvExtBrc',
+      type: 'boolean',
+      defaultValue: 'false',
+      inputUI: {
+        type: 'switch',
+        displayConditions: {
+          logic: 'AND',
+          sets: [
+            {
+              logic: 'AND',
+              inputs: [
+                {
+                  name: 'hardwareType',
+                  value: 'qsv',
+                  condition: '===',
+                },
+              ],
+            },
+          ],
+        },
+      },
+      tooltip:
+        'Enable QSV extbrc. Required for look_ahead_depth on supported QSV encoders',
+    },
+    {
+      label: 'QSV Look Ahead Depth',
+      name: 'qsvLookAheadDepth',
+      type: 'number',
+      defaultValue: '0',
+      inputUI: {
+        type: 'slider',
+        sliderOptions: {
+          min: 0,
+          max: 100,
+        },
+        displayConditions: {
+          logic: 'AND',
+          sets: [
+            {
+              logic: 'AND',
+              inputs: [
+                {
+                  name: 'hardwareType',
+                  value: 'qsv',
+                  condition: '===',
+                },
+                {
+                  name: 'qsvLookAhead',
+                  value: 'true',
+                  condition: '===',
+                },
+                {
+                  name: 'qsvExtBrc',
+                  value: 'true',
+                  condition: '===',
+                },
+              ],
+            },
+          ],
+        },
+      },
+      tooltip:
+        'Set QSV look_ahead_depth when look_ahead and extbrc are enabled',
+    },
+    {
       label: 'Hardware Encoding',
       name: 'hardwareEncoding',
       type: 'boolean',
@@ -139,14 +292,7 @@ const details = (): IpluginDetails => ({
       defaultValue: 'auto',
       inputUI: {
         type: 'dropdown',
-        options: [
-          'auto',
-          'nvenc',
-          'rkmpp',
-          'qsv',
-          'vaapi',
-          'videotoolbox',
-        ],
+        options: ['auto', 'nvenc', 'rkmpp', 'qsv', 'vaapi', 'videotoolbox'],
       },
       tooltip: 'Specify codec of the output file',
     },
@@ -168,7 +314,8 @@ const details = (): IpluginDetails => ({
       inputUI: {
         type: 'switch',
       },
-      tooltip: 'Specify whether to force encoding if stream already has the target codec',
+      tooltip:
+        'Specify whether to force encoding if stream already has the target codec',
     },
   ],
   outputs: [
@@ -179,7 +326,6 @@ const details = (): IpluginDetails => ({
   ],
 });
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const plugin = async (args: IpluginInputArgs): Promise<IpluginOutputArgs> => {
   const lib = require('../../../../../methods/lib')();
   // eslint-disable-next-line @typescript-eslint/no-unused-vars,no-param-reassign
@@ -199,19 +345,21 @@ const plugin = async (args: IpluginInputArgs): Promise<IpluginOutputArgs> => {
       const { ffmpegPresetEnabled, ffmpegQualityEnabled } = args.inputs;
       const ffmpegPreset = String(args.inputs.ffmpegPreset);
       const ffmpegQuality = String(args.inputs.ffmpegQuality);
+      const qsvGlobalQuality = args.inputs.qsvGlobalQuality === true;
+      const qsvGlobalQualityValue = String(args.inputs.qsvGlobalQualityValue);
+      const qsvLookAhead = args.inputs.qsvLookAhead === true;
+      const qsvExtBrc = args.inputs.qsvExtBrc === true;
+      const qsvLookAheadDepth = Number(args.inputs.qsvLookAheadDepth);
       const forceEncoding = args.inputs.forceEncoding === true;
-      const hardwarEncoding = args.inputs.hardwareEncoding === true;
+      const hardwareEncoding = args.inputs.hardwareEncoding === true;
 
-      if (
-        forceEncoding
-        || stream.codec_name !== targetCodec
-      ) {
+      if (forceEncoding || stream.codec_name !== targetCodec) {
         args.variables.ffmpegCommand.shouldProcess = true;
 
         // eslint-disable-next-line no-await-in-loop
         const encoderProperties = await getEncoder({
           targetCodec,
-          hardwareEncoding: hardwarEncoding,
+          hardwareEncoding,
           hardwareType,
           args,
         });
@@ -220,8 +368,8 @@ const plugin = async (args: IpluginInputArgs): Promise<IpluginOutputArgs> => {
 
         if (ffmpegQualityEnabled) {
           if (encoderProperties.isGpu) {
-            if (encoderProperties.encoder === 'hevc_qsv') {
-              stream.outputArgs.push('-global_quality', ffmpegQuality);
+            if (encoderProperties.encoder.includes('qsv') && qsvGlobalQuality) {
+              stream.outputArgs.push('-global_quality', qsvGlobalQualityValue);
             } else {
               stream.outputArgs.push('-qp', ffmpegQuality);
             }
@@ -230,8 +378,25 @@ const plugin = async (args: IpluginInputArgs): Promise<IpluginOutputArgs> => {
           }
         }
 
+        if (encoderProperties.encoder.includes('qsv')) {
+          if (qsvExtBrc) {
+            stream.outputArgs.push('-extbrc', '1');
+          }
+
+          if (qsvLookAhead) {
+            stream.outputArgs.push('-look_ahead', '1');
+
+            if (qsvExtBrc && qsvLookAheadDepth > 0) {
+              stream.outputArgs.push(
+                '-look_ahead_depth',
+                String(qsvLookAheadDepth),
+              );
+            }
+          }
+        }
+
         if (ffmpegPresetEnabled) {
-          if (targetCodec !== 'av1' && ffmpegPreset) {
+          if (ffmpegPreset) {
             let presetToUse: string | null = ffmpegPreset;
             // Convert CPU preset names to GPU-specific presets for hardware encoders
             if (encoderProperties.isGpu) {
@@ -291,7 +456,4 @@ const plugin = async (args: IpluginInputArgs): Promise<IpluginOutputArgs> => {
     variables: args.variables,
   };
 };
-export {
-  details,
-  plugin,
-};
+export { details, plugin };

--- a/FlowPluginsTs/FlowHelpers/1.0.0/hardwareUtils.ts
+++ b/FlowPluginsTs/FlowHelpers/1.0.0/hardwareUtils.ts
@@ -29,12 +29,12 @@ export const hasEncoder = async ({
   filter,
   args,
 }: {
-  ffmpegPath: string,
-  encoder: string,
-  inputArgs: string[],
-  outputArgs: string[],
-  filter: string,
-  args: IpluginInputArgs,
+  ffmpegPath: string;
+  encoder: string;
+  inputArgs: string[];
+  outputArgs: string[];
+  filter: string;
+  args: IpluginInputArgs;
 }): Promise<boolean> => {
   const { spawn } = require('child_process');
   let isEnabled = false;
@@ -103,12 +103,13 @@ export const hasEncoder = async ({
 };
 
 interface IgpuEncoder {
-  encoder: string,
-  enabled: boolean,
+  encoder: string;
+  enabled: boolean;
 
-  inputArgs: string[],
-  outputArgs: string[],
-  filter: string,
+  inputArgs: string[];
+  probeInputArgs?: string[];
+  outputArgs: string[];
+  filter: string;
 }
 
 // credit to UNCode101 for this
@@ -116,8 +117,8 @@ export const getBestNvencDevice = ({
   args,
   nvencDevice,
 }: {
-  args: IpluginInputArgs
-  nvencDevice: IgpuEncoder,
+  args: IpluginInputArgs;
+  nvencDevice: IgpuEncoder;
 }): IgpuEncoder => {
   const { execSync } = require('child_process');
   let gpu_num = -1;
@@ -146,12 +147,15 @@ export const getBestNvencDevice = ({
     for (let gpui = 0; gpui < gpu_count; gpui += 1) {
       // Check if GPU # is in GPUs to exclude
       if (gpus_to_exclude.includes(String(gpui))) {
-        args.jobLog(`GPU ${gpui}: ${gpu_names[gpui]} is in exclusion list, will not be used!\n`);
+        args.jobLog(
+          `GPU ${gpui}: ${gpu_names[gpui]} is in exclusion list, will not be used!\n`,
+        );
       } else {
         try {
           const cmd_gpu = `nvidia-smi --query-gpu=utilization.gpu --format=csv,noheader,nounits -i ${gpui}`;
           result_util = parseInt(execSync(cmd_gpu), 10);
-          if (!Number.isNaN(result_util)) { // != "No devices were found") {
+          if (!Number.isNaN(result_util)) {
+            // != "No devices were found") {
             args.jobLog(`GPU ${gpui} : Utilization ${result_util}%\n`);
 
             if (result_util < lowest_gpu_util) {
@@ -160,7 +164,9 @@ export const getBestNvencDevice = ({
             }
           }
         } catch (error) {
-          args.jobLog(`Error in reading GPU ${gpui} Utilization\nError: ${error}\n`);
+          args.jobLog(
+            `Error in reading GPU ${gpui} Utilization\nError: ${error}\n`,
+          );
         }
       }
     }
@@ -176,11 +182,16 @@ export const getBestNvencDevice = ({
 };
 
 const encoderFilter = (encoder: string, targetCodec: string) => {
-  if (targetCodec === 'hevc' && (encoder.includes('hevc') || encoder.includes('h265'))) {
+  if (
+    targetCodec === 'hevc'
+    && (encoder.includes('hevc') || encoder.includes('h265'))
+  ) {
     return true;
-  } if (targetCodec === 'h264' && encoder.includes('h264')) {
+  }
+  if (targetCodec === 'h264' && encoder.includes('h264')) {
     return true;
-  } if (targetCodec === 'av1' && encoder.includes('av1')) {
+  }
+  if (targetCodec === 'av1' && encoder.includes('av1')) {
     return true;
   }
 
@@ -188,11 +199,11 @@ const encoderFilter = (encoder: string, targetCodec: string) => {
 };
 
 export interface IgetEncoder {
-  encoder: string,
-  inputArgs: string[],
-  outputArgs: string[],
-  isGpu: boolean,
-  enabledDevices: IgpuEncoder[],
+  encoder: string;
+  inputArgs: string[];
+  outputArgs: string[];
+  isGpu: boolean;
+  enabledDevices: IgpuEncoder[];
 }
 
 export const getEncoder = async ({
@@ -201,17 +212,20 @@ export const getEncoder = async ({
   hardwareType,
   args,
 }: {
-  targetCodec: string,
-  hardwareEncoding: boolean,
-  hardwareType: string,
-  args: IpluginInputArgs,
+  targetCodec: string;
+  hardwareEncoding: boolean;
+  hardwareType: string;
+  args: IpluginInputArgs;
 }): Promise<IgetEncoder> => {
   const supportedGpuEncoders = ['hevc', 'h264', 'av1'];
 
   if (
     args.workerType
     && args.workerType.includes('gpu')
-    && hardwareEncoding && (supportedGpuEncoders.includes(targetCodec))) {
+    && hardwareEncoding
+    && supportedGpuEncoders.includes(targetCodec)
+  ) {
+    const qsvInputArgs = ['-hwaccel', 'qsv', '-hwaccel_output_format', 'qsv'];
     const vaapiDevice = getVaapiRenderDevice();
     const vaapiInputArgs = [
       '-hwaccel',
@@ -227,20 +241,14 @@ export const getEncoder = async ({
       {
         encoder: 'hevc_nvenc',
         enabled: false,
-        inputArgs: [
-          '-hwaccel',
-          'cuda',
-        ],
+        inputArgs: ['-hwaccel', 'cuda'],
         outputArgs: [],
         filter: '',
       },
       {
         encoder: 'hevc_rkmpp',
         enabled: false,
-        inputArgs: [
-          '-hwaccel',
-          'rkmpp',
-        ],
+        inputArgs: ['-hwaccel', 'rkmpp'],
         outputArgs: [],
         filter: '',
       },
@@ -254,10 +262,8 @@ export const getEncoder = async ({
       {
         encoder: 'hevc_qsv',
         enabled: false,
-        inputArgs: [
-          '-hwaccel',
-          'qsv',
-        ],
+        inputArgs: qsvInputArgs,
+        probeInputArgs: ['-hwaccel', 'qsv'],
         outputArgs: [
           ...(os.platform() === 'win32' ? ['-load_plugin', 'hevc_hw'] : []),
         ],
@@ -273,10 +279,7 @@ export const getEncoder = async ({
       {
         encoder: 'hevc_videotoolbox',
         enabled: false,
-        inputArgs: [
-          '-hwaccel',
-          'videotoolbox',
-        ],
+        inputArgs: ['-hwaccel', 'videotoolbox'],
         outputArgs: [],
         filter: '',
       },
@@ -285,10 +288,7 @@ export const getEncoder = async ({
       {
         encoder: 'h264_nvenc',
         enabled: false,
-        inputArgs: [
-          '-hwaccel',
-          'cuda',
-        ],
+        inputArgs: ['-hwaccel', 'cuda'],
         outputArgs: [],
         filter: '',
       },
@@ -302,30 +302,22 @@ export const getEncoder = async ({
       {
         encoder: 'h264_qsv',
         enabled: false,
-        inputArgs: [
-          '-hwaccel',
-          'qsv',
-        ],
+        inputArgs: qsvInputArgs,
+        probeInputArgs: ['-hwaccel', 'qsv'],
         outputArgs: [],
         filter: '',
       },
       {
         encoder: 'h264_rkmpp',
         enabled: false,
-        inputArgs: [
-          '-hwaccel',
-          'rkmpp',
-        ],
+        inputArgs: ['-hwaccel', 'rkmpp'],
         outputArgs: [],
         filter: '',
       },
       {
         encoder: 'h264_videotoolbox',
         enabled: false,
-        inputArgs: [
-          '-hwaccel',
-          'videotoolbox',
-        ],
+        inputArgs: ['-hwaccel', 'videotoolbox'],
         outputArgs: [],
         filter: '',
       },
@@ -348,7 +340,8 @@ export const getEncoder = async ({
       {
         encoder: 'av1_qsv',
         enabled: false,
-        inputArgs: [],
+        inputArgs: qsvInputArgs,
+        probeInputArgs: ['-hwaccel', 'qsv'],
         outputArgs: [],
         filter: '',
       },
@@ -367,7 +360,9 @@ export const getEncoder = async ({
       const idx = filteredGpuEncoders.findIndex((device) => device.encoder.includes(hardwareType));
 
       if (idx === -1) {
-        throw new Error(`Could not find encoder ${targetCodec} for hardware ${hardwareType}`);
+        throw new Error(
+          `Could not find encoder ${targetCodec} for hardware ${hardwareType}`,
+        );
       }
 
       return {
@@ -385,14 +380,16 @@ export const getEncoder = async ({
       gpuEncoder.enabled = await hasEncoder({
         ffmpegPath: args.ffmpegPath,
         encoder: gpuEncoder.encoder,
-        inputArgs: gpuEncoder.inputArgs,
+        inputArgs: gpuEncoder.probeInputArgs || gpuEncoder.inputArgs,
         outputArgs: gpuEncoder.outputArgs,
         filter: gpuEncoder.filter,
         args,
       });
     }
 
-    const enabledDevices = filteredGpuEncoders.filter((device) => device.enabled === true);
+    const enabledDevices = filteredGpuEncoders.filter(
+      (device) => device.enabled === true,
+    );
 
     args.jobLog(JSON.stringify({ enabledDevices }));
 
@@ -427,7 +424,9 @@ export const getEncoder = async ({
     }
 
     if (!supportedGpuEncoders.includes(targetCodec)) {
-      args.jobLog(`Target codec ${targetCodec} is not supported for GPU encoding`);
+      args.jobLog(
+        `Target codec ${targetCodec} is not supported for GPU encoding`,
+      );
     }
   }
 
@@ -439,7 +438,8 @@ export const getEncoder = async ({
       isGpu: false,
       enabledDevices: [],
     };
-  } if (targetCodec === 'h264') {
+  }
+  if (targetCodec === 'h264') {
     return {
       encoder: 'libx264',
       inputArgs: [],
@@ -447,7 +447,8 @@ export const getEncoder = async ({
       isGpu: false,
       enabledDevices: [],
     };
-  } if (targetCodec === 'av1') {
+  }
+  if (targetCodec === 'av1') {
     return {
       encoder: 'libsvtav1',
       inputArgs: [],

--- a/tests/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandSetVideoEncoder/1.0.0/index.test.ts
+++ b/tests/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandSetVideoEncoder/1.0.0/index.test.ts
@@ -1,14 +1,17 @@
-import { plugin } from
-  '../../../../../../FlowPluginsTs/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandSetVideoEncoder/1.0.0/index';
+// eslint-disable-next-line max-len
+import { plugin } from '../../../../../../FlowPluginsTs/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandSetVideoEncoder/1.0.0/index';
 import { IpluginInputArgs } from '../../../../../../FlowPluginsTs/FlowHelpers/1.0.0/interfaces/interfaces';
 import { IFileObject } from '../../../../../../FlowPluginsTs/FlowHelpers/1.0.0/interfaces/synced/IFileObject';
 
 const sampleH264 = require('../../../../../sampleData/media/sampleH264_1.json');
 
 // Mock the getEncoder function from hardwareUtils
-jest.mock('../../../../../../FlowPluginsTs/FlowHelpers/1.0.0/hardwareUtils', () => ({
-  getEncoder: jest.fn(),
-}));
+jest.mock(
+  '../../../../../../FlowPluginsTs/FlowHelpers/1.0.0/hardwareUtils',
+  () => ({
+    getEncoder: jest.fn(),
+  }),
+);
 
 describe('ffmpegCommandSetVideoEncoder Plugin', () => {
   let baseArgs: IpluginInputArgs;
@@ -18,7 +21,9 @@ describe('ffmpegCommandSetVideoEncoder Plugin', () => {
 
   beforeEach(() => {
     // Reset the mock
-    const { getEncoder } = require('../../../../../../FlowPluginsTs/FlowHelpers/1.0.0/hardwareUtils');
+    const {
+      getEncoder,
+    } = require('../../../../../../FlowPluginsTs/FlowHelpers/1.0.0/hardwareUtils');
     mockGetEncoder = getEncoder as jest.MockedFunction<
       typeof import('../../../../../../FlowPluginsTs/FlowHelpers/1.0.0/hardwareUtils').getEncoder
     >;
@@ -37,6 +42,7 @@ describe('ffmpegCommandSetVideoEncoder Plugin', () => {
         ffmpegPreset: 'fast',
         ffmpegQualityEnabled: true,
         ffmpegQuality: '25',
+        qsvExtBrc: false,
         hardwareEncoding: true,
         hardwareType: 'auto',
         hardwareDecoding: true,
@@ -142,47 +148,46 @@ describe('ffmpegCommandSetVideoEncoder Plugin', () => {
   });
 
   describe('Codec Types', () => {
-    it.each([
-      'hevc',
-      'h264',
-      'av1',
-    ])('should handle %s codec', async (codec) => {
-      baseArgs.inputs.outputCodec = codec;
-      let expectedEncoder: string;
-      if (codec === 'hevc') {
-        expectedEncoder = 'libx265';
-      } else if (codec === 'h264') {
-        expectedEncoder = 'libx264';
-      } else {
-        expectedEncoder = 'libsvtav1';
-      }
-      mockGetEncoder.mockResolvedValue({
-        encoder: expectedEncoder,
-        inputArgs: [],
-        outputArgs: [],
-        isGpu: false,
-        enabledDevices: [],
-      });
+    it.each(['hevc', 'h264', 'av1'])(
+      'should handle %s codec',
+      async (codec) => {
+        baseArgs.inputs.outputCodec = codec;
+        let expectedEncoder: string;
+        if (codec === 'hevc') {
+          expectedEncoder = 'libx265';
+        } else if (codec === 'h264') {
+          expectedEncoder = 'libx264';
+        } else {
+          expectedEncoder = 'libsvtav1';
+        }
+        mockGetEncoder.mockResolvedValue({
+          encoder: expectedEncoder,
+          inputArgs: [],
+          outputArgs: [],
+          isGpu: false,
+          enabledDevices: [],
+        });
 
-      const result = await plugin(baseArgs);
+        const result = await plugin(baseArgs);
 
-      expect(mockGetEncoder).toHaveBeenCalledWith({
-        targetCodec: codec,
-        hardwareEncoding: true,
-        hardwareType: 'auto',
-        args: baseArgs,
-      });
+        expect(mockGetEncoder).toHaveBeenCalledWith({
+          targetCodec: codec,
+          hardwareEncoding: true,
+          hardwareType: 'auto',
+          args: baseArgs,
+        });
 
-      const videoStream = result.variables.ffmpegCommand.streams[0];
-      expect(videoStream.outputArgs).toContain(expectedEncoder);
-    });
+        const videoStream = result.variables.ffmpegCommand.streams[0];
+        expect(videoStream.outputArgs).toContain(expectedEncoder);
+      },
+    );
   });
 
   describe('Hardware Encoding Settings', () => {
-    it('should handle GPU encoding with QSV using global_quality', async () => {
+    it('should handle GPU encoding with QSV using qp by default', async () => {
       mockGetEncoder.mockResolvedValue({
         encoder: 'hevc_qsv',
-        inputArgs: ['-hwaccel', 'qsv'],
+        inputArgs: ['-hwaccel', 'qsv', '-hwaccel_output_format', 'qsv'],
         outputArgs: ['-load_plugin', 'hevc_hw'],
         isGpu: true,
         enabledDevices: [],
@@ -192,9 +197,15 @@ describe('ffmpegCommandSetVideoEncoder Plugin', () => {
 
       const videoStream = result.variables.ffmpegCommand.streams[0];
       expect(videoStream.outputArgs).toContain('hevc_qsv');
-      expect(videoStream.outputArgs).toContain('-global_quality');
+      expect(videoStream.outputArgs).toContain('-qp');
       expect(videoStream.outputArgs).toContain('25');
-      expect(videoStream.inputArgs).toEqual(['-hwaccel', 'qsv']);
+      expect(videoStream.outputArgs).not.toContain('-global_quality');
+      expect(videoStream.inputArgs).toEqual([
+        '-hwaccel',
+        'qsv',
+        '-hwaccel_output_format',
+        'qsv',
+      ]);
     });
 
     it('should handle GPU encoding with NVENC using qp', async () => {
@@ -253,6 +264,158 @@ describe('ffmpegCommandSetVideoEncoder Plugin', () => {
         args: baseArgs,
       });
     });
+
+    it('should use QSV global_quality when enabled', async () => {
+      baseArgs.inputs.hardwareType = 'qsv';
+      baseArgs.inputs.qsvGlobalQuality = true;
+      baseArgs.inputs.qsvGlobalQualityValue = '19';
+      mockGetEncoder.mockResolvedValue({
+        encoder: 'hevc_qsv',
+        inputArgs: ['-hwaccel', 'qsv', '-hwaccel_output_format', 'qsv'],
+        outputArgs: ['-load_plugin', 'hevc_hw'],
+        isGpu: true,
+        enabledDevices: [],
+      });
+
+      const result = await plugin(baseArgs);
+
+      const videoStream = result.variables.ffmpegCommand.streams[0];
+      expect(videoStream.outputArgs).toContain('-global_quality');
+      expect(videoStream.outputArgs).toContain('19');
+      expect(videoStream.outputArgs).not.toContain('-qp');
+    });
+
+    it('should use QSV global_quality for H264 QSV when enabled', async () => {
+      baseArgs.inputs.hardwareType = 'qsv';
+      baseArgs.inputs.outputCodec = 'h264';
+      baseArgs.inputs.qsvGlobalQuality = true;
+      baseArgs.inputs.qsvGlobalQualityValue = '21';
+      mockGetEncoder.mockResolvedValue({
+        encoder: 'h264_qsv',
+        inputArgs: ['-hwaccel', 'qsv', '-hwaccel_output_format', 'qsv'],
+        outputArgs: [],
+        isGpu: true,
+        enabledDevices: [],
+      });
+
+      const result = await plugin(baseArgs);
+
+      const videoStream = result.variables.ffmpegCommand.streams[0];
+      expect(videoStream.outputArgs).toContain('h264_qsv');
+      expect(videoStream.outputArgs).toContain('-global_quality');
+      expect(videoStream.outputArgs).toContain('21');
+      expect(videoStream.outputArgs).not.toContain('-qp');
+    });
+
+    it('should use QSV global_quality for AV1 QSV when enabled', async () => {
+      baseArgs.inputs.hardwareType = 'qsv';
+      baseArgs.inputs.outputCodec = 'av1';
+      baseArgs.inputs.qsvGlobalQuality = true;
+      baseArgs.inputs.qsvGlobalQualityValue = '20';
+      mockGetEncoder.mockResolvedValue({
+        encoder: 'av1_qsv',
+        inputArgs: ['-hwaccel', 'qsv', '-hwaccel_output_format', 'qsv'],
+        outputArgs: [],
+        isGpu: true,
+        enabledDevices: [],
+      });
+
+      const result = await plugin(baseArgs);
+
+      const videoStream = result.variables.ffmpegCommand.streams[0];
+      expect(videoStream.outputArgs).toContain('av1_qsv');
+      expect(videoStream.outputArgs).toContain('-global_quality');
+      expect(videoStream.outputArgs).toContain('20');
+      expect(videoStream.outputArgs).not.toContain('-qp');
+    });
+
+    it('should apply QSV look_ahead and look_ahead_depth when enabled', async () => {
+      baseArgs.inputs.hardwareType = 'qsv';
+      baseArgs.inputs.qsvLookAhead = true;
+      baseArgs.inputs.qsvExtBrc = true;
+      baseArgs.inputs.qsvLookAheadDepth = '40';
+      mockGetEncoder.mockResolvedValue({
+        encoder: 'hevc_qsv',
+        inputArgs: ['-hwaccel', 'qsv', '-hwaccel_output_format', 'qsv'],
+        outputArgs: [],
+        isGpu: true,
+        enabledDevices: [],
+      });
+
+      const result = await plugin(baseArgs);
+
+      const videoStream = result.variables.ffmpegCommand.streams[0];
+      expect(videoStream.outputArgs).toContain('-extbrc');
+      expect(videoStream.outputArgs).toContain('1');
+      expect(videoStream.outputArgs).toContain('-look_ahead');
+      expect(videoStream.outputArgs).toContain('1');
+      expect(videoStream.outputArgs).toContain('-look_ahead_depth');
+      expect(videoStream.outputArgs).toContain('40');
+    });
+
+    it('should apply QSV extbrc without requiring look_ahead', async () => {
+      baseArgs.inputs.hardwareType = 'qsv';
+      baseArgs.inputs.qsvExtBrc = true;
+      mockGetEncoder.mockResolvedValue({
+        encoder: 'hevc_qsv',
+        inputArgs: ['-hwaccel', 'qsv', '-hwaccel_output_format', 'qsv'],
+        outputArgs: [],
+        isGpu: true,
+        enabledDevices: [],
+      });
+
+      const result = await plugin(baseArgs);
+
+      const videoStream = result.variables.ffmpegCommand.streams[0];
+      expect(videoStream.outputArgs).toContain('-extbrc');
+      expect(videoStream.outputArgs).toContain('1');
+      expect(videoStream.outputArgs).not.toContain('-look_ahead');
+      expect(videoStream.outputArgs).not.toContain('-look_ahead_depth');
+    });
+
+    it('should not apply QSV look_ahead_depth when look_ahead is disabled', async () => {
+      baseArgs.inputs.hardwareType = 'qsv';
+      baseArgs.inputs.qsvLookAhead = false;
+      baseArgs.inputs.qsvExtBrc = true;
+      baseArgs.inputs.qsvLookAheadDepth = '40';
+      mockGetEncoder.mockResolvedValue({
+        encoder: 'hevc_qsv',
+        inputArgs: ['-hwaccel', 'qsv', '-hwaccel_output_format', 'qsv'],
+        outputArgs: [],
+        isGpu: true,
+        enabledDevices: [],
+      });
+
+      const result = await plugin(baseArgs);
+
+      const videoStream = result.variables.ffmpegCommand.streams[0];
+      expect(videoStream.outputArgs).not.toContain('-look_ahead');
+      expect(videoStream.outputArgs).not.toContain('-look_ahead_depth');
+      expect(videoStream.outputArgs).not.toContain('40');
+    });
+
+    it('should not apply QSV look_ahead_depth when extbrc is disabled', async () => {
+      baseArgs.inputs.hardwareType = 'qsv';
+      baseArgs.inputs.qsvLookAhead = true;
+      baseArgs.inputs.qsvExtBrc = false;
+      baseArgs.inputs.qsvLookAheadDepth = '40';
+      mockGetEncoder.mockResolvedValue({
+        encoder: 'hevc_qsv',
+        inputArgs: ['-hwaccel', 'qsv', '-hwaccel_output_format', 'qsv'],
+        outputArgs: [],
+        isGpu: true,
+        enabledDevices: [],
+      });
+
+      const result = await plugin(baseArgs);
+
+      const videoStream = result.variables.ffmpegCommand.streams[0];
+      expect(videoStream.outputArgs).toContain('-look_ahead');
+      expect(videoStream.outputArgs).toContain('1');
+      expect(videoStream.outputArgs).not.toContain('-extbrc');
+      expect(videoStream.outputArgs).not.toContain('-look_ahead_depth');
+      expect(videoStream.outputArgs).not.toContain('40');
+    });
   });
 
   describe('Quality and Preset Settings', () => {
@@ -276,7 +439,7 @@ describe('ffmpegCommandSetVideoEncoder Plugin', () => {
       expect(videoStream.outputArgs).not.toContain('-preset');
     });
 
-    it('should not apply preset for av1 codec', async () => {
+    it('should apply preset for software av1 codec', async () => {
       baseArgs.inputs.outputCodec = 'av1';
       mockGetEncoder.mockResolvedValue({
         encoder: 'libsvtav1',
@@ -289,22 +452,54 @@ describe('ffmpegCommandSetVideoEncoder Plugin', () => {
       const result = await plugin(baseArgs);
 
       const videoStream = result.variables.ffmpegCommand.streams[0];
-      expect(videoStream.outputArgs).not.toContain('-preset');
+      expect(videoStream.outputArgs).toContain('-preset');
+      expect(videoStream.outputArgs).toContain('fast');
+    });
+
+    it('should apply CPU-style preset directly for AV1 QSV encoders', async () => {
+      baseArgs.inputs.outputCodec = 'av1';
+      baseArgs.inputs.hardwareType = 'qsv';
+      baseArgs.inputs.ffmpegPreset = 'slow';
+      mockGetEncoder.mockResolvedValue({
+        encoder: 'av1_qsv',
+        inputArgs: ['-hwaccel', 'qsv', '-hwaccel_output_format', 'qsv'],
+        outputArgs: [],
+        isGpu: true,
+        enabledDevices: [],
+      });
+
+      const result = await plugin(baseArgs);
+
+      const videoStream = result.variables.ffmpegCommand.streams[0];
+      expect(videoStream.outputArgs).toContain('-preset');
+      expect(videoStream.outputArgs).toContain('slow');
     });
 
     it('should handle different preset values for CPU encoders', async () => {
-      const presets = ['veryslow', 'slower', 'slow', 'medium', 'fast', 'faster', 'veryfast', 'superfast', 'ultrafast'];
+      const presets = [
+        'veryslow',
+        'slower',
+        'slow',
+        'medium',
+        'fast',
+        'faster',
+        'veryfast',
+        'superfast',
+        'ultrafast',
+      ];
 
-      await Promise.all(presets.map(async (preset) => {
-        baseArgs.inputs.ffmpegPreset = preset;
-        baseArgs.variables.ffmpegCommand.streams[0].outputArgs = []; // Reset
+      await Promise.all(
+        presets.map(async (preset) => {
+          baseArgs.inputs.ffmpegPreset = preset;
+          baseArgs.variables.ffmpegCommand.streams[0].outputArgs = []; // Reset
 
-        const result = await plugin(baseArgs);
+          const result = await plugin(baseArgs);
 
-        const videoStream = result.variables.ffmpegCommand.streams[0];
-        expect(videoStream.outputArgs).toContain('-preset');
-        expect(videoStream.outputArgs).toContain(preset);
-      }));
+          const videoStream = result.variables.ffmpegCommand.streams[0];
+          expect(videoStream.outputArgs).toContain('-preset');
+          expect(videoStream.outputArgs).toContain(preset);
+        }),
+      );
     });
 
     it('should convert CPU presets to p1-p7 for NVENC encoders', async () => {
@@ -328,17 +523,19 @@ describe('ffmpegCommandSetVideoEncoder Plugin', () => {
         ultrafast: 'p1',
       };
 
-      await Promise.all(Object.entries(presetMapping).map(async ([cpuPreset, gpuPreset]) => {
-        baseArgs.inputs.ffmpegPreset = cpuPreset;
-        baseArgs.variables.ffmpegCommand.streams[0].outputArgs = []; // Reset
+      await Promise.all(
+        Object.entries(presetMapping).map(async ([cpuPreset, gpuPreset]) => {
+          baseArgs.inputs.ffmpegPreset = cpuPreset;
+          baseArgs.variables.ffmpegCommand.streams[0].outputArgs = []; // Reset
 
-        const result = await plugin(baseArgs);
+          const result = await plugin(baseArgs);
 
-        const videoStream = result.variables.ffmpegCommand.streams[0];
-        expect(videoStream.outputArgs).toContain('-preset');
-        expect(videoStream.outputArgs).toContain(gpuPreset);
-        expect(videoStream.outputArgs).not.toContain(cpuPreset);
-      }));
+          const videoStream = result.variables.ffmpegCommand.streams[0];
+          expect(videoStream.outputArgs).toContain('-preset');
+          expect(videoStream.outputArgs).toContain(gpuPreset);
+          expect(videoStream.outputArgs).not.toContain(cpuPreset);
+        }),
+      );
     });
 
     it('should convert CPU presets to quality/balanced/speed for AMF encoders', async () => {
@@ -362,17 +559,19 @@ describe('ffmpegCommandSetVideoEncoder Plugin', () => {
         ultrafast: 'speed',
       };
 
-      await Promise.all(Object.entries(presetMapping).map(async ([cpuPreset, amfPreset]) => {
-        baseArgs.inputs.ffmpegPreset = cpuPreset;
-        baseArgs.variables.ffmpegCommand.streams[0].outputArgs = []; // Reset
+      await Promise.all(
+        Object.entries(presetMapping).map(async ([cpuPreset, amfPreset]) => {
+          baseArgs.inputs.ffmpegPreset = cpuPreset;
+          baseArgs.variables.ffmpegCommand.streams[0].outputArgs = []; // Reset
 
-        const result = await plugin(baseArgs);
+          const result = await plugin(baseArgs);
 
-        const videoStream = result.variables.ffmpegCommand.streams[0];
-        expect(videoStream.outputArgs).toContain('-preset');
-        expect(videoStream.outputArgs).toContain(amfPreset);
-        expect(videoStream.outputArgs).not.toContain(cpuPreset);
-      }));
+          const videoStream = result.variables.ffmpegCommand.streams[0];
+          expect(videoStream.outputArgs).toContain('-preset');
+          expect(videoStream.outputArgs).toContain(amfPreset);
+          expect(videoStream.outputArgs).not.toContain(cpuPreset);
+        }),
+      );
     });
 
     it('should use CPU preset names directly for QSV encoders', async () => {
@@ -386,16 +585,18 @@ describe('ffmpegCommandSetVideoEncoder Plugin', () => {
 
       const presets = ['veryslow', 'slow', 'medium', 'fast', 'veryfast'];
 
-      await Promise.all(presets.map(async (preset) => {
-        baseArgs.inputs.ffmpegPreset = preset;
-        baseArgs.variables.ffmpegCommand.streams[0].outputArgs = []; // Reset
+      await Promise.all(
+        presets.map(async (preset) => {
+          baseArgs.inputs.ffmpegPreset = preset;
+          baseArgs.variables.ffmpegCommand.streams[0].outputArgs = []; // Reset
 
-        const result = await plugin(baseArgs);
+          const result = await plugin(baseArgs);
 
-        const videoStream = result.variables.ffmpegCommand.streams[0];
-        expect(videoStream.outputArgs).toContain('-preset');
-        expect(videoStream.outputArgs).toContain(preset);
-      }));
+          const videoStream = result.variables.ffmpegCommand.streams[0];
+          expect(videoStream.outputArgs).toContain('-preset');
+          expect(videoStream.outputArgs).toContain(preset);
+        }),
+      );
     });
 
     it('should skip preset for VAAPI encoders (not supported)', async () => {
@@ -409,15 +610,17 @@ describe('ffmpegCommandSetVideoEncoder Plugin', () => {
 
       const presets = ['veryslow', 'slow', 'medium', 'fast', 'veryfast'];
 
-      await Promise.all(presets.map(async (preset) => {
-        baseArgs.inputs.ffmpegPreset = preset;
-        baseArgs.variables.ffmpegCommand.streams[0].outputArgs = []; // Reset
+      await Promise.all(
+        presets.map(async (preset) => {
+          baseArgs.inputs.ffmpegPreset = preset;
+          baseArgs.variables.ffmpegCommand.streams[0].outputArgs = []; // Reset
 
-        const result = await plugin(baseArgs);
+          const result = await plugin(baseArgs);
 
-        const videoStream = result.variables.ffmpegCommand.streams[0];
-        expect(videoStream.outputArgs).not.toContain('-preset');
-      }));
+          const videoStream = result.variables.ffmpegCommand.streams[0];
+          expect(videoStream.outputArgs).not.toContain('-preset');
+        }),
+      );
     });
 
     it('should skip preset for rkmpp encoders (not supported)', async () => {
@@ -459,16 +662,18 @@ describe('ffmpegCommandSetVideoEncoder Plugin', () => {
     it('should handle different quality values', async () => {
       const qualityValues = ['18', '23', '28'];
 
-      await Promise.all(qualityValues.map(async (quality) => {
-        baseArgs.inputs.ffmpegQuality = quality;
-        baseArgs.variables.ffmpegCommand.streams[0].outputArgs = []; // Reset
+      await Promise.all(
+        qualityValues.map(async (quality) => {
+          baseArgs.inputs.ffmpegQuality = quality;
+          baseArgs.variables.ffmpegCommand.streams[0].outputArgs = []; // Reset
 
-        const result = await plugin(baseArgs);
+          const result = await plugin(baseArgs);
 
-        const videoStream = result.variables.ffmpegCommand.streams[0];
-        expect(videoStream.outputArgs).toContain('-crf');
-        expect(videoStream.outputArgs).toContain(quality);
-      }));
+          const videoStream = result.variables.ffmpegCommand.streams[0];
+          expect(videoStream.outputArgs).toContain('-crf');
+          expect(videoStream.outputArgs).toContain(quality);
+        }),
+      );
     });
   });
 

--- a/tests/FlowPlugins/FlowHelpers/1.0.0/hardwareUtils.test.ts
+++ b/tests/FlowPlugins/FlowHelpers/1.0.0/hardwareUtils.test.ts
@@ -1,0 +1,69 @@
+import { getEncoder } from '../../../../FlowPluginsTs/FlowHelpers/1.0.0/hardwareUtils';
+import { IpluginInputArgs } from '../../../../FlowPluginsTs/FlowHelpers/1.0.0/interfaces/interfaces';
+
+describe('hardwareUtils QSV encoder selection', () => {
+  const baseArgs = {
+    workerType: 'transcodegpu',
+    ffmpegPath: 'ffmpeg',
+    jobLog: jest.fn(),
+  } as Partial<IpluginInputArgs> as IpluginInputArgs;
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return full QSV decode args for explicit HEVC QSV selection', async () => {
+    const result = await getEncoder({
+      targetCodec: 'hevc',
+      hardwareEncoding: true,
+      hardwareType: 'qsv',
+      args: baseArgs,
+    });
+
+    expect(result.encoder).toBe('hevc_qsv');
+    expect(result.isGpu).toBe(true);
+    expect(result.inputArgs).toEqual([
+      '-hwaccel',
+      'qsv',
+      '-hwaccel_output_format',
+      'qsv',
+    ]);
+  });
+
+  it('should return full QSV decode args for explicit H264 QSV selection', async () => {
+    const result = await getEncoder({
+      targetCodec: 'h264',
+      hardwareEncoding: true,
+      hardwareType: 'qsv',
+      args: baseArgs,
+    });
+
+    expect(result.encoder).toBe('h264_qsv');
+    expect(result.isGpu).toBe(true);
+    expect(result.inputArgs).toEqual([
+      '-hwaccel',
+      'qsv',
+      '-hwaccel_output_format',
+      'qsv',
+    ]);
+  });
+
+  it('should return QSV AV1 without extra output args', async () => {
+    const result = await getEncoder({
+      targetCodec: 'av1',
+      hardwareEncoding: true,
+      hardwareType: 'qsv',
+      args: baseArgs,
+    });
+
+    expect(result.encoder).toBe('av1_qsv');
+    expect(result.isGpu).toBe(true);
+    expect(result.inputArgs).toEqual([
+      '-hwaccel',
+      'qsv',
+      '-hwaccel_output_format',
+      'qsv',
+    ]);
+    expect(result.outputArgs).toEqual([]);
+  });
+});


### PR DESCRIPTION
This pull request enhances the FFmpeg video encoder plugin, primarily by adding advanced support for Intel QSV (Quick Sync Video) hardware encoding options and improving code quality and maintainability. The most significant changes are the introduction of new QSV-specific controls, improved handling of encoder arguments, and code style updates for consistency.

**QSV (Quick Sync Video) enhancements:**

* Added new input options for QSV encoders:
  - `qsvGlobalQuality`: Enables use of `-global_quality` instead of `-qp` for QSV quality-based rate control.
  - `qsvGlobalQualityValue`: Allows setting the value for `-global_quality` when enabled.
  - `qsvLookAhead`: Enables QSV look-ahead feature.
  - `qsvExtBrc`: Enables QSV extended bitrate control (extbrc), required for look-ahead depth.
  - [`qsvLookAheadDepth`](diffhunk://#diff-08ea8b0676f32e871013d8dbf45dc02117577a2448d02996f0cd495ab92d0759R101-R126): Allows setting look-ahead depth when both look-ahead and extbrc are enabled. [[1]](diffhunk://#diff-08ea8b0676f32e871013d8dbf45dc02117577a2448d02996f0cd495ab92d0759R101-R126) [[2]](diffhunk://#diff-08ea8b0676f32e871013d8dbf45dc02117577a2448d02996f0cd495ab92d0759R152-R277)
* Plugin logic updated to:
  - Pass the new QSV options as FFmpeg arguments when appropriate.
  - Use `-global_quality` for QSV encoders if enabled, otherwise fall back to `-qp`.
  - Handle look-ahead and extbrc flags and their dependencies correctly in the FFmpeg command. [[1]](diffhunk://#diff-08ea8b0676f32e871013d8dbf45dc02117577a2448d02996f0cd495ab92d0759R348-R362) [[2]](diffhunk://#diff-08ea8b0676f32e871013d8dbf45dc02117577a2448d02996f0cd495ab92d0759L223-R372) [[3]](diffhunk://#diff-08ea8b0676f32e871013d8dbf45dc02117577a2448d02996f0cd495ab92d0759R381-R399)

**Encoder argument and detection improvements:**

* Refactored encoder definitions to add `probeInputArgs` for QSV encoders, ensuring correct hardware probing and initialization.
* Updated `getEncoder` and related logic to use these new arguments, improving hardware detection and compatibility for QSV. [[1]](diffhunk://#diff-2417789d5b16dda9d7a5773d39db449611e71d3a73cf431085a050651130a2f5L106-R121) [[2]](diffhunk://#diff-2417789d5b16dda9d7a5773d39db449611e71d3a73cf431085a050651130a2f5L204-R228) [[3]](diffhunk://#diff-2417789d5b16dda9d7a5773d39db449611e71d3a73cf431085a050651130a2f5L257-R266) [[4]](diffhunk://#diff-2417789d5b16dda9d7a5773d39db449611e71d3a73cf431085a050651130a2f5L305-R320) [[5]](diffhunk://#diff-2417789d5b16dda9d7a5773d39db449611e71d3a73cf431085a050651130a2f5L351-R344) [[6]](diffhunk://#diff-2417789d5b16dda9d7a5773d39db449611e71d3a73cf431085a050651130a2f5L388-R392)

**Code style and maintainability:**

* Standardized TypeScript type annotations and formatting across helper files for better readability and maintainability. [[1]](diffhunk://#diff-2417789d5b16dda9d7a5773d39db449611e71d3a73cf431085a050651130a2f5L32-R37) [[2]](diffhunk://#diff-2417789d5b16dda9d7a5773d39db449611e71d3a73cf431085a050651130a2f5L106-R121) [[3]](diffhunk://#diff-2417789d5b16dda9d7a5773d39db449611e71d3a73cf431085a050651130a2f5L204-R228)
* Improved logging and error handling for GPU device selection and hardware encoder detection. [[1]](diffhunk://#diff-2417789d5b16dda9d7a5773d39db449611e71d3a73cf431085a050651130a2f5L149-R158) [[2]](diffhunk://#diff-2417789d5b16dda9d7a5773d39db449611e71d3a73cf431085a050651130a2f5L163-R169) [[3]](diffhunk://#diff-2417789d5b16dda9d7a5773d39db449611e71d3a73cf431085a050651130a2f5L370-R365)
* Minor tooltip and text formatting improvements for plugin UI clarity. [[1]](diffhunk://#diff-08ea8b0676f32e871013d8dbf45dc02117577a2448d02996f0cd495ab92d0759L86-R87) [[2]](diffhunk://#diff-08ea8b0676f32e871013d8dbf45dc02117577a2448d02996f0cd495ab92d0759L142-R295) [[3]](diffhunk://#diff-08ea8b0676f32e871013d8dbf45dc02117577a2448d02996f0cd495ab92d0759L171-R318)

These changes provide users with more granular control over Intel QSV hardware encoding, improve reliability when detecting and using hardware encoders, and make the codebase easier to maintain and extend.