### PR TITLE
chore: bump CI to Node 22 / macos-26 and rewrite README for first-time contributors

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -11,12 +11,12 @@ jobs:
   test:
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [22.x]
         os:
           [
             ["ubuntu-22.04"],
             ["windows-2022"],
-            ["macos-14"],
+            ["macos-26"],
           ]
     runs-on: ${{ matrix.os }}
 
@@ -53,10 +53,10 @@ jobs:
       with:
         ref: ${{ github.event.pull_request.head.sha }}
 
-    - name: Use Node.js 18.x
+    - name: Use Node.js 22.x
       uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1
       with:
-        node-version: 18.x
+        node-version: 22.x
     - run: npm ci
     - run: npm i -g typescript@5.9.3 && tsc
     - run: npm run test:flows
@@ -79,7 +79,7 @@ jobs:
   
     - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
       with:
-        node-version: '18.x'
+        node-version: '22.x'
 
     - run: npm ci && npm i -g typescript@5.9.3 && rm -rdf ./FlowPlugins && tsc -v && tsc
 

--- a/README.md
+++ b/README.md
@@ -2,22 +2,54 @@
   <img src="https://s7.gifyu.com/images/GifCroppedTran.gif"/>
 </p>
 
-
 # Tdarr_Plugins
 
 Visit the docs for more info:
 https://docs.tdarr.io/docs/plugins/basics
 
-
 ### Development
 
-Make sure NodeJS v16 is installed
+#### 1. Install NodeJS v22 via nvm
 
-Install dependencies:
+nvm (Node Version Manager) lets you install and switch between Node.js versions.
+
+- macOS / Linux: follow the install instructions at https://github.com/nvm-sh/nvm (copy the `curl` command from that page and paste it into your terminal). Then **close and reopen your terminal**.
+- Windows: install nvm-windows instead from https://github.com/coreybutler/nvm-windows/releases (download `nvm-setup.exe` and run it).
+
+Then install and use Node 22:
+
+```
+nvm install 22
+nvm use 22
+```
+
+Verify:
+
+```
+node -v
+npm -v
+```
+
+You should see a version starting with `v22.`.
+
+#### 2. Clone this repo
+
+In your terminal, navigate to where you want the code (for example your home folder or `C:/`), then run:
+
+```
+git clone https://github.com/HaveAGitGat/Tdarr_Plugins.git
+cd Tdarr_Plugins
+```
+
+#### 3. Install dependencies
+
+From inside the `Tdarr_Plugins` folder:
 
 `npm install`
 
-Run ESLint:
+#### 4. Common commands
+
+Run ESLint (auto-fix code style issues):
 
 `npm run lint:fix`
 
@@ -29,15 +61,26 @@ Run tests:
 
 `npm run test`
 
+Run flow plugin tests:
+
+`npm run test:flows`
 
 # Steps to write a Tdarr Flow plugin:
 
-1. Clone this repo
-2. Set env variable `pluginsDir` to the location of the plugins repo and run Tdarr Server and Node. E.g. `export pluginsDir=C:/Tdarr_Plugins`
-3. Browse the typescript plugins here https://github.com/HaveAGitGat/Tdarr_Plugins/tree/master/FlowPluginsTs/CommunityFlowPlugins and make edits locally or create a new one locally: 
-4. Make sure typescript is intalled with `npm i -g typescript` then run `tsc` to compile the changes.
-5. Refresh the browser and Tdarr will pick up the changes
+1. Clone this repo (see step 2 above if you haven't already).
+2. Open a terminal and set the `pluginsDir` env variable to the location where you cloned this repo. Use the command that matches your OS / shell:
+   - macOS / Linux: `export pluginsDir=/path/to/Tdarr_Plugins`
+   - Windows (PowerShell): `$env:pluginsDir="C:/Tdarr_Plugins"`
+   - Windows (Command Prompt): `set pluginsDir=C:/Tdarr_Plugins`
 
-Note, `pluginsDir` directories that contain a `.git` folder (such as when cloning this repo) will cause Tdarr to skip plugin updates to prevent overwriting development changes.
+   Then, **in the same terminal** (so it inherits the env variable), start Tdarr Server or Tdarr Node by running its executable. For example:
+   - macOS / Linux: `./Tdarr_Server` or `./Tdarr_Node`
+   - Windows: `Tdarr_Server.exe` or `Tdarr_Node.exe`
 
+   The env variable only applies to processes started from that same terminal session. If you close the terminal, you will need to set the variable again before starting Tdarr.
 
+3. Browse the typescript plugins here https://github.com/HaveAGitGat/Tdarr_Plugins/tree/master/FlowPluginsTs/CommunityFlowPlugins and edit one locally, or create a new one.
+4. Install TypeScript globally with `npm i -g typescript@5.9.3`, then run `tsc` from the repo folder to compile your changes. `tsc` reads the TypeScript sources from `FlowPluginsTs/` and writes the compiled JavaScript into `FlowPlugins/` (the folder Tdarr actually loads). Do not edit files under `FlowPlugins/` directly, they will be overwritten on the next `tsc` run.
+5. Refresh the browser and Tdarr will pick up the changes.
+
+Note: `pluginsDir` directories that contain a `.git` folder (such as when cloning this repo) will cause Tdarr to skip plugin updates, to prevent overwriting your development changes.


### PR DESCRIPTION
## Summary

- **CI (`.github/workflows/lint_and_test.yml`)**:
  - Bump Node matrix from `18.x` to `22.x`
  - Move the macOS runner from `macos-14` to the GA `macos-26`
- **`README.md`**: update Development section.
  - Pin global TypeScript install to `typescript@5.9.3` to match CI.
  - Document that `tsc` compiles sources from `FlowPluginsTs/` into `FlowPlugins/`, and warn against editing the compiled folder directly.

