### PR TITLE
fix: copy ffmpeg streams with metadata args

### DIFF
--- a/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandExecute/1.0.0/index.js
+++ b/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandExecute/1.0.0/index.js
@@ -95,6 +95,24 @@ var getOuputStreamTypeIndex = function (streams, stream) {
     }
     return index;
 };
+var hasCodecOutputArg = function (outputArgs) { return outputArgs.some(function (arg) { return (/^-(c|codec)(:|$)/.test(arg)
+    || /^-[vasd]codec(:|$)/.test(arg)); }); };
+var isCopyCompatibleOutputOption = function (arg) { return (arg === '-metadata'
+    || arg.startsWith('-metadata:')
+    || arg === '-disposition'
+    || arg.startsWith('-disposition:')); };
+var hasOnlyCopyCompatibleOutputArgs = function (outputArgs) {
+    for (var i = 0; i < outputArgs.length; i += 1) {
+        var arg = outputArgs[i];
+        if (!isCopyCompatibleOutputOption(arg)) {
+            return false;
+        }
+        i += 1;
+    }
+    return true;
+};
+var shouldAddCopyCodec = function (outputArgs) { return (outputArgs.length === 0
+    || (!hasCodecOutputArg(outputArgs) && hasOnlyCopyCompatibleOutputArgs(outputArgs))); };
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 var plugin = function (args) { return __awaiter(void 0, void 0, void 0, function () {
     var lib, cliArgs, _a, shouldProcess, streams, inputArgs, _loop_1, i, idx, outputFilePath, spawnArgs, cli, res;
@@ -138,12 +156,10 @@ var plugin = function (args) { return __awaiter(void 0, void 0, void 0, function
                         return arg;
                     });
                     cliArgs.push.apply(cliArgs, stream.mapArgs);
-                    if (stream.outputArgs.length === 0) {
+                    if (shouldAddCopyCodec(stream.outputArgs)) {
                         cliArgs.push("-c:".concat(getOuputStreamIndex(streams, stream)), 'copy');
                     }
-                    else {
-                        cliArgs.push.apply(cliArgs, stream.outputArgs);
-                    }
+                    cliArgs.push.apply(cliArgs, stream.outputArgs);
                     inputArgs.push.apply(inputArgs, stream.inputArgs);
                 };
                 for (i = 0; i < streams.length; i += 1) {

--- a/FlowPluginsTs/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandExecute/1.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandExecute/1.0.0/index.ts
@@ -63,6 +63,37 @@ const getOuputStreamTypeIndex = (streams: IffmpegCommandStream[], stream: Iffmpe
   return index;
 };
 
+const hasCodecOutputArg = (outputArgs: string[]): boolean => outputArgs.some((arg) => (
+  /^-(c|codec)(:|$)/.test(arg)
+  || /^-[vasd]codec(:|$)/.test(arg)
+));
+
+const isCopyCompatibleOutputOption = (arg: string): boolean => (
+  arg === '-metadata'
+  || arg.startsWith('-metadata:')
+  || arg === '-disposition'
+  || arg.startsWith('-disposition:')
+);
+
+const hasOnlyCopyCompatibleOutputArgs = (outputArgs: string[]): boolean => {
+  for (let i = 0; i < outputArgs.length; i += 1) {
+    const arg = outputArgs[i];
+
+    if (!isCopyCompatibleOutputOption(arg)) {
+      return false;
+    }
+
+    i += 1;
+  }
+
+  return true;
+};
+
+const shouldAddCopyCodec = (outputArgs: string[]): boolean => (
+  outputArgs.length === 0
+  || (!hasCodecOutputArg(outputArgs) && hasOnlyCopyCompatibleOutputArgs(outputArgs))
+);
+
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const plugin = async (args: IpluginInputArgs): Promise<IpluginOutputArgs> => {
   const lib = require('../../../../../methods/lib')();
@@ -118,11 +149,11 @@ const plugin = async (args: IpluginInputArgs): Promise<IpluginOutputArgs> => {
 
     cliArgs.push(...stream.mapArgs);
 
-    if (stream.outputArgs.length === 0) {
+    if (shouldAddCopyCodec(stream.outputArgs)) {
       cliArgs.push(`-c:${getOuputStreamIndex(streams, stream)}`, 'copy');
-    } else {
-      cliArgs.push(...stream.outputArgs);
     }
+
+    cliArgs.push(...stream.outputArgs);
 
     inputArgs.push(...stream.inputArgs);
   }

--- a/tests/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandExecute/1.0.0/index.test.ts
+++ b/tests/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandExecute/1.0.0/index.test.ts
@@ -122,6 +122,69 @@ describe('ffmpegCommandExecute Plugin', () => {
       expect(baseArgs.jobLog).toHaveBeenCalledWith('Processing file');
     });
 
+    it('should copy streams with only metadata or disposition output args', async () => {
+      baseArgs.variables.ffmpegCommand.streams[0].outputArgs = ['-metadata:s:v:{outputTypeIndex}', 'title=-Main'];
+      baseArgs.variables.ffmpegCommand.streams[1].outputArgs = ['-disposition:{outputIndex}', 'default+original'];
+
+      const result = await plugin(baseArgs);
+
+      const { CLI } = require('../../../../../../FlowPluginsTs/FlowHelpers/1.0.0/cliUtils');
+      const [cliOptions] = CLI.mock.calls[0];
+      const { spawnArgs } = cliOptions;
+
+      expect(result.outputNumber).toBe(1);
+      expect(spawnArgs).toEqual(expect.arrayContaining([
+        '-c:0',
+        'copy',
+        '-metadata:s:v:0',
+        'title=-Main',
+        '-c:1',
+        'copy',
+        '-disposition:1',
+        'default+original',
+      ]));
+      expect(spawnArgs.indexOf('-c:0')).toBeLessThan(spawnArgs.indexOf('-metadata:s:v:0'));
+      expect(spawnArgs.indexOf('-c:1')).toBeLessThan(spawnArgs.indexOf('-disposition:1'));
+    });
+
+    it('should not add copy codec when output args include a codec arg', async () => {
+      baseArgs.variables.ffmpegCommand.streams[0].outputArgs = [
+        '-c:{outputIndex}',
+        'libx264',
+        '-metadata:s:v:{outputTypeIndex}',
+        'title=Encoded',
+      ];
+
+      const result = await plugin(baseArgs);
+
+      const { CLI } = require('../../../../../../FlowPluginsTs/FlowHelpers/1.0.0/cliUtils');
+      const [cliOptions] = CLI.mock.calls[0];
+      const { spawnArgs } = cliOptions;
+
+      expect(result.outputNumber).toBe(1);
+      expect(spawnArgs).toEqual(expect.arrayContaining([
+        '-c:0',
+        'libx264',
+        '-metadata:s:v:0',
+        'title=Encoded',
+      ]));
+      expect(spawnArgs.filter((arg: string) => arg === '-c:0')).toHaveLength(1);
+    });
+
+    it('should not add copy codec for non-copy-compatible output args', async () => {
+      baseArgs.variables.ffmpegCommand.streams[0].outputArgs = ['-vf', 'scale=1280:-2'];
+
+      const result = await plugin(baseArgs);
+
+      const { CLI } = require('../../../../../../FlowPluginsTs/FlowHelpers/1.0.0/cliUtils');
+      const [cliOptions] = CLI.mock.calls[0];
+      const { spawnArgs } = cliOptions;
+
+      expect(result.outputNumber).toBe(1);
+      expect(spawnArgs).toEqual(expect.arrayContaining(['-vf', 'scale=1280:-2']));
+      expect(spawnArgs).not.toContain('-c:0');
+    });
+
     it('should handle streams with output args', async () => {
       baseArgs.variables.ffmpegCommand.streams[0].outputArgs = ['-c:{outputIndex}', 'libx264'];
       baseArgs.variables.ffmpegCommand.streams[1].outputArgs = ['-c:{outputIndex}', 'aac'];

--- a/tests/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandExecute/1.0.0/index.test.ts
+++ b/tests/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandExecute/1.0.0/index.test.ts
@@ -147,6 +147,90 @@ describe('ffmpegCommandExecute Plugin', () => {
       expect(spawnArgs.indexOf('-c:1')).toBeLessThan(spawnArgs.indexOf('-disposition:1'));
     });
 
+    it('should mirror issue 793 by copying kept audio with disposition after removed streams', async () => {
+      baseArgs.variables.ffmpegCommand.streams = [
+        {
+          index: 0,
+          codec_name: 'av1',
+          codec_type: 'video',
+          removed: false,
+          forceEncoding: false,
+          inputArgs: [],
+          outputArgs: [],
+          mapArgs: ['-map', '0:0'],
+        },
+        {
+          index: 1,
+          codec_name: 'eac3',
+          codec_type: 'audio',
+          removed: true,
+          forceEncoding: false,
+          inputArgs: [],
+          outputArgs: [],
+          mapArgs: ['-map', '0:1'],
+        },
+        {
+          index: 2,
+          codec_name: 'eac3',
+          codec_type: 'audio',
+          removed: false,
+          forceEncoding: false,
+          inputArgs: [],
+          outputArgs: ['-disposition:{outputIndex}', 'default+original'],
+          mapArgs: ['-map', '0:2'],
+        },
+        {
+          index: 3,
+          codec_name: 'subrip',
+          codec_type: 'subtitle',
+          removed: true,
+          forceEncoding: false,
+          inputArgs: [],
+          outputArgs: [],
+          mapArgs: ['-map', '0:3'],
+        },
+        {
+          index: 4,
+          codec_name: 'subrip',
+          codec_type: 'subtitle',
+          removed: false,
+          forceEncoding: false,
+          inputArgs: [],
+          outputArgs: [],
+          mapArgs: ['-map', '0:4'],
+        },
+      ];
+
+      const result = await plugin(baseArgs);
+
+      const { CLI } = require('../../../../../../FlowPluginsTs/FlowHelpers/1.0.0/cliUtils');
+      const [cliOptions] = CLI.mock.calls[0];
+      const { spawnArgs } = cliOptions;
+
+      expect(result.outputNumber).toBe(1);
+      expect(spawnArgs.slice(0, -1)).toEqual([
+        '-y',
+        '-i',
+        baseArgs.inputFileObj._id,
+        '-map',
+        '0:0',
+        '-c:0',
+        'copy',
+        '-map',
+        '0:2',
+        '-c:1',
+        'copy',
+        '-disposition:1',
+        'default+original',
+        '-map',
+        '0:4',
+        '-c:2',
+        'copy',
+      ]);
+      expect(spawnArgs[spawnArgs.length - 1]).toContain('.mp4');
+      expect(spawnArgs.indexOf('-c:1')).toBeLessThan(spawnArgs.indexOf('-disposition:1'));
+    });
+
     it('should not add copy codec when output args include a codec arg', async () => {
       baseArgs.variables.ffmpegCommand.streams[0].outputArgs = [
         '-c:{outputIndex}',


### PR DESCRIPTION
## Summary
- add explicit stream copy when ffmpegCommandExecute sees metadata or disposition-only output args
- keep metadata and disposition args after the inserted copy codec
- add regression coverage for copy insertion, codec args, and filter args
- fixes https://github.com/HaveAGitGat/Tdarr_Plugins/issues/793

