### PR TITLE
fix: ffmpegCommandRemoveStreamByProperty skipping falsy values

### DIFF
--- a/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandRemoveStreamByProperty/1.0.0/index.js
+++ b/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandRemoveStreamByProperty/1.0.0/index.js
@@ -97,7 +97,7 @@ var plugin = function (args) {
         else {
             target = stream[propertyToCheck];
         }
-        if (!target) {
+        if (target === undefined || target === null) {
             return;
         }
         var prop = String(target).toLowerCase();

--- a/FlowPluginsTs/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandRemoveStreamByProperty/1.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandRemoveStreamByProperty/1.0.0/index.ts
@@ -123,7 +123,7 @@ const plugin = (args: IpluginInputArgs): IpluginOutputArgs => {
         target = stream[propertyToCheck];
       }
 
-      if (!target) {
+      if (target === undefined || target === null) {
         return;
       }
 

--- a/tests/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandRemoveStreamByProperty/1.0.0/index.test.ts
+++ b/tests/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandRemoveStreamByProperty/1.0.0/index.test.ts
@@ -777,4 +777,113 @@ describe('ffmpegCommandRemoveStreamByProperty Plugin', () => {
       expect(itStream?.removed).toBe(false);
     });
   });
+
+  describe('Falsy property values (issue #959)', () => {
+    beforeEach(() => {
+      baseArgs.variables.ffmpegCommand.streams = [
+        {
+          index: 0,
+          codec_name: 'subrip',
+          codec_type: 'subtitle',
+          removed: false,
+          forceEncoding: false,
+          mapArgs: ['-map', '0:0'],
+          inputArgs: [],
+          outputArgs: [],
+          disposition: { forced: 1 },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any,
+        {
+          index: 1,
+          codec_name: 'subrip',
+          codec_type: 'subtitle',
+          removed: false,
+          forceEncoding: false,
+          mapArgs: ['-map', '0:1'],
+          inputArgs: [],
+          outputArgs: [],
+          disposition: { forced: 0 },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any,
+      ];
+    });
+
+    it('should remove non-forced subtitle when using disposition.forced with not_includes=1', () => {
+      baseArgs.inputs.codecType = 'subtitle';
+      baseArgs.inputs.propertyToCheck = 'disposition.forced';
+      baseArgs.inputs.valuesToRemove = '1';
+      baseArgs.inputs.condition = 'not_includes';
+
+      const result = plugin(baseArgs);
+
+      const forcedStream = result.variables.ffmpegCommand.streams.find(
+        (stream) => stream.index === 0,
+      );
+      const nonForcedStream = result.variables.ffmpegCommand.streams.find(
+        (stream) => stream.index === 1,
+      );
+      expect(forcedStream?.removed).toBe(false);
+      expect(nonForcedStream?.removed).toBe(true);
+    });
+
+    it('should remove forced subtitle when using disposition.forced with includes=1', () => {
+      baseArgs.inputs.codecType = 'subtitle';
+      baseArgs.inputs.propertyToCheck = 'disposition.forced';
+      baseArgs.inputs.valuesToRemove = '1';
+      baseArgs.inputs.condition = 'includes';
+
+      const result = plugin(baseArgs);
+
+      const forcedStream = result.variables.ffmpegCommand.streams.find(
+        (stream) => stream.index === 0,
+      );
+      const nonForcedStream = result.variables.ffmpegCommand.streams.find(
+        (stream) => stream.index === 1,
+      );
+      expect(forcedStream?.removed).toBe(true);
+      expect(nonForcedStream?.removed).toBe(false);
+    });
+
+    it('should evaluate numeric zero properties instead of skipping them', () => {
+      baseArgs.variables.ffmpegCommand.streams = [
+        {
+          index: 0,
+          codec_name: 'aac',
+          codec_type: 'audio',
+          channels: 0,
+          removed: false,
+          forceEncoding: false,
+          mapArgs: ['-map', '0:0'],
+          inputArgs: [],
+          outputArgs: [],
+        },
+        {
+          index: 1,
+          codec_name: 'aac',
+          codec_type: 'audio',
+          channels: 2,
+          removed: false,
+          forceEncoding: false,
+          mapArgs: ['-map', '0:1'],
+          inputArgs: [],
+          outputArgs: [],
+        },
+      ];
+      baseArgs.inputs.codecType = 'audio';
+      baseArgs.inputs.propertyToCheck = 'channels';
+      baseArgs.inputs.valuesToRemove = '0';
+      baseArgs.inputs.condition = 'includes';
+
+      const result = plugin(baseArgs);
+
+      const zeroChannels = result.variables.ffmpegCommand.streams.find(
+        (stream) => stream.index === 0,
+      );
+      const twoChannels = result.variables.ffmpegCommand.streams.find(
+        (stream) => stream.index === 1,
+      );
+      expect(zeroChannels?.removed).toBe(true);
+      expect(twoChannels?.removed).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #959.

`ffmpegCommandRemoveStreamByProperty` used a truthy guard (`if (!target) return;`) on the extracted stream property, so any property whose value was `0`, `""`, `false`, or `NaN` was silently skipped before any condition evaluation.

The most visible symptom is the one reported in #959: with `propertyToCheck=disposition.forced, valuesToRemove=1, condition=not_includes`, non-forced subtitles (`disposition.forced = 0`) were never removed because the stream bailed out at the guard and `stream.removed` was never set.

The fix replaces the truthy check with an explicit nullish check (`target === undefined || target === null`), so numeric zero and empty-string properties participate in the comparison. Missing properties still short-circuit as before, preserving the existing `tags.title` (missing nested property) behavior.

## Test plan

- [x] Existing 27 tests still pass
- [x] New regression test: `disposition.forced=0` with `not_includes=1` removes the non-forced subtitle and keeps the forced one
- [x] New test: `disposition.forced=1` with `includes=1` removes the forced subtitle and keeps the non-forced one
- [x] New test: numeric `channels=0` with `includes=0` removes the zero-channel stream
- [x] `npx jest tests/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandRemoveStreamByProperty` — 30/30 pass