### PR TITLE
Fix runCli shell command argument parsing

### DIFF
--- a/FlowPlugins/CommunityFlowPlugins/tools/runCli/1.0.0/index.js
+++ b/FlowPlugins/CommunityFlowPlugins/tools/runCli/1.0.0/index.js
@@ -45,10 +45,37 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
     return to.concat(ar || Array.prototype.slice.call(from));
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.plugin = exports.details = void 0;
+exports.plugin = exports.parseRunCliArguments = exports.details = void 0;
 var cliUtils_1 = require("../../../../FlowHelpers/1.0.0/cliUtils");
 var fileUtils_1 = require("../../../../FlowHelpers/1.0.0/fileUtils");
-/* eslint no-plusplus: ["error", { "allowForLoopAfterthoughts": true }] */
+var parseRunCliArguments = function (cliPath, cliArguments, parseArgsStringToArgv) {
+    var normalizedCliPath = cliPath.replace(/\\/g, '/');
+    var cliName = normalizedCliPath
+        .slice(normalizedCliPath.lastIndexOf('/') + 1)
+        .toLowerCase()
+        .replace(/\.exe$/i, '');
+    var shellCommandArgMatch = null;
+    if (cliName === 'bash' || cliName === 'sh') {
+        shellCommandArgMatch = cliArguments.match(/(^|\s)(-[^\s]*c[^\s]*)(\s+)([\s\S]*)$/);
+    }
+    else if (cliName === 'powershell' || cliName === 'pwsh') {
+        shellCommandArgMatch = cliArguments.match(/(^|\s)(-command|-c)(\s+)([\s\S]*)$/i);
+    }
+    if (!shellCommandArgMatch) {
+        return __spreadArray([], parseArgsStringToArgv(cliArguments, '', ''), true);
+    }
+    var prefixArgsString = cliArguments.slice(0, shellCommandArgMatch.index).trim();
+    var prefixArgs = prefixArgsString
+        ? parseArgsStringToArgv(prefixArgsString, '', '')
+        : [];
+    var commandArg = shellCommandArgMatch[4]
+        .trim()
+        .replace(/^(['"])([\s\S]*)\1$/, '$2');
+    return __spreadArray(__spreadArray(__spreadArray([], prefixArgs, true), [
+        shellCommandArgMatch[2]
+    ], false), (commandArg ? [commandArg] : []), true);
+};
+exports.parseRunCliArguments = parseRunCliArguments;
 var details = function () { return ({
     name: 'Run CLI',
     description: 'Choose a CLI and custom arguments to run',
@@ -214,7 +241,7 @@ var details = function () { return ({
 exports.details = details;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 var plugin = function (args) { return __awaiter(void 0, void 0, void 0, function () {
-    var lib, userCli, useCustomCliPath, customCliPath, cliPath, outputFileBecomesWorkingFile, userOutputFilePath, cliArguments, cacheDir, fileName, cliArgs, availableCli, msg, cli, res, msg;
+    var lib, userCli, useCustomCliPath, customCliPath, cliPath, outputFileBecomesWorkingFile, userOutputFilePath, cliArguments, cacheDir, fileName, availableCli, msg, cliArgs, cli, res, msg;
     return __generator(this, function (_a) {
         switch (_a.label) {
             case 0:
@@ -242,7 +269,6 @@ var plugin = function (args) { return __awaiter(void 0, void 0, void 0, function
                     }
                     cliArguments = cliArguments.replace(/\${outputFilePath}/g, userOutputFilePath);
                 }
-                cliArgs = __spreadArray([], args.deps.parseArgsStringToArgv(cliArguments, '', ''), true);
                 availableCli = {
                     mkvpropedit: args.mkvpropeditPath,
                     mkvmerge: 'mkvmerge',
@@ -258,6 +284,7 @@ var plugin = function (args) { return __awaiter(void 0, void 0, void 0, function
                     }
                     cliPath = availableCli[userCli];
                 }
+                cliArgs = parseRunCliArguments(cliPath, cliArguments, args.deps.parseArgsStringToArgv);
                 cli = new cliUtils_1.CLI({
                     cli: cliPath,
                     spawnArgs: cliArgs,

--- a/FlowPlugins/CommunityFlowPlugins/tools/runCli/1.0.0/index.js
+++ b/FlowPlugins/CommunityFlowPlugins/tools/runCli/1.0.0/index.js
@@ -56,7 +56,7 @@ var parseRunCliArguments = function (cliPath, cliArguments, parseArgsStringToArg
         .replace(/\.exe$/i, '');
     var shellCommandArgMatch = null;
     if (cliName === 'bash' || cliName === 'sh') {
-        shellCommandArgMatch = cliArguments.match(/(^|\s)(-[^\s]*c[^\s]*)(\s+)([\s\S]*)$/);
+        shellCommandArgMatch = cliArguments.match(/(^|\s)(-[^-\s]*c[^\s]*)(\s+)([\s\S]*)$/);
     }
     else if (cliName === 'powershell' || cliName === 'pwsh') {
         shellCommandArgMatch = cliArguments.match(/(^|\s)(-command|-c)(\s+)([\s\S]*)$/i);

--- a/FlowPlugins/CommunityFlowPlugins/tools/runCli/1.0.0/index.js
+++ b/FlowPlugins/CommunityFlowPlugins/tools/runCli/1.0.0/index.js
@@ -68,12 +68,17 @@ var parseRunCliArguments = function (cliPath, cliArguments, parseArgsStringToArg
     var prefixArgs = prefixArgsString
         ? parseArgsStringToArgv(prefixArgsString, '', '')
         : [];
-    var commandArg = shellCommandArgMatch[4]
-        .trim()
-        .replace(/^(['"])([\s\S]*)\1$/, '$2');
+    var commandArgsString = shellCommandArgMatch[4].trim();
+    var commandArgs = [];
+    if (/^['"]/.test(commandArgsString)) {
+        commandArgs = parseArgsStringToArgv(commandArgsString, '', '');
+    }
+    else if (commandArgsString) {
+        commandArgs = [commandArgsString];
+    }
     return __spreadArray(__spreadArray(__spreadArray([], prefixArgs, true), [
         shellCommandArgMatch[2]
-    ], false), (commandArg ? [commandArg] : []), true);
+    ], false), commandArgs, true);
 };
 exports.parseRunCliArguments = parseRunCliArguments;
 var details = function () { return ({

--- a/FlowPluginsTs/CommunityFlowPlugins/tools/runCli/1.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/tools/runCli/1.0.0/index.ts
@@ -24,7 +24,7 @@ const parseRunCliArguments = (
   let shellCommandArgMatch: RegExpMatchArray | null = null;
 
   if (cliName === 'bash' || cliName === 'sh') {
-    shellCommandArgMatch = cliArguments.match(/(^|\s)(-[^\s]*c[^\s]*)(\s+)([\s\S]*)$/);
+    shellCommandArgMatch = cliArguments.match(/(^|\s)(-[^-\s]*c[^\s]*)(\s+)([\s\S]*)$/);
   } else if (cliName === 'powershell' || cliName === 'pwsh') {
     shellCommandArgMatch = cliArguments.match(/(^|\s)(-command|-c)(\s+)([\s\S]*)$/i);
   }

--- a/FlowPluginsTs/CommunityFlowPlugins/tools/runCli/1.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/tools/runCli/1.0.0/index.ts
@@ -7,6 +7,49 @@ import {
 } from '../../../../FlowHelpers/1.0.0/interfaces/interfaces';
 
 /* eslint no-plusplus: ["error", { "allowForLoopAfterthoughts": true }] */
+
+type ParseArgsStringToArgv = (argsString: string, env: string, cwd: string) => string[];
+
+const parseRunCliArguments = (
+  cliPath: string,
+  cliArguments: string,
+  parseArgsStringToArgv: ParseArgsStringToArgv,
+): string[] => {
+  const normalizedCliPath = cliPath.replace(/\\/g, '/');
+  const cliName = normalizedCliPath
+    .slice(normalizedCliPath.lastIndexOf('/') + 1)
+    .toLowerCase()
+    .replace(/\.exe$/i, '');
+
+  let shellCommandArgMatch: RegExpMatchArray | null = null;
+
+  if (cliName === 'bash' || cliName === 'sh') {
+    shellCommandArgMatch = cliArguments.match(/(^|\s)(-[^\s]*c[^\s]*)(\s+)([\s\S]*)$/);
+  } else if (cliName === 'powershell' || cliName === 'pwsh') {
+    shellCommandArgMatch = cliArguments.match(/(^|\s)(-command|-c)(\s+)([\s\S]*)$/i);
+  }
+
+  if (!shellCommandArgMatch) {
+    return [
+      ...parseArgsStringToArgv(cliArguments, '', ''),
+    ];
+  }
+
+  const prefixArgsString = cliArguments.slice(0, shellCommandArgMatch.index).trim();
+  const prefixArgs = prefixArgsString
+    ? parseArgsStringToArgv(prefixArgsString, '', '')
+    : [];
+  const commandArg = shellCommandArgMatch[4]
+    .trim()
+    .replace(/^(['"])([\s\S]*)\1$/, '$2');
+
+  return [
+    ...prefixArgs,
+    shellCommandArgMatch[2],
+    ...(commandArg ? [commandArg] : []),
+  ];
+};
+
 const details = (): IpluginDetails => ({
   name: 'Run CLI',
   description: 'Choose a CLI and custom arguments to run',
@@ -225,10 +268,6 @@ const plugin = async (args: IpluginInputArgs): Promise<IpluginOutputArgs> => {
     cliArguments = cliArguments.replace(/\${outputFilePath}/g, userOutputFilePath);
   }
 
-  const cliArgs = [
-    ...args.deps.parseArgsStringToArgv(cliArguments, '', ''),
-  ];
-
   const availableCli:{
     [index: string]: string;
   } = {
@@ -247,6 +286,12 @@ const plugin = async (args: IpluginInputArgs): Promise<IpluginOutputArgs> => {
 
     cliPath = availableCli[userCli];
   }
+
+  const cliArgs = parseRunCliArguments(
+    cliPath,
+    cliArguments,
+    args.deps.parseArgsStringToArgv,
+  );
 
   const cli = new CLI({
     cli: cliPath,
@@ -279,5 +324,6 @@ const plugin = async (args: IpluginInputArgs): Promise<IpluginOutputArgs> => {
 };
 export {
   details,
+  parseRunCliArguments,
   plugin,
 };

--- a/FlowPluginsTs/CommunityFlowPlugins/tools/runCli/1.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/tools/runCli/1.0.0/index.ts
@@ -39,14 +39,19 @@ const parseRunCliArguments = (
   const prefixArgs = prefixArgsString
     ? parseArgsStringToArgv(prefixArgsString, '', '')
     : [];
-  const commandArg = shellCommandArgMatch[4]
-    .trim()
-    .replace(/^(['"])([\s\S]*)\1$/, '$2');
+  const commandArgsString = shellCommandArgMatch[4].trim();
+  let commandArgs: string[] = [];
+
+  if (/^['"]/.test(commandArgsString)) {
+    commandArgs = parseArgsStringToArgv(commandArgsString, '', '');
+  } else if (commandArgsString) {
+    commandArgs = [commandArgsString];
+  }
 
   return [
     ...prefixArgs,
     shellCommandArgMatch[2],
-    ...(commandArg ? [commandArg] : []),
+    ...commandArgs,
   ];
 };
 

--- a/tests/FlowPlugins/CommunityFlowPlugins/tools/runCli/1.0.0/index.test.ts
+++ b/tests/FlowPlugins/CommunityFlowPlugins/tools/runCli/1.0.0/index.test.ts
@@ -347,6 +347,21 @@ describe('parseRunCliArguments', () => {
     ]);
   });
 
+  it('should not treat bash long options containing c as command switches', () => {
+    const result = parseRunCliArguments(
+      '/bin/bash',
+      '--norc -c echo hi',
+      mockParseArgsStringToArgv,
+    );
+
+    expect(result).toEqual([
+      '--norc',
+      '-c',
+      'echo hi',
+    ]);
+    expect(mockParseArgsStringToArgv).toHaveBeenCalledWith('--norc', '', '');
+  });
+
   it('should parse PowerShell options before -Command and keep the command string intact', () => {
     const result = parseRunCliArguments(
       'powershell.exe',

--- a/tests/FlowPlugins/CommunityFlowPlugins/tools/runCli/1.0.0/index.test.ts
+++ b/tests/FlowPlugins/CommunityFlowPlugins/tools/runCli/1.0.0/index.test.ts
@@ -347,6 +347,26 @@ describe('parseRunCliArguments', () => {
     ]);
   });
 
+  it('should preserve bash positional arguments after a quoted command string', () => {
+    const result = parseRunCliArguments(
+      '/bin/bash',
+      '-c \'printf "%s" "$1"\' shell-name "two words"',
+      mockParseArgsStringToArgv,
+    );
+
+    expect(result).toEqual([
+      '-c',
+      'printf "%s" "$1"',
+      'shell-name',
+      'two words',
+    ]);
+    expect(mockParseArgsStringToArgv).toHaveBeenCalledWith(
+      '\'printf "%s" "$1"\' shell-name "two words"',
+      '',
+      '',
+    );
+  });
+
   it('should not treat bash long options containing c as command switches', () => {
     const result = parseRunCliArguments(
       '/bin/bash',
@@ -375,5 +395,24 @@ describe('parseRunCliArguments', () => {
       'if (Get-Process -Name \'ffmpeg\') { Write-Host \'found process\' }',
     ]);
     expect(mockParseArgsStringToArgv).toHaveBeenCalledWith('-NoProfile', '', '');
+  });
+
+  it('should preserve PowerShell arguments after a quoted command string', () => {
+    const result = parseRunCliArguments(
+      'pwsh',
+      '-Command "Write-Host $args[0]" "two words"',
+      mockParseArgsStringToArgv,
+    );
+
+    expect(result).toEqual([
+      '-Command',
+      'Write-Host $args[0]',
+      'two words',
+    ]);
+    expect(mockParseArgsStringToArgv).toHaveBeenCalledWith(
+      '"Write-Host $args[0]" "two words"',
+      '',
+      '',
+    );
   });
 });

--- a/tests/FlowPlugins/CommunityFlowPlugins/tools/runCli/1.0.0/index.test.ts
+++ b/tests/FlowPlugins/CommunityFlowPlugins/tools/runCli/1.0.0/index.test.ts
@@ -1,4 +1,4 @@
-import { plugin } from
+import { parseRunCliArguments, plugin } from
   '../../../../../../FlowPluginsTs/CommunityFlowPlugins/tools/runCli/1.0.0/index';
 import { IpluginInputArgs } from '../../../../../../FlowPluginsTs/FlowHelpers/1.0.0/interfaces/interfaces';
 import { IFileObject } from '../../../../../../FlowPluginsTs/FlowHelpers/1.0.0/interfaces/synced/IFileObject';
@@ -162,6 +162,27 @@ describe('runCli Plugin', () => {
         '',
       );
     });
+
+    it('should keep bash -c commands with quoted paths as one command argument', async () => {
+      baseArgs.inputs.useCustomCliPath = true;
+      baseArgs.inputs.customCliPath = '/usr/bin/bash';
+      baseArgs.inputs.userOutputFilePath = '/cache/out file.mkv';
+      // eslint-disable-next-line no-template-curly-in-string
+      baseArgs.inputs.cliArguments = '-c /app/configs/remove_dovi.sh "/Video/Testing\'s Movie.mkv" "${outputFilePath}"';
+
+      await plugin(baseArgs);
+
+      expect(mockCLI).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cli: '/usr/bin/bash',
+          spawnArgs: [
+            '-c',
+            '/app/configs/remove_dovi.sh "/Video/Testing\'s Movie.mkv" "/cache/out file.mkv"',
+          ],
+        }),
+      );
+      expect(baseArgs.deps.parseArgsStringToArgv).not.toHaveBeenCalled();
+    });
   });
 
   describe('CLI Error Handling', () => {
@@ -258,5 +279,86 @@ describe('runCli Plugin', () => {
 
       expect(result.variables).toEqual(expect.objectContaining({ testVar: 'testValue' }));
     });
+  });
+});
+
+describe('parseRunCliArguments', () => {
+  const mockParseArgsStringToArgv = jest.fn((value: string) => (
+    value.match(/"[^"]*"|'[^']*'|\S+/g)?.map((arg) => arg.replace(/^["']|["']$/g, '')) || []
+  ));
+
+  beforeEach(() => {
+    mockParseArgsStringToArgv.mockClear();
+  });
+
+  it('should delegate normal spawn argument parsing', () => {
+    const result = parseRunCliArguments(
+      'mkvmerge',
+      '-o "/cache/out file.mkv" "/video/input file.mkv"',
+      mockParseArgsStringToArgv,
+    );
+
+    expect(result).toEqual(['-o', '/cache/out file.mkv', '/video/input file.mkv']);
+    expect(mockParseArgsStringToArgv).toHaveBeenCalledWith(
+      '-o "/cache/out file.mkv" "/video/input file.mkv"',
+      '',
+      '',
+    );
+  });
+
+  it('should keep unquoted bash -c remainder as one command string', () => {
+    const result = parseRunCliArguments(
+      '/usr/bin/bash',
+      '-c /app/configs/remove_dovi.sh "/Video/Testing\'s Movie.mkv" "/cache/out file.mkv"',
+      mockParseArgsStringToArgv,
+    );
+
+    expect(result).toEqual([
+      '-c',
+      '/app/configs/remove_dovi.sh "/Video/Testing\'s Movie.mkv" "/cache/out file.mkv"',
+    ]);
+    expect(mockParseArgsStringToArgv).not.toHaveBeenCalled();
+  });
+
+  it('should keep sh -c remainder as one command string', () => {
+    const result = parseRunCliArguments(
+      '/bin/sh',
+      '-c echo "hello world"',
+      mockParseArgsStringToArgv,
+    );
+
+    expect(result).toEqual([
+      '-c',
+      'echo "hello world"',
+    ]);
+    expect(mockParseArgsStringToArgv).not.toHaveBeenCalled();
+  });
+
+  it('should unwrap quoted shell command strings and preserve inner quotes', () => {
+    const result = parseRunCliArguments(
+      '/bin/bash',
+      '-lc "printf \'%s\' \'two words\'"',
+      mockParseArgsStringToArgv,
+    );
+
+    expect(result).toEqual([
+      '-lc',
+      'printf \'%s\' \'two words\'',
+    ]);
+  });
+
+  it('should parse PowerShell options before -Command and keep the command string intact', () => {
+    const result = parseRunCliArguments(
+      'powershell.exe',
+      '-NoProfile -Command "if (Get-Process -Name \'ffmpeg\') { Write-Host \'found process\' }"',
+      mockParseArgsStringToArgv,
+    );
+
+    expect(result).toEqual([
+      '-NoProfile',
+      '-Command',
+      'if (Get-Process -Name \'ffmpeg\') { Write-Host \'found process\' }',
+    ]);
+    expect(mockParseArgsStringToArgv).toHaveBeenCalledWith('-NoProfile', '', '');
   });
 });


### PR DESCRIPTION
Fixes #810

Summary:
- Keep bash, sh, and PowerShell command strings as one spawn argument when using -c or -Command.
- Continue using the worker supplied parser for normal CLI args.
- Add regression tests for quoted paths and shell command strings.

Tests:
- npm run test:flows -- tests/FlowPlugins/CommunityFlowPlugins/tools/runCli/1.0.0/index.test.ts --runInBand
- eslint on touched TS and test files
- tsc -p tsconfig.json