### PR TITLE
fix: e5c3 CnT_Remove_Letterbox 10-bit transcode failure

### DIFF
--- a/Community/Tdarr_Plugin_e5c3_CnT_Remove_Letterbox.js
+++ b/Community/Tdarr_Plugin_e5c3_CnT_Remove_Letterbox.js
@@ -223,9 +223,12 @@ function hevc(file) {
 function decoder_string(file) {
   // Use modern CUDA hwaccel instead of legacy *_cuvid decoders
   // which cause frame-ordering issues (stuttering) with FFmpeg 7+.
+  // Request software frames because this plugin uses software crop/scale
+  // filters and an encoder-side `-pix_fmt p010le`, both of which fail on
+  // the CUDA hwframes produced by `-hwaccel_output_format cuda`.
   // Helper returns '' for AV1 to keep older GPUs on software decode.
   const { getNvdecHwaccelPreset } = require('../methods/nvdecPreset');
-  return getNvdecHwaccelPreset(file);
+  return getNvdecHwaccelPreset(file, { softwareFrames: true });
 }
 
 function crop_decider(file, crop_height) {

--- a/methods/nvdecPreset.js
+++ b/methods/nvdecPreset.js
@@ -49,12 +49,19 @@ const getNvdecHwaccelPreset = (file, options) => {
 };
 
 // Returns the correct 10-bit output argument for the current decode path.
-// When CUDA hwaccel is in use (`-hwaccel_output_format cuda`), frames live in
-// GPU memory and an encoder-side `-pix_fmt p010le` fails with
-// "Function not implemented" because ffmpeg can't apply a CPU pixel format
-// to a hwframe without a `scale_cuda` step. When CUDA hwaccel is not in use
-// (software decode), `-pix_fmt p010le` works as expected.
-const getNvenc10BitFormatArg = (file) => {
+// When `-hwaccel_output_format cuda` is in use, frames live in GPU memory and
+// an encoder-side `-pix_fmt p010le` fails with "Function not implemented"
+// because ffmpeg can't apply a CPU pixel format to a hwframe without a
+// `scale_cuda` step. When the decode path produces system-memory frames
+// (software decode, or `-hwaccel cuda` without the output-format flag),
+// `-pix_fmt p010le` works as expected.
+//
+// Pass the same `options` you pass to `getNvdecHwaccelPreset` so this helper
+// stays consistent with the actual decode path being emitted.
+const getNvenc10BitFormatArg = (file, options) => {
+  if (options && options.softwareFrames === true) {
+    return '-pix_fmt p010le ';
+  }
   if (getNvdecHwaccelPreset(file) !== '') {
     return '-vf scale_cuda=format=p010le ';
   }

--- a/methods/nvdecPreset.js
+++ b/methods/nvdecPreset.js
@@ -32,12 +32,20 @@ const getPrimaryVideoCodec = (file) => {
   return (file && file.video_codec_name) || '';
 };
 
-const getNvdecHwaccelPreset = (file) => {
+const getNvdecHwaccelPreset = (file, options) => {
   const codec = getPrimaryVideoCodec(file);
-  if (NVDEC_SUPPORTED_CODECS.includes(codec)) {
-    return '-hwaccel cuda -hwaccel_output_format cuda';
+  if (!NVDEC_SUPPORTED_CODECS.includes(codec)) {
+    return '';
   }
-  return '';
+  // softwareFrames: omit `-hwaccel_output_format cuda` so decoded frames land
+  // in system memory. Use this for plugins whose filter chain or encoder
+  // pix_fmt expects CPU frames (e.g. software crop/scale filters or
+  // `-pix_fmt p010le`). Slightly slower than full-GPU but compatible with
+  // arbitrary downstream filters.
+  if (options && options.softwareFrames === true) {
+    return '-hwaccel cuda';
+  }
+  return '-hwaccel cuda -hwaccel_output_format cuda';
 };
 
 // Returns the correct 10-bit output argument for the current decode path.


### PR DESCRIPTION
## Summary

Fixes a 10-bit NVENC failure in `Tdarr_Plugin_e5c3_CnT_Remove_Letterbox.js`. The plugin's transcode path produces a 0-byte output with `Function not implemented (-38)` / `Could not open encoder before EOF` on real 8-bit yuv420p inputs. Reported pattern is the same family as Tdarr#1180 (which was fixed for the Migz plugins in #965), but e5c3 needs a different mitigation because of how its filter chain is structured.

## Root cause

e5c3 combines:

- `-hwaccel cuda -hwaccel_output_format cuda` from the shared helper (introduced by #921)
- Software filters (`-filter:0 crop=...`, `-filter:0 scale=...`)
- Unconditional encoder-side `-pix_fmt p010le`

CUDA hwframes can't be consumed by software filters or `-pix_fmt p010le` without explicit `hwdownload` / `scale_cuda` steps. The Migz fix in #965 used `scale_cuda=format=p010le` on the GPU, but that approach doesn't work for e5c3 because its filter chain already has crop / scale steps that expect system-memory frames.

## Fix

Add a `softwareFrames` option to `getNvdecHwaccelPreset` that emits just `-hwaccel cuda` (no `-hwaccel_output_format cuda`), so NVDEC still accelerates decode but frames land in system memory. Existing software filters and the encoder-side `-pix_fmt p010le` then work without modification.

```js
const getNvdecHwaccelPreset = (file, options) => {
  // ...
  if (options && options.softwareFrames === true) {
    return '-hwaccel cuda';
  }
  return '-hwaccel cuda -hwaccel_output_format cuda';
};
```

`getNvenc10BitFormatArg` accepts the same `options` object and threads it through to stay consistent with the decode path. No current plugin combines both helpers with `softwareFrames: true`, but the thread-through prevents a latent footgun where a future caller would receive the GPU-frame branch (`scale_cuda`) for an actual sw-frame decode path.

e5c3's `decoder_string()` now passes `{ softwareFrames: true }`. No changes to the filter or encoder logic.

## Why not the same approach as #965?

#965 used `scale_cuda=format=p010le` to keep the full-GPU pipeline. That works because the affected plugins (Migz1FFMPEG, 00td_action_transcode, d5d3) had no other filters, so we could drop in a single GPU filter. e5c3 already has multiple software filters per branch, and stacking GPU + software filters requires `hwdownload,format=nv12,...` insertion at the start of every chain (4 different chains in `encoder_string_full`). The `softwareFrames` approach is a much smaller diff for a plugin that's `// tdarrSkipTest` and has no unit tests to validate filter-chain changes against.

## Speed

On a 10s 720p H.264 test clip, NVDEC decode + sw filter chain runs at ~5-7x realtime depending on which branch is taken (highres+crop, highres only, crop only, no filter). Pure software decode is ~2.6x. The plugin's filter logic is CPU-bound regardless, so the full-GPU pipeline wouldn't have helped meaningfully even if it were feasible here.

## Verification

- `npm test` passes (e5c3 itself is `// tdarrSkipTest` so the runner skips it; nothing else regresses)
- ESLint clean on the helper and modified plugin
- Live-tested against ffmpeg 7.1.2-Jellyfin on real NVIDIA hardware across all four `encoder_string_full` branches:
  - highres + crop: valid output at 5.12x
  - highres only: valid output at 6.29x
  - crop only: valid output at 6.64x
  - no filter: valid output at 6.24x

Frame counts verified equal in/out for each branch.