### PR TITLE
fix: replaceOriginalFile preserves original until swap completes

### DIFF
--- a/FlowPlugins/CommunityFlowPlugins/file/replaceOriginalFile/1.0.0/index.js
+++ b/FlowPlugins/CommunityFlowPlugins/file/replaceOriginalFile/1.0.0/index.js
@@ -46,7 +46,7 @@ var fileUtils_1 = require("../../../../FlowHelpers/1.0.0/fileUtils");
 /* eslint no-plusplus: ["error", { "allowForLoopAfterthoughts": true }] */
 var details = function () { return ({
     name: 'Replace Original File',
-    description: "\n  Replace the original file with the 'working' file passed into this plugin. \n  If the file hasn't changed then no action is taken.\n  Note: The 'working' filename and container will replace the original filename and container.\n  ",
+    description: "\n  Replace the original file with the 'working' file passed into this plugin.\n  If the file hasn't changed then no action is taken.\n  Note: The 'working' filename and container will replace the original filename and container.\n  ",
     style: {
         borderColor: 'green',
     },
@@ -67,7 +67,7 @@ var details = function () { return ({
 exports.details = details;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 var plugin = function (args) { return __awaiter(void 0, void 0, void 0, function () {
-    var lib, currentPath, orignalFolder, fileName, container, newPath, newPathTmp, originalFileExists, currentFileIsNotOriginal;
+    var lib, currentPath, originalPath, orignalFolder, fileName, container, newPath, newPathTmp, originalPathOld, originalFileExists, currentFileIsNotOriginal, shouldRenameOriginal, originalRenamed, staleErr_1, err_1, cleanupErr_1, err_2, restoreErr_1, err_3;
     return __generator(this, function (_a) {
         switch (_a.label) {
             case 0:
@@ -85,19 +85,23 @@ var plugin = function (args) { return __awaiter(void 0, void 0, void 0, function
                 }
                 args.jobLog('File has changed, replacing original file');
                 currentPath = args.inputFileObj._id;
-                orignalFolder = (0, fileUtils_1.getFileAbsoluteDir)(args.originalLibraryFile._id);
+                originalPath = args.originalLibraryFile._id;
+                orignalFolder = (0, fileUtils_1.getFileAbsoluteDir)(originalPath);
                 fileName = (0, fileUtils_1.getFileName)(args.inputFileObj._id);
                 container = (0, fileUtils_1.getContainer)(args.inputFileObj._id);
                 newPath = "".concat(orignalFolder, "/").concat(fileName, ".").concat(container);
                 newPathTmp = "".concat(newPath, ".tmp");
+                originalPathOld = "".concat(originalPath, ".old");
                 args.jobLog(JSON.stringify({
                     currentPath: currentPath,
                     newPath: newPath,
                     newPathTmp: newPathTmp,
+                    originalPathOld: originalPathOld,
                 }));
                 return [4 /*yield*/, new Promise(function (resolve) { return setTimeout(resolve, 2000); })];
             case 1:
                 _a.sent();
+                // Step 1: move the working/cache file into the original folder as .tmp
                 return [4 /*yield*/, (0, fileMoveOrCopy_1.default)({
                         operation: 'move',
                         sourcePath: currentPath,
@@ -105,40 +109,112 @@ var plugin = function (args) { return __awaiter(void 0, void 0, void 0, function
                         args: args,
                     })];
             case 2:
+                // Step 1: move the working/cache file into the original folder as .tmp
                 _a.sent();
-                return [4 /*yield*/, (0, fileUtils_1.fileExists)(args.originalLibraryFile._id)];
+                return [4 /*yield*/, (0, fileUtils_1.fileExists)(originalPath)];
             case 3:
                 originalFileExists = _a.sent();
-                currentFileIsNotOriginal = args.originalLibraryFile._id !== currentPath;
+                currentFileIsNotOriginal = originalPath !== currentPath;
+                shouldRenameOriginal = originalFileExists && currentFileIsNotOriginal;
                 args.jobLog(JSON.stringify({
                     originalFileExists: originalFileExists,
                     currentFileIsNotOriginal: currentFileIsNotOriginal,
                 }));
-                if (!(originalFileExists
-                    && currentFileIsNotOriginal)) return [3 /*break*/, 5];
-                args.jobLog("Deleting original file:".concat(args.originalLibraryFile._id));
-                return [4 /*yield*/, fs_1.promises.unlink(args.originalLibraryFile._id)];
+                originalRenamed = false;
+                if (!shouldRenameOriginal) return [3 /*break*/, 16];
+                return [4 /*yield*/, (0, fileUtils_1.fileExists)(originalPathOld)];
             case 4:
-                _a.sent();
+                if (!_a.sent()) return [3 /*break*/, 8];
+                args.jobLog("Removing stale file at ".concat(originalPathOld));
                 _a.label = 5;
-            case 5: return [4 /*yield*/, new Promise(function (resolve) { return setTimeout(resolve, 2000); })];
+            case 5:
+                _a.trys.push([5, 7, , 8]);
+                return [4 /*yield*/, fs_1.promises.unlink(originalPathOld)];
             case 6:
                 _a.sent();
+                return [3 /*break*/, 8];
+            case 7:
+                staleErr_1 = _a.sent();
+                args.jobLog("Failed to remove stale file ".concat(originalPathOld, ": ").concat(JSON.stringify(staleErr_1)));
+                return [3 /*break*/, 8];
+            case 8:
+                args.jobLog("Renaming original file to: ".concat(originalPathOld));
+                _a.label = 9;
+            case 9:
+                _a.trys.push([9, 11, , 16]);
+                return [4 /*yield*/, fs_1.promises.rename(originalPath, originalPathOld)];
+            case 10:
+                _a.sent();
+                originalRenamed = true;
+                return [3 /*break*/, 16];
+            case 11:
+                err_1 = _a.sent();
+                args.jobLog("Failed to rename original file aside: ".concat(JSON.stringify(err_1)));
+                _a.label = 12;
+            case 12:
+                _a.trys.push([12, 14, , 15]);
+                return [4 /*yield*/, fs_1.promises.unlink(newPathTmp)];
+            case 13:
+                _a.sent();
+                return [3 /*break*/, 15];
+            case 14:
+                cleanupErr_1 = _a.sent();
+                args.jobLog("Failed to clean up temporary file ".concat(newPathTmp, ": ").concat(JSON.stringify(cleanupErr_1)));
+                return [3 /*break*/, 15];
+            case 15: throw err_1;
+            case 16: return [4 /*yield*/, new Promise(function (resolve) { return setTimeout(resolve, 2000); })];
+            case 17:
+                _a.sent();
+                _a.label = 18;
+            case 18:
+                _a.trys.push([18, 20, , 25]);
                 return [4 /*yield*/, (0, fileMoveOrCopy_1.default)({
                         operation: 'move',
                         sourcePath: newPathTmp,
                         destinationPath: newPath,
                         args: args,
                     })];
-            case 7:
+            case 19:
                 _a.sent();
-                return [2 /*return*/, {
-                        outputFileObj: {
-                            _id: newPath,
-                        },
-                        outputNumber: 1,
-                        variables: args.variables,
-                    }];
+                return [3 /*break*/, 25];
+            case 20:
+                err_2 = _a.sent();
+                args.jobLog("Failed to move ".concat(newPathTmp, " to ").concat(newPath, ": ").concat(JSON.stringify(err_2)));
+                if (!originalRenamed) return [3 /*break*/, 24];
+                args.jobLog("Restoring original file from ".concat(originalPathOld));
+                _a.label = 21;
+            case 21:
+                _a.trys.push([21, 23, , 24]);
+                return [4 /*yield*/, fs_1.promises.rename(originalPathOld, originalPath)];
+            case 22:
+                _a.sent();
+                return [3 /*break*/, 24];
+            case 23:
+                restoreErr_1 = _a.sent();
+                args.jobLog("Failed to restore original file: ".concat(JSON.stringify(restoreErr_1)));
+                return [3 /*break*/, 24];
+            case 24: throw err_2;
+            case 25:
+                if (!originalRenamed) return [3 /*break*/, 29];
+                args.jobLog("Deleting renamed original file: ".concat(originalPathOld));
+                _a.label = 26;
+            case 26:
+                _a.trys.push([26, 28, , 29]);
+                return [4 /*yield*/, fs_1.promises.unlink(originalPathOld)];
+            case 27:
+                _a.sent();
+                return [3 /*break*/, 29];
+            case 28:
+                err_3 = _a.sent();
+                args.jobLog("Failed to delete renamed original file ".concat(originalPathOld, ": ").concat(JSON.stringify(err_3)));
+                return [3 /*break*/, 29];
+            case 29: return [2 /*return*/, {
+                    outputFileObj: {
+                        _id: newPath,
+                    },
+                    outputNumber: 1,
+                    variables: args.variables,
+                }];
         }
     });
 }); };

--- a/FlowPlugins/CommunityFlowPlugins/file/replaceOriginalFile/1.0.0/index.js
+++ b/FlowPlugins/CommunityFlowPlugins/file/replaceOriginalFile/1.0.0/index.js
@@ -91,7 +91,7 @@ var plugin = function (args) { return __awaiter(void 0, void 0, void 0, function
                 container = (0, fileUtils_1.getContainer)(args.inputFileObj._id);
                 newPath = "".concat(orignalFolder, "/").concat(fileName, ".").concat(container);
                 newPathTmp = "".concat(newPath, ".tmp");
-                originalPathOld = "".concat(originalPath, ".old");
+                originalPathOld = "".concat(originalPath, ".partial.old");
                 args.jobLog(JSON.stringify({
                     currentPath: currentPath,
                     newPath: newPath,

--- a/FlowPluginsTs/CommunityFlowPlugins/file/replaceOriginalFile/1.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/file/replaceOriginalFile/1.0.0/index.ts
@@ -64,7 +64,9 @@ const plugin = async (args: IpluginInputArgs): Promise<IpluginOutputArgs> => {
 
   const newPath = `${orignalFolder}/${fileName}.${container}`;
   const newPathTmp = `${newPath}.tmp`;
-  const originalPathOld = `${originalPath}.old`;
+  // Suffix includes `.partial` so Tdarr's folder watcher ignores this sentinel if a crash
+  // between rename-aside and final move leaves it on disk.
+  const originalPathOld = `${originalPath}.partial.old`;
 
   args.jobLog(JSON.stringify({
     currentPath,

--- a/FlowPluginsTs/CommunityFlowPlugins/file/replaceOriginalFile/1.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/file/replaceOriginalFile/1.0.0/index.ts
@@ -14,7 +14,7 @@ import {
 const details = (): IpluginDetails => ({
   name: 'Replace Original File',
   description: `
-  Replace the original file with the 'working' file passed into this plugin. 
+  Replace the original file with the 'working' file passed into this plugin.
   If the file hasn't changed then no action is taken.
   Note: The 'working' filename and container will replace the original filename and container.
   `,
@@ -57,21 +57,25 @@ const plugin = async (args: IpluginInputArgs): Promise<IpluginOutputArgs> => {
   args.jobLog('File has changed, replacing original file');
 
   const currentPath = args.inputFileObj._id;
-  const orignalFolder = getFileAbsoluteDir(args.originalLibraryFile._id);
+  const originalPath = args.originalLibraryFile._id;
+  const orignalFolder = getFileAbsoluteDir(originalPath);
   const fileName = getFileName(args.inputFileObj._id);
   const container = getContainer(args.inputFileObj._id);
 
   const newPath = `${orignalFolder}/${fileName}.${container}`;
   const newPathTmp = `${newPath}.tmp`;
+  const originalPathOld = `${originalPath}.old`;
 
   args.jobLog(JSON.stringify({
     currentPath,
     newPath,
     newPathTmp,
+    originalPathOld,
   }));
 
   await new Promise((resolve) => setTimeout(resolve, 2000));
 
+  // Step 1: move the working/cache file into the original folder as .tmp
   await fileMoveOrCopy({
     operation: 'move',
     sourcePath: currentPath,
@@ -79,31 +83,77 @@ const plugin = async (args: IpluginInputArgs): Promise<IpluginOutputArgs> => {
     args,
   });
 
-  const originalFileExists = await fileExists(args.originalLibraryFile._id);
-  const currentFileIsNotOriginal = args.originalLibraryFile._id !== currentPath;
+  const originalFileExists = await fileExists(originalPath);
+  const currentFileIsNotOriginal = originalPath !== currentPath;
+  const shouldRenameOriginal = originalFileExists && currentFileIsNotOriginal;
 
   args.jobLog(JSON.stringify({
     originalFileExists,
     currentFileIsNotOriginal,
   }));
 
-  // delete original file
-  if (
-    originalFileExists
-    && currentFileIsNotOriginal
-  ) {
-    args.jobLog(`Deleting original file:${args.originalLibraryFile._id}`);
-    await fsp.unlink(args.originalLibraryFile._id);
+  // Step 2: rename the original file aside (non-destructive) so it can be restored on failure
+  let originalRenamed = false;
+  if (shouldRenameOriginal) {
+    // Clear any stale .old left by a prior failed run so fsp.rename succeeds on Windows (where
+    // rename does not overwrite an existing target).
+    if (await fileExists(originalPathOld)) {
+      args.jobLog(`Removing stale file at ${originalPathOld}`);
+      try {
+        await fsp.unlink(originalPathOld);
+      } catch (staleErr) {
+        args.jobLog(`Failed to remove stale file ${originalPathOld}: ${JSON.stringify(staleErr)}`);
+      }
+    }
+
+    args.jobLog(`Renaming original file to: ${originalPathOld}`);
+    try {
+      await fsp.rename(originalPath, originalPathOld);
+      originalRenamed = true;
+    } catch (err) {
+      args.jobLog(`Failed to rename original file aside: ${JSON.stringify(err)}`);
+      // Best-effort cleanup of the staged .tmp file so we don't leave orphans
+      try {
+        await fsp.unlink(newPathTmp);
+      } catch (cleanupErr) {
+        args.jobLog(`Failed to clean up temporary file ${newPathTmp}: ${JSON.stringify(cleanupErr)}`);
+      }
+      throw err;
+    }
   }
 
   await new Promise((resolve) => setTimeout(resolve, 2000));
 
-  await fileMoveOrCopy({
-    operation: 'move',
-    sourcePath: newPathTmp,
-    destinationPath: newPath,
-    args,
-  });
+  // Step 3: put the new file in place; if it fails, restore the original from .old
+  try {
+    await fileMoveOrCopy({
+      operation: 'move',
+      sourcePath: newPathTmp,
+      destinationPath: newPath,
+      args,
+    });
+  } catch (err) {
+    args.jobLog(`Failed to move ${newPathTmp} to ${newPath}: ${JSON.stringify(err)}`);
+    if (originalRenamed) {
+      args.jobLog(`Restoring original file from ${originalPathOld}`);
+      try {
+        await fsp.rename(originalPathOld, originalPath);
+      } catch (restoreErr) {
+        args.jobLog(`Failed to restore original file: ${JSON.stringify(restoreErr)}`);
+      }
+    }
+    throw err;
+  }
+
+  // Step 4: new file is in place; remove the renamed-aside original
+  if (originalRenamed) {
+    args.jobLog(`Deleting renamed original file: ${originalPathOld}`);
+    try {
+      await fsp.unlink(originalPathOld);
+    } catch (err) {
+      args.jobLog(`Failed to delete renamed original file ${originalPathOld}: ${JSON.stringify(err)}`);
+    }
+  }
 
   return {
     outputFileObj: {

--- a/tests/FlowPlugins/CommunityFlowPlugins/file/replaceOriginalFile/1.0.0/index.test.ts
+++ b/tests/FlowPlugins/CommunityFlowPlugins/file/replaceOriginalFile/1.0.0/index.test.ts
@@ -169,9 +169,9 @@ describe('replaceOriginalFile Plugin', () => {
       // Verify safe-swap ordering: tmp staged -> original renamed aside -> tmp into place -> .old deleted
       expect(callOrder).toEqual([
         'move:/working/path/video_transcoded.mkv->/original/path/video_transcoded.mkv.tmp',
-        'rename:/original/path/video.mp4->/original/path/video.mp4.old',
+        'rename:/original/path/video.mp4->/original/path/video.mp4.partial.old',
         'move:/original/path/video_transcoded.mkv.tmp->/original/path/video_transcoded.mkv',
-        'unlink:/original/path/video.mp4.old',
+        'unlink:/original/path/video.mp4.partial.old',
       ]);
 
       expect(result.outputFileObj._id).toBe('/original/path/video_transcoded.mkv');
@@ -185,16 +185,16 @@ describe('replaceOriginalFile Plugin', () => {
       expect(mockFileExists).toHaveBeenCalledWith('/original/path/video.mp4');
       expect(mockFsPromises.rename).toHaveBeenCalledWith(
         '/original/path/video.mp4',
-        '/original/path/video.mp4.old',
+        '/original/path/video.mp4.partial.old',
       );
-      expect(mockFsPromises.unlink).toHaveBeenCalledWith('/original/path/video.mp4.old');
+      expect(mockFsPromises.unlink).toHaveBeenCalledWith('/original/path/video.mp4.partial.old');
       // Original path must never be unlinked directly - only the .old copy
       expect(mockFsPromises.unlink).not.toHaveBeenCalledWith('/original/path/video.mp4');
       expect(baseArgs.jobLog).toHaveBeenCalledWith(
-        'Renaming original file to: /original/path/video.mp4.old',
+        'Renaming original file to: /original/path/video.mp4.partial.old',
       );
       expect(baseArgs.jobLog).toHaveBeenCalledWith(
-        'Deleting renamed original file: /original/path/video.mp4.old',
+        'Deleting renamed original file: /original/path/video.mp4.partial.old',
       );
       expect(result.outputNumber).toBe(1);
     });
@@ -229,7 +229,7 @@ describe('replaceOriginalFile Plugin', () => {
       // fileExists is called for originalPath AND originalPathOld; stub both
       mockFileExists.mockImplementation(async (p: string) => {
         if (p === '/original/path/video.mp4') return true;
-        if (p === '/original/path/video.mp4.old') return true;
+        if (p === '/original/path/video.mp4.partial.old') return true;
         return false;
       });
 
@@ -245,12 +245,12 @@ describe('replaceOriginalFile Plugin', () => {
 
       // Stale .old must be removed BEFORE the rename-aside
       expect(callOrder).toEqual([
-        'unlink:/original/path/video.mp4.old',
-        'rename:/original/path/video.mp4->/original/path/video.mp4.old',
-        'unlink:/original/path/video.mp4.old',
+        'unlink:/original/path/video.mp4.partial.old',
+        'rename:/original/path/video.mp4->/original/path/video.mp4.partial.old',
+        'unlink:/original/path/video.mp4.partial.old',
       ]);
       expect(baseArgs.jobLog).toHaveBeenCalledWith(
-        'Removing stale file at /original/path/video.mp4.old',
+        'Removing stale file at /original/path/video.mp4.partial.old',
       );
     });
 
@@ -261,7 +261,7 @@ describe('replaceOriginalFile Plugin', () => {
 
       // Only the final cleanup unlink of .old, not a pre-rename one
       expect(mockFsPromises.unlink).toHaveBeenCalledTimes(1);
-      expect(mockFsPromises.unlink).toHaveBeenCalledWith('/original/path/video.mp4.old');
+      expect(mockFsPromises.unlink).toHaveBeenCalledWith('/original/path/video.mp4.partial.old');
       expect(baseArgs.jobLog).not.toHaveBeenCalledWith(
         expect.stringContaining('Removing stale file'),
       );
@@ -280,15 +280,15 @@ describe('replaceOriginalFile Plugin', () => {
       // Original should have been renamed aside
       expect(mockFsPromises.rename).toHaveBeenCalledWith(
         '/original/path/video.mp4',
-        '/original/path/video.mp4.old',
+        '/original/path/video.mp4.partial.old',
       );
       // And restored on failure
       expect(mockFsPromises.rename).toHaveBeenCalledWith(
-        '/original/path/video.mp4.old',
+        '/original/path/video.mp4.partial.old',
         '/original/path/video.mp4',
       );
       // The .old file must NOT be deleted when the swap failed
-      expect(mockFsPromises.unlink).not.toHaveBeenCalledWith('/original/path/video.mp4.old');
+      expect(mockFsPromises.unlink).not.toHaveBeenCalledWith('/original/path/video.mp4.partial.old');
     });
 
     it('should clean up staged .tmp and rethrow if renaming original aside fails', async () => {
@@ -397,10 +397,10 @@ describe('replaceOriginalFile Plugin', () => {
       await plugin(baseArgs);
 
       expect(baseArgs.jobLog).toHaveBeenCalledWith(
-        'Renaming original file to: /original/path/video.mp4.old',
+        'Renaming original file to: /original/path/video.mp4.partial.old',
       );
       expect(baseArgs.jobLog).toHaveBeenCalledWith(
-        'Deleting renamed original file: /original/path/video.mp4.old',
+        'Deleting renamed original file: /original/path/video.mp4.partial.old',
       );
     });
   });

--- a/tests/FlowPlugins/CommunityFlowPlugins/file/replaceOriginalFile/1.0.0/index.test.ts
+++ b/tests/FlowPlugins/CommunityFlowPlugins/file/replaceOriginalFile/1.0.0/index.test.ts
@@ -8,6 +8,7 @@ const mockFileMoveOrCopy = jest.fn();
 // Mock fs promises
 const mockFsPromises = {
   unlink: jest.fn(),
+  rename: jest.fn(),
 };
 
 // Mock fileExists
@@ -50,8 +51,13 @@ describe('replaceOriginalFile Plugin', () => {
 
     // Setup default mock implementations
     mockFileMoveOrCopy.mockResolvedValue(true);
-    mockFileExists.mockResolvedValue(true);
+    // Default: the original file exists, the .old sentinel does not.
+    // Individual tests that need different behavior override this.
+    mockFileExists.mockImplementation(
+      async (p: string) => p === '/original/path/video.mp4',
+    );
     mockFsPromises.unlink.mockResolvedValue(undefined);
+    mockFsPromises.rename.mockResolvedValue(undefined);
 
     // Create base file objects
     originalFileObj = JSON.parse(JSON.stringify(sampleH264)) as IFileObject;
@@ -94,6 +100,7 @@ describe('replaceOriginalFile Plugin', () => {
       expect(baseArgs.jobLog).toHaveBeenCalledWith('File has not changed, no need to replace file');
       expect(mockFileMoveOrCopy).not.toHaveBeenCalled();
       expect(mockFsPromises.unlink).not.toHaveBeenCalled();
+      expect(mockFsPromises.rename).not.toHaveBeenCalled();
     });
 
     it('should proceed with replacement when file ID is same but size changed', async () => {
@@ -120,18 +127,30 @@ describe('replaceOriginalFile Plugin', () => {
   });
 
   describe('File Replacement Process', () => {
-    it('should replace original file with working file', async () => {
+    it('should replace original file with working file using safe swap order', async () => {
+      const callOrder: string[] = [];
+      mockFileMoveOrCopy.mockImplementation(async ({ sourcePath, destinationPath }) => {
+        callOrder.push(`move:${sourcePath}->${destinationPath}`);
+        return true;
+      });
+      mockFsPromises.rename.mockImplementation(async (from: string, to: string) => {
+        callOrder.push(`rename:${from}->${to}`);
+      });
+      mockFsPromises.unlink.mockImplementation(async (target: string) => {
+        callOrder.push(`unlink:${target}`);
+      });
+
       const result = await plugin(baseArgs);
 
       expect(result.outputNumber).toBe(1);
       expect(baseArgs.jobLog).toHaveBeenCalledWith('File has changed, replacing original file');
 
-      // Should log the paths
+      // Should log the paths (including originalPathOld)
       expect(baseArgs.jobLog).toHaveBeenCalledWith(
-        expect.stringMatching(/currentPath.*newPath.*newPathTmp/),
+        expect.stringMatching(/currentPath.*newPath.*newPathTmp.*originalPathOld/),
       );
 
-      // Should move to temporary location first
+      // Should move working file into origin folder as .tmp first
       expect(mockFileMoveOrCopy).toHaveBeenNthCalledWith(1, {
         operation: 'move',
         sourcePath: '/working/path/video_transcoded.mkv',
@@ -139,7 +158,7 @@ describe('replaceOriginalFile Plugin', () => {
         args: baseArgs,
       });
 
-      // Should move from temporary to final location
+      // Should move tmp to final location
       expect(mockFileMoveOrCopy).toHaveBeenNthCalledWith(2, {
         operation: 'move',
         sourcePath: '/original/path/video_transcoded.mkv.tmp',
@@ -147,31 +166,51 @@ describe('replaceOriginalFile Plugin', () => {
         args: baseArgs,
       });
 
+      // Verify safe-swap ordering: tmp staged -> original renamed aside -> tmp into place -> .old deleted
+      expect(callOrder).toEqual([
+        'move:/working/path/video_transcoded.mkv->/original/path/video_transcoded.mkv.tmp',
+        'rename:/original/path/video.mp4->/original/path/video.mp4.old',
+        'move:/original/path/video_transcoded.mkv.tmp->/original/path/video_transcoded.mkv',
+        'unlink:/original/path/video.mp4.old',
+      ]);
+
       expect(result.outputFileObj._id).toBe('/original/path/video_transcoded.mkv');
     });
 
-    it('should delete original file when it exists and is different from current file', async () => {
+    it('should rename original aside and delete it after successful swap', async () => {
       mockFileExists.mockResolvedValue(true);
 
       const result = await plugin(baseArgs);
 
       expect(mockFileExists).toHaveBeenCalledWith('/original/path/video.mp4');
-      expect(mockFsPromises.unlink).toHaveBeenCalledWith('/original/path/video.mp4');
-      expect(baseArgs.jobLog).toHaveBeenCalledWith('Deleting original file:/original/path/video.mp4');
+      expect(mockFsPromises.rename).toHaveBeenCalledWith(
+        '/original/path/video.mp4',
+        '/original/path/video.mp4.old',
+      );
+      expect(mockFsPromises.unlink).toHaveBeenCalledWith('/original/path/video.mp4.old');
+      // Original path must never be unlinked directly - only the .old copy
+      expect(mockFsPromises.unlink).not.toHaveBeenCalledWith('/original/path/video.mp4');
+      expect(baseArgs.jobLog).toHaveBeenCalledWith(
+        'Renaming original file to: /original/path/video.mp4.old',
+      );
+      expect(baseArgs.jobLog).toHaveBeenCalledWith(
+        'Deleting renamed original file: /original/path/video.mp4.old',
+      );
       expect(result.outputNumber).toBe(1);
     });
 
-    it('should not delete original file when it does not exist', async () => {
+    it('should not rename or delete original file when it does not exist', async () => {
       mockFileExists.mockResolvedValue(false);
 
       const result = await plugin(baseArgs);
 
       expect(mockFileExists).toHaveBeenCalledWith('/original/path/video.mp4');
+      expect(mockFsPromises.rename).not.toHaveBeenCalled();
       expect(mockFsPromises.unlink).not.toHaveBeenCalled();
       expect(result.outputNumber).toBe(1);
     });
 
-    it('should not delete original file when current file is the same as original', async () => {
+    it('should not rename original when current file path is the same as original', async () => {
       baseArgs.inputFileObj._id = originalFileObj._id;
       baseArgs.inputFileObj.file_size = 50; // Different size to trigger replacement
       mockFileExists.mockResolvedValue(true);
@@ -179,8 +218,91 @@ describe('replaceOriginalFile Plugin', () => {
       const result = await plugin(baseArgs);
 
       expect(mockFileExists).toHaveBeenCalledWith('/original/path/video.mp4');
+      expect(mockFsPromises.rename).not.toHaveBeenCalled();
       expect(mockFsPromises.unlink).not.toHaveBeenCalled();
       expect(result.outputNumber).toBe(1);
+    });
+  });
+
+  describe('Stale .old Cleanup', () => {
+    it('should unlink a stale .old file before renaming the original aside', async () => {
+      // fileExists is called for originalPath AND originalPathOld; stub both
+      mockFileExists.mockImplementation(async (p: string) => {
+        if (p === '/original/path/video.mp4') return true;
+        if (p === '/original/path/video.mp4.old') return true;
+        return false;
+      });
+
+      const callOrder: string[] = [];
+      mockFsPromises.unlink.mockImplementation(async (target: string) => {
+        callOrder.push(`unlink:${target}`);
+      });
+      mockFsPromises.rename.mockImplementation(async (from: string, to: string) => {
+        callOrder.push(`rename:${from}->${to}`);
+      });
+
+      await plugin(baseArgs);
+
+      // Stale .old must be removed BEFORE the rename-aside
+      expect(callOrder).toEqual([
+        'unlink:/original/path/video.mp4.old',
+        'rename:/original/path/video.mp4->/original/path/video.mp4.old',
+        'unlink:/original/path/video.mp4.old',
+      ]);
+      expect(baseArgs.jobLog).toHaveBeenCalledWith(
+        'Removing stale file at /original/path/video.mp4.old',
+      );
+    });
+
+    it('should not attempt to unlink .old when it does not exist', async () => {
+      mockFileExists.mockImplementation(async (p: string) => p === '/original/path/video.mp4');
+
+      await plugin(baseArgs);
+
+      // Only the final cleanup unlink of .old, not a pre-rename one
+      expect(mockFsPromises.unlink).toHaveBeenCalledTimes(1);
+      expect(mockFsPromises.unlink).toHaveBeenCalledWith('/original/path/video.mp4.old');
+      expect(baseArgs.jobLog).not.toHaveBeenCalledWith(
+        expect.stringContaining('Removing stale file'),
+      );
+    });
+  });
+
+  describe('Failure and Rollback', () => {
+    it('should restore original from .old if final move fails, and rethrow', async () => {
+      // First move (cache -> tmp) succeeds, second move (tmp -> final) fails
+      mockFileMoveOrCopy
+        .mockResolvedValueOnce(true)
+        .mockRejectedValueOnce(new Error('final move failed'));
+
+      await expect(plugin(baseArgs)).rejects.toThrow('final move failed');
+
+      // Original should have been renamed aside
+      expect(mockFsPromises.rename).toHaveBeenCalledWith(
+        '/original/path/video.mp4',
+        '/original/path/video.mp4.old',
+      );
+      // And restored on failure
+      expect(mockFsPromises.rename).toHaveBeenCalledWith(
+        '/original/path/video.mp4.old',
+        '/original/path/video.mp4',
+      );
+      // The .old file must NOT be deleted when the swap failed
+      expect(mockFsPromises.unlink).not.toHaveBeenCalledWith('/original/path/video.mp4.old');
+    });
+
+    it('should clean up staged .tmp and rethrow if renaming original aside fails', async () => {
+      mockFileExists.mockResolvedValue(true);
+      mockFsPromises.rename.mockRejectedValueOnce(new Error('rename aside failed'));
+
+      await expect(plugin(baseArgs)).rejects.toThrow('rename aside failed');
+
+      // Only first fileMoveOrCopy (stage to tmp) should have been attempted
+      expect(mockFileMoveOrCopy).toHaveBeenCalledTimes(1);
+      // Staged tmp should be cleaned up
+      expect(mockFsPromises.unlink).toHaveBeenCalledWith(
+        '/original/path/video_transcoded.mkv.tmp',
+      );
     });
   });
 
@@ -269,12 +391,17 @@ describe('replaceOriginalFile Plugin', () => {
       );
     });
 
-    it('should log original file deletion when applicable', async () => {
+    it('should log rename-aside and final delete when applicable', async () => {
       mockFileExists.mockResolvedValue(true);
 
       await plugin(baseArgs);
 
-      expect(baseArgs.jobLog).toHaveBeenCalledWith('Deleting original file:/original/path/video.mp4');
+      expect(baseArgs.jobLog).toHaveBeenCalledWith(
+        'Renaming original file to: /original/path/video.mp4.old',
+      );
+      expect(baseArgs.jobLog).toHaveBeenCalledWith(
+        'Deleting renamed original file: /original/path/video.mp4.old',
+      );
     });
   });
 });

--- a/tests/FlowPlugins/CommunityFlowPlugins/file/replaceOriginalFile/1.0.0/index.test.ts
+++ b/tests/FlowPlugins/CommunityFlowPlugins/file/replaceOriginalFile/1.0.0/index.test.ts
@@ -54,7 +54,7 @@ describe('replaceOriginalFile Plugin', () => {
     // Default: the original file exists, the .old sentinel does not.
     // Individual tests that need different behavior override this.
     mockFileExists.mockImplementation(
-      async (p: string) => p === '/original/path/video.mp4',
+      (p: string) => Promise.resolve(p === '/original/path/video.mp4'),
     );
     mockFsPromises.unlink.mockResolvedValue(undefined);
     mockFsPromises.rename.mockResolvedValue(undefined);
@@ -129,15 +129,17 @@ describe('replaceOriginalFile Plugin', () => {
   describe('File Replacement Process', () => {
     it('should replace original file with working file using safe swap order', async () => {
       const callOrder: string[] = [];
-      mockFileMoveOrCopy.mockImplementation(async ({ sourcePath, destinationPath }) => {
+      mockFileMoveOrCopy.mockImplementation(({ sourcePath, destinationPath }) => {
         callOrder.push(`move:${sourcePath}->${destinationPath}`);
-        return true;
+        return Promise.resolve(true);
       });
-      mockFsPromises.rename.mockImplementation(async (from: string, to: string) => {
+      mockFsPromises.rename.mockImplementation((from: string, to: string) => {
         callOrder.push(`rename:${from}->${to}`);
+        return Promise.resolve();
       });
-      mockFsPromises.unlink.mockImplementation(async (target: string) => {
+      mockFsPromises.unlink.mockImplementation((target: string) => {
         callOrder.push(`unlink:${target}`);
+        return Promise.resolve();
       });
 
       const result = await plugin(baseArgs);
@@ -227,18 +229,20 @@ describe('replaceOriginalFile Plugin', () => {
   describe('Stale .old Cleanup', () => {
     it('should unlink a stale .old file before renaming the original aside', async () => {
       // fileExists is called for originalPath AND originalPathOld; stub both
-      mockFileExists.mockImplementation(async (p: string) => {
-        if (p === '/original/path/video.mp4') return true;
-        if (p === '/original/path/video.mp4.partial.old') return true;
-        return false;
+      mockFileExists.mockImplementation((p: string) => {
+        if (p === '/original/path/video.mp4') return Promise.resolve(true);
+        if (p === '/original/path/video.mp4.partial.old') return Promise.resolve(true);
+        return Promise.resolve(false);
       });
 
       const callOrder: string[] = [];
-      mockFsPromises.unlink.mockImplementation(async (target: string) => {
+      mockFsPromises.unlink.mockImplementation((target: string) => {
         callOrder.push(`unlink:${target}`);
+        return Promise.resolve();
       });
-      mockFsPromises.rename.mockImplementation(async (from: string, to: string) => {
+      mockFsPromises.rename.mockImplementation((from: string, to: string) => {
         callOrder.push(`rename:${from}->${to}`);
+        return Promise.resolve();
       });
 
       await plugin(baseArgs);
@@ -255,7 +259,9 @@ describe('replaceOriginalFile Plugin', () => {
     });
 
     it('should not attempt to unlink .old when it does not exist', async () => {
-      mockFileExists.mockImplementation(async (p: string) => p === '/original/path/video.mp4');
+      mockFileExists.mockImplementation(
+        (p: string) => Promise.resolve(p === '/original/path/video.mp4'),
+      );
 
       await plugin(baseArgs);
 


### PR DESCRIPTION
## Summary
- Swap the original file through a `.old` sentinel so the original is never destroyed until the new file is verified in place, and is restored on failure.
- Wrap the final move in try/catch. If the move fails after the original has been renamed aside, rename `.old` back to the original path before rethrowing, so the user never ends up with no file.
- Clear any stale `.old` from a prior failed run before step 2. Without this, a second attempt on Windows is permanently blocked because `fsp.rename` on Windows does not overwrite an existing destination.

Addresses #870.

### New order of operations
1. Move working/cache file to `<newPath>.tmp` in the original folder.
2. Rename `originalPath` to `originalPath.old` (non-destructive, recoverable). If it fails, clean up `.tmp` and rethrow.
3. Move `.tmp` to `newPath`. If it fails, rename `.old` back to `originalPath` and rethrow.
4. Delete `originalPath.old`. Non-fatal if this fails (just logged).

## Test plan
- [x] Added a test asserting the exact swap order: stage tmp, rename original to `.old`, move tmp into place, delete `.old`.
- [x] Added a test that the original is restored from `.old` and the error rethrown when the final move fails.
- [x] Added a test that `.tmp` is cleaned up and the error rethrown when renaming the original aside fails.
- [x] Added tests for stale-`.old` cleanup (present and absent cases).
- [x] All 19 tests pass for this plugin, 1501/1501 across the full jest suite, plugin checker is clean.