### PR TITLE
fix: increase hardware encoder probe frame size to 512x512 (#857)

### DIFF
--- a/Community/Tdarr_Plugin_00td_action_transcode.js
+++ b/Community/Tdarr_Plugin_00td_action_transcode.js
@@ -188,7 +188,7 @@ const hasEncoder = async ({
   let isEnabled = false;
   try {
     isEnabled = await new Promise((resolve) => {
-      const command = `${ffmpegPath} ${inputArgs || ''} -f lavfi -i color=c=black:s=256x256:d=1:r=30`
+      const command = `${ffmpegPath} ${inputArgs || ''} -f lavfi -i color=c=black:s=512x512:d=1:r=30`
               + ` ${filter || ''}`
               + ` -c:v ${encoder} -f null /dev/null`;
       exec(command, (

--- a/FlowPlugins/FlowHelpers/1.0.0/hardwareUtils.js
+++ b/FlowPlugins/FlowHelpers/1.0.0/hardwareUtils.js
@@ -95,7 +95,7 @@ var hasEncoder = function (_a) { return __awaiter(void 0, [_a], void 0, function
                     '-f',
                     'lavfi',
                     '-i',
-                    'color=c=black:s=256x256:d=1:r=30'
+                    'color=c=black:s=512x512:d=1:r=30'
                 ], false), (filter ? filter.split(' ') : []), true), [
                     '-c:v',
                     encoder

--- a/FlowPluginsTs/FlowHelpers/1.0.0/hardwareUtils.ts
+++ b/FlowPluginsTs/FlowHelpers/1.0.0/hardwareUtils.ts
@@ -43,7 +43,7 @@ export const hasEncoder = async ({
       '-f',
       'lavfi',
       '-i',
-      'color=c=black:s=256x256:d=1:r=30',
+      'color=c=black:s=512x512:d=1:r=30',
       ...(filter ? filter.split(' ') : []),
       '-c:v',
       encoder,


### PR DESCRIPTION
## Summary
- Bumps the lavfi probe frame in `hasEncoder` from `256x256` to `512x512` so AMD AV1 (`av1_amf`) on RDNA4 GPUs (e.g. RX 9070 XT) does not return `AMF_OUT_OF_RANGE` and get incorrectly reported as unsupported. Fixes #857.
- Applied in three places that share the same probe command: `FlowPluginsTs/FlowHelpers/1.0.0/hardwareUtils.ts`, its compiled JS counterpart, and `Community/Tdarr_Plugin_00td_action_transcode.js`.

## Why this is safe
- 512x512 is still far below any realistic media resolution, so it cannot mask a real hardware limitation that would matter for actual transcodes.
- Verified against an Intel iGPU (QSV + VAAPI) and an NVIDIA GPU at both 256x256 and 512x512: every encoder that worked at 256x256 also worked at 512x512, and every encoder that failed at 256x256 failed for the same hardware reason at 512x512. No detection regression observed.
- Original reporter confirmed 512x512 fixes detection on RX 9070 XT.

## Test plan
- [x] Probe `hevc_qsv`, `h264_qsv`, `av1_qsv`, `hevc_vaapi`, `h264_vaapi`, `hevc_nvenc`, `h264_nvenc`, `av1_nvenc` at both 256x256 and 512x512 and confirm identical pass/fail outcomes.