### PR TITLE
Add Check For Hardlinks flow plugin

### DIFF
--- a/FlowPlugins/CommunityFlowPlugins/file/checkForHardlinks/1.0.0/index.js
+++ b/FlowPlugins/CommunityFlowPlugins/file/checkForHardlinks/1.0.0/index.js
@@ -1,0 +1,101 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g = Object.create((typeof Iterator === "function" ? Iterator : Object).prototype);
+    return g.next = verb(0), g["throw"] = verb(1), g["return"] = verb(2), typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (g && (g = 0, op[0] && (_ = 0)), _) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.plugin = exports.details = void 0;
+var fs_1 = require("fs");
+/* eslint no-plusplus: ["error", { "allowForLoopAfterthoughts": true }] */
+var details = function () { return ({
+    name: 'Check For Hardlinks',
+    description: 'Check if the original file has hardlinks (nlink > 1). Useful for detecting files that share'
+        + ' data blocks on disk, allowing you to route hardlinked files differently in your flow.',
+    style: {
+        borderColor: 'orange',
+    },
+    tags: 'video',
+    isStartPlugin: false,
+    pType: '',
+    requiresVersion: '2.11.01',
+    sidebarPosition: -1,
+    icon: 'faLink',
+    inputs: [],
+    outputs: [
+        {
+            number: 1,
+            tooltip: 'File has hardlinks',
+        },
+        {
+            number: 2,
+            tooltip: 'File does not have hardlinks',
+        },
+    ],
+}); };
+exports.details = details;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+var plugin = function (args) { return __awaiter(void 0, void 0, void 0, function () {
+    var lib, filePath, stat, nlink;
+    return __generator(this, function (_a) {
+        switch (_a.label) {
+            case 0:
+                lib = require('../../../../../methods/lib')();
+                // eslint-disable-next-line @typescript-eslint/no-unused-vars,no-param-reassign
+                args.inputs = lib.loadDefaultValues(args.inputs, details);
+                filePath = args.originalLibraryFile._id;
+                args.jobLog("Checking hardlinks for: ".concat(filePath));
+                return [4 /*yield*/, fs_1.promises.stat(filePath)];
+            case 1:
+                stat = _a.sent();
+                nlink = stat.nlink;
+                args.jobLog("File has ".concat(nlink, " link(s)"));
+                if (nlink > 1) {
+                    args.jobLog('File has hardlinks, routing to output 1');
+                    return [2 /*return*/, {
+                            outputFileObj: args.inputFileObj,
+                            outputNumber: 1,
+                            variables: args.variables,
+                        }];
+                }
+                args.jobLog('File does not have hardlinks, routing to output 2');
+                return [2 /*return*/, {
+                        outputFileObj: args.inputFileObj,
+                        outputNumber: 2,
+                        variables: args.variables,
+                    }];
+        }
+    });
+}); };
+exports.plugin = plugin;

