### PR TITLE
feat: Migz4CleanSubs add option to preserve SDH subtitles when removing commentary (#883)

### DIFF
--- a/Community/Tdarr_Plugin_MC93_Migz4CleanSubs.js
+++ b/Community/Tdarr_Plugin_MC93_Migz4CleanSubs.js
@@ -6,7 +6,7 @@ const details = () => ({
   Type: 'Subtitle',
   Operation: 'Transcode',
   Description: 'This plugin keeps only specified language tracks & can tag tracks with an unknown language. \n\n',
-  Version: '2.4',
+  Version: '2.5',
   Tags: 'pre-processing,ffmpeg,subtitle only,configurable',
   Inputs: [{
     name: 'language',
@@ -35,6 +35,25 @@ const details = () => ({
       ],
     },
     tooltip: `Specify if subtitle tracks that contain commentary/description should be removed.
+               \\nExample:\\n
+               true
+
+               \\nExample:\\n
+               false`,
+  },
+  {
+    name: 'sdh',
+    type: 'boolean',
+    defaultValue: false,
+    inputUI: {
+      type: 'dropdown',
+      options: [
+        'false',
+        'true',
+      ],
+    },
+    tooltip: `Specify if subtitle tracks tagged as SDH (Subtitles for the Deaf and Hard of hearing) should be removed.
+                    \\nSDH tracks are accessibility subtitles, not commentary, so this is disabled by default.
                \\nExample:\\n
                true
 
@@ -123,23 +142,29 @@ const plugin = (file, librarySettings, inputs, otherArguments) => {
 
     // Catch error here incase the title metadata is completely missing.
     try {
+      // SDH (Subtitles for the Deaf and Hard of hearing) tracks are accessibility
+      // subtitles, not commentary, so they're handled by a separate input below
+      // and removed only when inputs.sdh is set to true.
+      const titleLower = file.ffProbeData.streams[i].tags.title.toLowerCase();
+      const isSubtitle = file.ffProbeData.streams[i].codec_type.toLowerCase() === 'subtitle';
+
       // Check if inputs.commentary is set to true
       // AND if stream is subtitle
-      // AND then checks for stream titles with the following "commentary, description, sdh".
-      // Removing any streams that are applicable.
+      // AND then checks for stream titles with "commentary" or "description".
       if (
         inputs.commentary === true
-        && file.ffProbeData.streams[i].codec_type.toLowerCase() === 'subtitle'
-        && (file.ffProbeData.streams[i].tags.title
-          .toLowerCase()
-          .includes('commentary')
-          || file.ffProbeData.streams[i].tags.title
-            .toLowerCase()
-            .includes('description')
-          || file.ffProbeData.streams[i].tags.title.toLowerCase().includes('sdh'))
+        && isSubtitle
+        && (titleLower.includes('commentary') || titleLower.includes('description'))
       ) {
         ffmpegCommandInsert += `-map -0:s:${subtitleIdx} `;
         response.infoLog += `☒Subtitle stream 0:s:${subtitleIdx} detected as being descriptive, removing. \n`;
+        convert = true;
+      } else if (inputs.sdh === true && isSubtitle && titleLower.includes('sdh')) {
+        // Check if inputs.sdh is set to true
+        // AND if stream is subtitle
+        // AND then checks for stream titles containing "sdh".
+        ffmpegCommandInsert += `-map -0:s:${subtitleIdx} `;
+        response.infoLog += `☒Subtitle stream 0:s:${subtitleIdx} detected as SDH, removing. \n`;
         convert = true;
       }
     } catch (err) {

--- a/Community/Tdarr_Plugin_MC93_Migz4CleanSubs.js
+++ b/Community/Tdarr_Plugin_MC93_Migz4CleanSubs.js
@@ -44,7 +44,7 @@ const details = () => ({
   {
     name: 'sdh',
     type: 'boolean',
-    defaultValue: false,
+    defaultValue: true,
     inputUI: {
       type: 'dropdown',
       options: [
@@ -53,7 +53,8 @@ const details = () => ({
       ],
     },
     tooltip: `Specify if subtitle tracks tagged as SDH (Subtitles for the Deaf and Hard of hearing) should be removed.
-                    \\nSDH tracks are accessibility subtitles, not commentary, so this is disabled by default.
+                    \\nOnly applies when the commentary option above is also set to true.
+                    \\nSet to false to preserve SDH/accessibility subtitle tracks while still removing commentary.
                \\nExample:\\n
                true
 
@@ -142,30 +143,23 @@ const plugin = (file, librarySettings, inputs, otherArguments) => {
 
     // Catch error here incase the title metadata is completely missing.
     try {
-      // SDH (Subtitles for the Deaf and Hard of hearing) tracks are accessibility
-      // subtitles, not commentary, so they're handled by a separate input below
-      // and removed only when inputs.sdh is set to true.
+      // SDH removal is gated on inputs.sdh so users can keep SDH/accessibility
+      // tracks while still stripping commentary/description (issue #883).
       const titleLower = file.ffProbeData.streams[i].tags.title.toLowerCase();
       const isSubtitle = file.ffProbeData.streams[i].codec_type.toLowerCase() === 'subtitle';
 
-      // Check if inputs.commentary is set to true
-      // AND if stream is subtitle
-      // AND then checks for stream titles with "commentary" or "description".
-      if (
-        inputs.commentary === true
-        && isSubtitle
-        && (titleLower.includes('commentary') || titleLower.includes('description'))
-      ) {
-        ffmpegCommandInsert += `-map -0:s:${subtitleIdx} `;
-        response.infoLog += `☒Subtitle stream 0:s:${subtitleIdx} detected as being descriptive, removing. \n`;
-        convert = true;
-      } else if (inputs.sdh === true && isSubtitle && titleLower.includes('sdh')) {
-        // Check if inputs.sdh is set to true
-        // AND if stream is subtitle
-        // AND then checks for stream titles containing "sdh".
-        ffmpegCommandInsert += `-map -0:s:${subtitleIdx} `;
-        response.infoLog += `☒Subtitle stream 0:s:${subtitleIdx} detected as SDH, removing. \n`;
-        convert = true;
+      if (inputs.commentary === true && isSubtitle) {
+        // Check for stream titles containing "commentary" or "description".
+        if (titleLower.includes('commentary') || titleLower.includes('description')) {
+          ffmpegCommandInsert += `-map -0:s:${subtitleIdx} `;
+          response.infoLog += `☒Subtitle stream 0:s:${subtitleIdx} detected as being descriptive, removing. \n`;
+          convert = true;
+        } else if (inputs.sdh === true && titleLower.includes('sdh')) {
+          // SDH removal opt-out: only strips when sdh input is true.
+          ffmpegCommandInsert += `-map -0:s:${subtitleIdx} `;
+          response.infoLog += `☒Subtitle stream 0:s:${subtitleIdx} detected as SDH, removing. \n`;
+          convert = true;
+        }
       }
     } catch (err) {
       // Error

--- a/tests/Community/Tdarr_Plugin_MC93_Migz4CleanSubs.js
+++ b/tests/Community/Tdarr_Plugin_MC93_Migz4CleanSubs.js
@@ -67,6 +67,62 @@ const tests = [
         + '☒Subtitle stream 0:s:1 has no language, tagging as eng. \n',
     },
   },
+  {
+    // SDH track must be kept when sdh option is left at its default (false),
+    // even with commentary removal enabled. Regression test for issue #883.
+    input: {
+      file: (() => {
+        const file = _.cloneDeep(require('../sampleData/media/sampleH264_2.json'));
+        file.ffProbeData.streams[6].tags.language = 'eng';
+        file.ffProbeData.streams[6].tags.title = 'English (SDH)';
+        return file;
+      })(),
+      librarySettings: {},
+      inputs: {
+        language: 'eng',
+        commentary: 'true',
+        tag_language: '',
+      },
+      otherArguments: {},
+    },
+    output: {
+      processFile: false,
+      preset: '',
+      container: '.mkv',
+      handBrakeMode: false,
+      FFmpegMode: true,
+      reQueueAfter: false,
+      infoLog: "☑File doesn't contain subtitle tracks which are unwanted or that require tagging.\n",
+    },
+  },
+  {
+    // SDH track is removed when the sdh option is opted into.
+    input: {
+      file: (() => {
+        const file = _.cloneDeep(require('../sampleData/media/sampleH264_2.json'));
+        file.ffProbeData.streams[6].tags.language = 'eng';
+        file.ffProbeData.streams[6].tags.title = 'English (SDH)';
+        return file;
+      })(),
+      librarySettings: {},
+      inputs: {
+        language: 'eng',
+        commentary: 'false',
+        sdh: 'true',
+        tag_language: '',
+      },
+      otherArguments: {},
+    },
+    output: {
+      processFile: true,
+      preset: ', -map 0 -map -0:s:0  -c copy -max_muxing_queue_size 9999',
+      container: '.mkv',
+      handBrakeMode: false,
+      FFmpegMode: true,
+      reQueueAfter: true,
+      infoLog: '☒Subtitle stream 0:s:0 detected as SDH, removing. \n',
+    },
+  },
 ];
 
 void run(tests);

--- a/tests/Community/Tdarr_Plugin_MC93_Migz4CleanSubs.js
+++ b/tests/Community/Tdarr_Plugin_MC93_Migz4CleanSubs.js
@@ -68,8 +68,8 @@ const tests = [
     },
   },
   {
-    // SDH track must be kept when sdh option is left at its default (false),
-    // even with commentary removal enabled. Regression test for issue #883.
+    // SDH track is preserved when the user opts out via sdh=false, even
+    // with commentary removal enabled. Fix for issue #883.
     input: {
       file: (() => {
         const file = _.cloneDeep(require('../sampleData/media/sampleH264_2.json'));
@@ -81,6 +81,7 @@ const tests = [
       inputs: {
         language: 'eng',
         commentary: 'true',
+        sdh: 'false',
         tag_language: '',
       },
       otherArguments: {},
@@ -96,7 +97,8 @@ const tests = [
     },
   },
   {
-    // SDH track is removed when the sdh option is opted into.
+    // Default behaviour preserved: with commentary=true and sdh left at its
+    // default (true), SDH-tagged tracks are still removed (matches pre-fix behaviour).
     input: {
       file: (() => {
         const file = _.cloneDeep(require('../sampleData/media/sampleH264_2.json'));
@@ -107,8 +109,7 @@ const tests = [
       librarySettings: {},
       inputs: {
         language: 'eng',
-        commentary: 'false',
-        sdh: 'true',
+        commentary: 'true',
         tag_language: '',
       },
       otherArguments: {},


### PR DESCRIPTION
## Summary
- Addresses #883: with `commentary=true`, the plugin was removing English SDH subtitle tracks (e.g. titles like `English (SDH)`) because `sdh` was hard-coded into the same title-substring match as `commentary`/`description`.
- Splits SDH removal out into a new dedicated `sdh` boolean input that **defaults to `true`**, preserving the existing behaviour for upgrading users. Users hitting #883 can now set `sdh` to `false` to keep SDH/accessibility tracks while still stripping commentary.
- The new option is gated on `commentary=true` so the existing combined toggle still controls overall descriptive-track removal; `sdh` only refines what counts as descriptive within that.
- Bumps plugin version 2.4 to 2.5.

## Test plan
- [x] `node tests/Community/Tdarr_Plugin_MC93_Migz4CleanSubs.js` passes for all 5 cases
  - existing 3 cases unchanged
  - new case: `commentary=true`, `sdh=false` -> SDH track is preserved (issue #883 fix path)
  - new case: `commentary=true`, `sdh` defaulted -> SDH track is removed (pre-fix behaviour preserved)