--- a/FlowPlugins/CommunityFlowPlugins/file/checkForHardlinks/1.0.0/index.js
+++ b/FlowPlugins/CommunityFlowPlugins/file/checkForHardlinks/1.0.0/index.js
@@ -46,7 +46,7 @@ var details = function () { return ({
     style: {
         borderColor: 'orange',
     },
-    tags: 'video',
+    tags: '',
     isStartPlugin: false,
     pType: '',
     requiresVersion: '2.11.01',

--- a/FlowPlugins/CommunityFlowPlugins/file/checkForHardlinks/1.0.0/index.js
+++ b/FlowPlugins/CommunityFlowPlugins/file/checkForHardlinks/1.0.0/index.js
@@ -41,7 +41,7 @@ var fs_1 = require("fs");
 /* eslint no-plusplus: ["error", { "allowForLoopAfterthoughts": true }] */
 var details = function () { return ({
     name: 'Check For Hardlinks',
-    description: 'Check if the original file has hardlinks (nlink > 1). Useful for detecting files that share'
+    description: 'Check if the working file has hardlinks (nlink > 1). Useful for detecting files that share'
         + ' data blocks on disk, allowing you to route hardlinked files differently in your flow.',
     style: {
         borderColor: 'orange',
@@ -74,7 +74,7 @@ var plugin = function (args) { return __awaiter(void 0, void 0, void 0, function
                 lib = require('../../../../../methods/lib')();
                 // eslint-disable-next-line @typescript-eslint/no-unused-vars,no-param-reassign
                 args.inputs = lib.loadDefaultValues(args.inputs, details);
-                filePath = args.originalLibraryFile._id;
+                filePath = args.inputFileObj._id;
                 args.jobLog("Checking hardlinks for: ".concat(filePath));
                 return [4 /*yield*/, fs_1.promises.stat(filePath)];
             case 1:

--- a/FlowPluginsTs/CommunityFlowPlugins/file/checkForHardlinks/1.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/file/checkForHardlinks/1.0.0/index.ts
@@ -9,7 +9,7 @@ import {
 /* eslint no-plusplus: ["error", { "allowForLoopAfterthoughts": true }] */
 const details = (): IpluginDetails => ({
   name: 'Check For Hardlinks',
-  description: 'Check if the original file has hardlinks (nlink > 1). Useful for detecting files that share'
+  description: 'Check if the working file has hardlinks (nlink > 1). Useful for detecting files that share'
   + ' data blocks on disk, allowing you to route hardlinked files differently in your flow.',
   style: {
     borderColor: 'orange',
@@ -39,7 +39,7 @@ const plugin = async (args: IpluginInputArgs): Promise<IpluginOutputArgs> => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars,no-param-reassign
   args.inputs = lib.loadDefaultValues(args.inputs, details);
 
-  const filePath = args.originalLibraryFile._id;
+  const filePath = args.inputFileObj._id;
 
   args.jobLog(`Checking hardlinks for: ${filePath}`);
 

--- a/FlowPluginsTs/CommunityFlowPlugins/file/checkForHardlinks/1.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/file/checkForHardlinks/1.0.0/index.ts
@@ -1,0 +1,70 @@
+import { promises as fsp } from 'fs';
+
+import {
+  IpluginDetails,
+  IpluginInputArgs,
+  IpluginOutputArgs,
+} from '../../../../FlowHelpers/1.0.0/interfaces/interfaces';
+
+/* eslint no-plusplus: ["error", { "allowForLoopAfterthoughts": true }] */
+const details = (): IpluginDetails => ({
+  name: 'Check For Hardlinks',
+  description: 'Check if the original file has hardlinks (nlink > 1). Useful for detecting files that share'
+  + ' data blocks on disk, allowing you to route hardlinked files differently in your flow.',
+  style: {
+    borderColor: 'orange',
+  },
+  tags: 'video',
+  isStartPlugin: false,
+  pType: '',
+  requiresVersion: '2.11.01',
+  sidebarPosition: -1,
+  icon: 'faLink',
+  inputs: [],
+  outputs: [
+    {
+      number: 1,
+      tooltip: 'File has hardlinks',
+    },
+    {
+      number: 2,
+      tooltip: 'File does not have hardlinks',
+    },
+  ],
+});
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const plugin = async (args: IpluginInputArgs): Promise<IpluginOutputArgs> => {
+  const lib = require('../../../../../methods/lib')();
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars,no-param-reassign
+  args.inputs = lib.loadDefaultValues(args.inputs, details);
+
+  const filePath = args.originalLibraryFile._id;
+
+  args.jobLog(`Checking hardlinks for: ${filePath}`);
+
+  const stat = await fsp.stat(filePath);
+  const { nlink } = stat;
+
+  args.jobLog(`File has ${nlink} link(s)`);
+
+  if (nlink > 1) {
+    args.jobLog('File has hardlinks, routing to output 1');
+    return {
+      outputFileObj: args.inputFileObj,
+      outputNumber: 1,
+      variables: args.variables,
+    };
+  }
+
+  args.jobLog('File does not have hardlinks, routing to output 2');
+  return {
+    outputFileObj: args.inputFileObj,
+    outputNumber: 2,
+    variables: args.variables,
+  };
+};
+export {
+  details,
+  plugin,
+};

--- a/FlowPluginsTs/CommunityFlowPlugins/file/checkForHardlinks/1.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/file/checkForHardlinks/1.0.0/index.ts
@@ -14,7 +14,7 @@ const details = (): IpluginDetails => ({
   style: {
     borderColor: 'orange',
   },
-  tags: 'video',
+  tags: '',
   isStartPlugin: false,
   pType: '',
   requiresVersion: '2.11.01',

--- a/tests/FlowPlugins/CommunityFlowPlugins/file/checkForHardlinks/1.0.0/index.test.ts
+++ b/tests/FlowPlugins/CommunityFlowPlugins/file/checkForHardlinks/1.0.0/index.test.ts
@@ -1,0 +1,132 @@
+import { promises as fsp } from 'fs';
+
+import { plugin, details } from
+  '../../../../../../FlowPluginsTs/CommunityFlowPlugins/file/checkForHardlinks/1.0.0/index';
+import { IpluginInputArgs } from '../../../../../../FlowPluginsTs/FlowHelpers/1.0.0/interfaces/interfaces';
+
+const sampleH264 = require('../../../../../sampleData/media/sampleH264_1.json');
+
+jest.mock('fs', () => {
+  const actual = jest.requireActual('fs');
+  return {
+    ...actual,
+    promises: {
+      ...actual.promises,
+      stat: jest.fn(),
+    },
+  };
+});
+
+describe('checkForHardlinks Plugin', () => {
+  let baseArgs: IpluginInputArgs;
+  const mockStat = fsp.stat as jest.MockedFunction<typeof fsp.stat>;
+
+  beforeEach(() => {
+    baseArgs = {
+      inputs: {},
+      variables: {
+        ffmpegCommand: {
+          init: false,
+          inputFiles: [],
+          streams: [],
+          container: '',
+          hardwareDecoding: false,
+          shouldProcess: false,
+          overallInputArguments: [],
+          overallOuputArguments: [],
+        },
+        flowFailed: false,
+        user: {},
+      },
+      inputFileObj: JSON.parse(JSON.stringify(sampleH264)),
+      originalLibraryFile: JSON.parse(JSON.stringify(sampleH264)),
+      jobLog: jest.fn(),
+    } as Partial<IpluginInputArgs> as IpluginInputArgs;
+
+    jest.clearAllMocks();
+  });
+
+  describe('details', () => {
+    it('should have the correct plugin details', () => {
+      const d = details();
+      expect(d.name).toBe('Check For Hardlinks');
+      expect(d.outputs).toHaveLength(2);
+      expect(d.outputs[0].tooltip).toBe('File has hardlinks');
+      expect(d.outputs[1].tooltip).toBe('File does not have hardlinks');
+    });
+  });
+
+  describe('hardlink detection', () => {
+    it('should return output 1 when file has hardlinks (nlink > 1)', async () => {
+      mockStat.mockResolvedValue({ nlink: 3 } as any);
+
+      const result = await plugin(baseArgs);
+
+      expect(result.outputNumber).toBe(1);
+      expect(result.outputFileObj).toBe(baseArgs.inputFileObj);
+      expect(mockStat).toHaveBeenCalledWith(baseArgs.originalLibraryFile._id);
+      expect(baseArgs.jobLog).toHaveBeenCalledWith(
+        expect.stringContaining('3 link(s)'),
+      );
+    });
+
+    it('should return output 2 when file has no hardlinks (nlink === 1)', async () => {
+      mockStat.mockResolvedValue({ nlink: 1 } as any);
+
+      const result = await plugin(baseArgs);
+
+      expect(result.outputNumber).toBe(2);
+      expect(result.outputFileObj).toBe(baseArgs.inputFileObj);
+      expect(baseArgs.jobLog).toHaveBeenCalledWith(
+        expect.stringContaining('1 link(s)'),
+      );
+    });
+
+    it('should return output 1 when file has exactly 2 links', async () => {
+      mockStat.mockResolvedValue({ nlink: 2 } as any);
+
+      const result = await plugin(baseArgs);
+
+      expect(result.outputNumber).toBe(1);
+    });
+  });
+
+  describe('variable propagation', () => {
+    it('should preserve variables in output', async () => {
+      mockStat.mockResolvedValue({ nlink: 1 } as any);
+      baseArgs.variables.user = { testVar: 'testValue' };
+
+      const result = await plugin(baseArgs);
+
+      expect(result.variables.user).toEqual({ testVar: 'testValue' });
+    });
+  });
+
+  describe('logging', () => {
+    it('should log the file path being checked', async () => {
+      mockStat.mockResolvedValue({ nlink: 1 } as any);
+
+      await plugin(baseArgs);
+
+      expect(baseArgs.jobLog).toHaveBeenCalledWith(
+        expect.stringContaining(baseArgs.originalLibraryFile._id),
+      );
+    });
+
+    it('should log the routing decision for hardlinked files', async () => {
+      mockStat.mockResolvedValue({ nlink: 2 } as any);
+
+      await plugin(baseArgs);
+
+      expect(baseArgs.jobLog).toHaveBeenCalledWith('File has hardlinks, routing to output 1');
+    });
+
+    it('should log the routing decision for non-hardlinked files', async () => {
+      mockStat.mockResolvedValue({ nlink: 1 } as any);
+
+      await plugin(baseArgs);
+
+      expect(baseArgs.jobLog).toHaveBeenCalledWith('File does not have hardlinks, routing to output 2');
+    });
+  });
+});

--- a/tests/FlowPlugins/CommunityFlowPlugins/file/checkForHardlinks/1.0.0/index.test.ts
+++ b/tests/FlowPlugins/CommunityFlowPlugins/file/checkForHardlinks/1.0.0/index.test.ts
@@ -64,7 +64,7 @@ describe('checkForHardlinks Plugin', () => {
 
       expect(result.outputNumber).toBe(1);
       expect(result.outputFileObj).toBe(baseArgs.inputFileObj);
-      expect(mockStat).toHaveBeenCalledWith(baseArgs.originalLibraryFile._id);
+      expect(mockStat).toHaveBeenCalledWith(baseArgs.inputFileObj._id);
       expect(baseArgs.jobLog).toHaveBeenCalledWith(
         expect.stringContaining('3 link(s)'),
       );
@@ -109,7 +109,7 @@ describe('checkForHardlinks Plugin', () => {
       await plugin(baseArgs);
 
       expect(baseArgs.jobLog).toHaveBeenCalledWith(
-        expect.stringContaining(baseArgs.originalLibraryFile._id),
+        expect.stringContaining(baseArgs.inputFileObj._id),
       );
     });
 


### PR DESCRIPTION
## Summary
- Adds a new flow plugin `checkForHardlinks` that checks if the original library file has hardlinks (nlink > 1) using `fs.stat`
- Routes to output 1 if the file has hardlinks, output 2 if it does not
- Useful for detecting files that share data blocks on disk so they can be handled differently in a flow (e.g. copy before transcoding to avoid breaking hardlinks)

## Test plan
- [x] Unit tests added covering hardlink detection, variable propagation, and logging
- [x] All 8 tests pass via `npm run test:flows`
- [x] TypeScript compiles cleanly with `tsc`