### PR TITLE
feat: add web request output 2 routing

### DIFF
--- a/FlowPlugins/CommunityFlowPlugins/tools/webRequest/1.0.0/index.js
+++ b/FlowPlugins/CommunityFlowPlugins/tools/webRequest/1.0.0/index.js
@@ -113,20 +113,92 @@ var details = function () { return ({
             },
             tooltip: 'Specify whether to log response body in the job report',
         },
+        {
+            label: 'Output 2 Status Codes',
+            name: 'output2StatusCodes',
+            type: 'string',
+            defaultValue: '',
+            inputUI: {
+                type: 'text',
+            },
+            tooltip: 'Comma-separated HTTP status codes or ranges to route to output 2 instead of failing, '
+                + 'e.g. 400,404,429,500-599.',
+        },
+        {
+            label: 'Output 2 On Network Error',
+            name: 'output2OnNetworkError',
+            type: 'boolean',
+            defaultValue: 'false',
+            inputUI: {
+                type: 'switch',
+            },
+            tooltip: 'Route connection errors, DNS errors, and timeouts to output 2 instead of failing the flow.',
+        },
     ],
     outputs: [
         {
             number: 1,
-            tooltip: 'Continue to next plugin',
+            tooltip: 'Request succeeded',
+        },
+        {
+            number: 2,
+            tooltip: 'Request failed with a configured status code or network error',
         },
     ],
 }); };
 exports.details = details;
+var MIN_HTTP_STATUS_CODE = 100;
+var MAX_HTTP_STATUS_CODE = 599;
+var MIN_SUCCESS_STATUS_CODE = 200;
+var MAX_SUCCESS_STATUS_CODE = 299;
+var validateStatusCode = function (statusCode, token) {
+    if (statusCode < MIN_HTTP_STATUS_CODE || statusCode > MAX_HTTP_STATUS_CODE) {
+        throw new Error("Invalid HTTP status code in Output 2 Status Codes: ".concat(token));
+    }
+};
+var parseOutput2StatusCodes = function (input) {
+    var tokens = input.split(',')
+        .map(function (rawToken) { return rawToken.trim(); })
+        .filter(function (token) { return token !== ''; });
+    return tokens.map(function (token) {
+        if (/^\d{3}$/.test(token)) {
+            var statusCode = Number(token);
+            validateStatusCode(statusCode, token);
+            return {
+                min: statusCode,
+                max: statusCode,
+            };
+        }
+        var rangeMatch = /^(\d{3})\s*-\s*(\d{3})$/.exec(token);
+        if (rangeMatch) {
+            var min = Number(rangeMatch[1]);
+            var max = Number(rangeMatch[2]);
+            validateStatusCode(min, token);
+            validateStatusCode(max, token);
+            if (min > max) {
+                throw new Error("Invalid HTTP status code range in Output 2 Status Codes: ".concat(token));
+            }
+            return {
+                min: min,
+                max: max,
+            };
+        }
+        throw new Error("Invalid Output 2 Status Codes value: ".concat(token));
+    });
+};
+var shouldRouteStatusCodeToOutput2 = function (statusCode, output2StatusCodeRanges) { return output2StatusCodeRanges.some(function (range) { return (statusCode >= range.min && statusCode <= range.max); }); };
+var isSuccessfulStatusCode = function (statusCode) { return (statusCode >= MIN_SUCCESS_STATUS_CODE && statusCode <= MAX_SUCCESS_STATUS_CODE); };
+var buildOutputArgs = function (args, outputNumber) { return ({
+    outputFileObj: args.inputFileObj,
+    outputNumber: outputNumber,
+    variables: args.variables,
+}); };
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 var plugin = function (args) { return __awaiter(void 0, void 0, void 0, function () {
-    var lib, method, requestUrl, requestHeaders, requestBody, logResponseBody, requestConfig, res, err_1;
-    return __generator(this, function (_a) {
-        switch (_a.label) {
+    var lib, method, requestUrl, requestHeaders, requestBody, logResponseBody, output2StatusCodeRanges, output2OnNetworkError, requestConfig, res, err_1, errWithResponse, rawStatusCode, statusCode_1, statusCode;
+    var _a;
+    return __generator(this, function (_b) {
+        switch (_b.label) {
             case 0:
                 lib = require('../../../../../methods/lib')();
                 // eslint-disable-next-line @typescript-eslint/no-unused-vars,no-param-reassign
@@ -136,33 +208,55 @@ var plugin = function (args) { return __awaiter(void 0, void 0, void 0, function
                 requestHeaders = JSON.parse(String(args.inputs.requestHeaders));
                 requestBody = JSON.parse(String(args.inputs.requestBody));
                 logResponseBody = args.inputs.logResponseBody;
+                output2StatusCodeRanges = parseOutput2StatusCodes(String(args.inputs.output2StatusCodes));
+                output2OnNetworkError = args.inputs.output2OnNetworkError;
                 requestConfig = {
                     method: method,
                     url: requestUrl,
                     headers: requestHeaders,
                     data: requestBody,
                 };
-                _a.label = 1;
+                _b.label = 1;
             case 1:
-                _a.trys.push([1, 3, , 4]);
+                _b.trys.push([1, 3, , 4]);
                 return [4 /*yield*/, args.deps.axios(requestConfig)];
             case 2:
-                res = _a.sent();
-                args.jobLog("Web request succeeded: Status Code: ".concat(res.status));
+                res = _b.sent();
+                return [3 /*break*/, 4];
+            case 3:
+                err_1 = _b.sent();
+                args.jobLog('Web Request Failed');
+                args.jobLog(JSON.stringify(err_1));
+                errWithResponse = err_1;
+                rawStatusCode = (_a = errWithResponse.response) === null || _a === void 0 ? void 0 : _a.status;
+                statusCode_1 = Number(rawStatusCode);
+                if (shouldRouteStatusCodeToOutput2(statusCode_1, output2StatusCodeRanges)) {
+                    args.jobLog("Routing status code ".concat(statusCode_1, " to output 2"));
+                    return [2 /*return*/, buildOutputArgs(args, 2)];
+                }
+                if (rawStatusCode === undefined && output2OnNetworkError) {
+                    args.jobLog('Routing network error to output 2');
+                    return [2 /*return*/, buildOutputArgs(args, 2)];
+                }
+                throw new Error('Web Request Failed');
+            case 4:
+                statusCode = Number(res.status);
+                if (isSuccessfulStatusCode(statusCode)) {
+                    args.jobLog("Web request succeeded: Status Code: ".concat(statusCode));
+                    if (logResponseBody) {
+                        args.jobLog("Response Body: ".concat(JSON.stringify(res.data)));
+                    }
+                    return [2 /*return*/, buildOutputArgs(args, 1)];
+                }
+                args.jobLog("Web request failed: Status Code: ".concat(statusCode));
                 if (logResponseBody) {
                     args.jobLog("Response Body: ".concat(JSON.stringify(res.data)));
                 }
-                return [3 /*break*/, 4];
-            case 3:
-                err_1 = _a.sent();
-                args.jobLog('Web Request Failed');
-                args.jobLog(JSON.stringify(err_1));
+                if (shouldRouteStatusCodeToOutput2(statusCode, output2StatusCodeRanges)) {
+                    args.jobLog("Routing status code ".concat(statusCode, " to output 2"));
+                    return [2 /*return*/, buildOutputArgs(args, 2)];
+                }
                 throw new Error('Web Request Failed');
-            case 4: return [2 /*return*/, {
-                    outputFileObj: args.inputFileObj,
-                    outputNumber: 1,
-                    variables: args.variables,
-                }];
         }
     });
 }); };

--- a/FlowPluginsTs/CommunityFlowPlugins/tools/webRequest/1.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/tools/webRequest/1.0.0/index.ts
@@ -84,13 +84,118 @@ const details = (): IpluginDetails => ({
       },
       tooltip: 'Specify whether to log response body in the job report',
     },
+    {
+      label: 'Output 2 Status Codes',
+      name: 'output2StatusCodes',
+      type: 'string',
+      defaultValue: '',
+      inputUI: {
+        type: 'text',
+      },
+      tooltip: 'Comma-separated HTTP status codes or ranges to route to output 2 instead of failing, '
+        + 'e.g. 400,404,429,500-599.',
+    },
+    {
+      label: 'Output 2 On Network Error',
+      name: 'output2OnNetworkError',
+      type: 'boolean',
+      defaultValue: 'false',
+      inputUI: {
+        type: 'switch',
+      },
+      tooltip: 'Route connection errors, DNS errors, and timeouts to output 2 instead of failing the flow.',
+    },
   ],
   outputs: [
     {
       number: 1,
-      tooltip: 'Continue to next plugin',
+      tooltip: 'Request succeeded',
+    },
+    {
+      number: 2,
+      tooltip: 'Request failed with a configured status code or network error',
     },
   ],
+});
+
+interface IStatusCodeRange {
+  min: number,
+  max: number,
+}
+
+interface IWebRequestResponse {
+  status: number | string,
+  data?: unknown,
+}
+
+interface IWebRequestError {
+  response?: {
+    status?: number | string,
+  },
+}
+
+const MIN_HTTP_STATUS_CODE = 100;
+const MAX_HTTP_STATUS_CODE = 599;
+const MIN_SUCCESS_STATUS_CODE = 200;
+const MAX_SUCCESS_STATUS_CODE = 299;
+
+const validateStatusCode = (statusCode: number, token: string): void => {
+  if (statusCode < MIN_HTTP_STATUS_CODE || statusCode > MAX_HTTP_STATUS_CODE) {
+    throw new Error(`Invalid HTTP status code in Output 2 Status Codes: ${token}`);
+  }
+};
+
+const parseOutput2StatusCodes = (input: string): IStatusCodeRange[] => {
+  const tokens = input.split(',')
+    .map((rawToken) => rawToken.trim())
+    .filter((token) => token !== '');
+
+  return tokens.map((token) => {
+    if (/^\d{3}$/.test(token)) {
+      const statusCode = Number(token);
+      validateStatusCode(statusCode, token);
+      return {
+        min: statusCode,
+        max: statusCode,
+      };
+    }
+
+    const rangeMatch = /^(\d{3})\s*-\s*(\d{3})$/.exec(token);
+    if (rangeMatch) {
+      const min = Number(rangeMatch[1]);
+      const max = Number(rangeMatch[2]);
+      validateStatusCode(min, token);
+      validateStatusCode(max, token);
+
+      if (min > max) {
+        throw new Error(`Invalid HTTP status code range in Output 2 Status Codes: ${token}`);
+      }
+
+      return {
+        min,
+        max,
+      };
+    }
+
+    throw new Error(`Invalid Output 2 Status Codes value: ${token}`);
+  });
+};
+
+const shouldRouteStatusCodeToOutput2 = (
+  statusCode: number,
+  output2StatusCodeRanges: IStatusCodeRange[],
+): boolean => output2StatusCodeRanges.some((range) => (
+  statusCode >= range.min && statusCode <= range.max
+));
+
+const isSuccessfulStatusCode = (statusCode: number): boolean => (
+  statusCode >= MIN_SUCCESS_STATUS_CODE && statusCode <= MAX_SUCCESS_STATUS_CODE
+);
+
+const buildOutputArgs = (args: IpluginInputArgs, outputNumber: number): IpluginOutputArgs => ({
+  outputFileObj: args.inputFileObj,
+  outputNumber,
+  variables: args.variables,
 });
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -104,6 +209,8 @@ const plugin = async (args: IpluginInputArgs): Promise<IpluginOutputArgs> => {
   const requestHeaders = JSON.parse(String(args.inputs.requestHeaders));
   const requestBody = JSON.parse(String(args.inputs.requestBody));
   const { logResponseBody } = args.inputs;
+  const output2StatusCodeRanges = parseOutput2StatusCodes(String(args.inputs.output2StatusCodes));
+  const { output2OnNetworkError } = args.inputs;
 
   const requestConfig = {
     method,
@@ -112,24 +219,53 @@ const plugin = async (args: IpluginInputArgs): Promise<IpluginOutputArgs> => {
     data: requestBody,
   };
 
+  let res: IWebRequestResponse;
   try {
-    const res = await args.deps.axios(requestConfig);
-    args.jobLog(`Web request succeeded: Status Code: ${res.status}`);
+    res = await args.deps.axios(requestConfig);
+  } catch (err) {
+    args.jobLog('Web Request Failed');
+    args.jobLog(JSON.stringify(err));
+
+    const errWithResponse = err as IWebRequestError;
+    const rawStatusCode = errWithResponse.response?.status;
+    const statusCode = Number(rawStatusCode);
+    if (shouldRouteStatusCodeToOutput2(statusCode, output2StatusCodeRanges)) {
+      args.jobLog(`Routing status code ${statusCode} to output 2`);
+      return buildOutputArgs(args, 2);
+    }
+
+    if (rawStatusCode === undefined && output2OnNetworkError) {
+      args.jobLog('Routing network error to output 2');
+      return buildOutputArgs(args, 2);
+    }
+
+    throw new Error('Web Request Failed');
+  }
+
+  const statusCode = Number(res.status);
+
+  if (isSuccessfulStatusCode(statusCode)) {
+    args.jobLog(`Web request succeeded: Status Code: ${statusCode}`);
 
     if (logResponseBody) {
       args.jobLog(`Response Body: ${JSON.stringify(res.data)}`);
     }
-  } catch (err) {
-    args.jobLog('Web Request Failed');
-    args.jobLog(JSON.stringify(err));
-    throw new Error('Web Request Failed');
+
+    return buildOutputArgs(args, 1);
   }
 
-  return {
-    outputFileObj: args.inputFileObj,
-    outputNumber: 1,
-    variables: args.variables,
-  };
+  args.jobLog(`Web request failed: Status Code: ${statusCode}`);
+
+  if (logResponseBody) {
+    args.jobLog(`Response Body: ${JSON.stringify(res.data)}`);
+  }
+
+  if (shouldRouteStatusCodeToOutput2(statusCode, output2StatusCodeRanges)) {
+    args.jobLog(`Routing status code ${statusCode} to output 2`);
+    return buildOutputArgs(args, 2);
+  }
+
+  throw new Error('Web Request Failed');
 };
 export {
   details,

--- a/tests/FlowPlugins/CommunityFlowPlugins/tools/webRequest/1.0.0/index.test.ts
+++ b/tests/FlowPlugins/CommunityFlowPlugins/tools/webRequest/1.0.0/index.test.ts
@@ -21,6 +21,8 @@ describe('webRequest Plugin', () => {
         requestHeaders: '{"Content-Type": "application/json"}',
         requestBody: '{"test": "test"}',
         logResponseBody: 'false',
+        output2StatusCodes: '',
+        output2OnNetworkError: 'false',
       },
       variables: {
         ffmpegCommand: {
@@ -274,6 +276,133 @@ describe('webRequest Plugin', () => {
       expect(baseArgs.jobLog).toHaveBeenCalledWith('Web Request Failed');
       expect(baseArgs.jobLog).toHaveBeenCalledWith(JSON.stringify(timeoutError));
     });
+
+    it('should throw on unconfigured non-2xx responses', async () => {
+      const mockResponse = {
+        status: 429,
+        data: { error: 'Rate limited' },
+      };
+      mockAxios.mockResolvedValue(mockResponse);
+
+      await expect(plugin(baseArgs)).rejects.toThrow('Web Request Failed');
+
+      expect(baseArgs.jobLog).toHaveBeenCalledWith('Web request failed: Status Code: 429');
+    });
+  });
+
+  describe('Output 2 Routing', () => {
+    it('should route configured status codes to output 2', async () => {
+      baseArgs.inputs.output2StatusCodes = '404,429';
+      const mockResponse = {
+        status: 429,
+        data: { error: 'Rate limited' },
+      };
+      mockAxios.mockResolvedValue(mockResponse);
+
+      const result = await plugin(baseArgs);
+
+      expect(result.outputNumber).toBe(2);
+      expect(result.outputFileObj).toBe(baseArgs.inputFileObj);
+      expect(baseArgs.jobLog).toHaveBeenCalledWith('Web request failed: Status Code: 429');
+      expect(baseArgs.jobLog).toHaveBeenCalledWith('Routing status code 429 to output 2');
+    });
+
+    it('should route configured status code ranges to output 2', async () => {
+      baseArgs.inputs.output2StatusCodes = '400-499, 500-599';
+      const mockResponse = {
+        status: 503,
+        data: { error: 'Unavailable' },
+      };
+      mockAxios.mockResolvedValue(mockResponse);
+
+      const result = await plugin(baseArgs);
+
+      expect(result.outputNumber).toBe(2);
+      expect(baseArgs.jobLog).toHaveBeenCalledWith('Web request failed: Status Code: 503');
+      expect(baseArgs.jobLog).toHaveBeenCalledWith('Routing status code 503 to output 2');
+    });
+
+    it('should ignore blank status code entries', async () => {
+      baseArgs.inputs.output2StatusCodes = '404, ,429,';
+      const mockResponse = {
+        status: 404,
+        data: { error: 'Not Found' },
+      };
+      mockAxios.mockResolvedValue(mockResponse);
+
+      const result = await plugin(baseArgs);
+
+      expect(result.outputNumber).toBe(2);
+      expect(baseArgs.jobLog).toHaveBeenCalledWith('Routing status code 404 to output 2');
+    });
+
+    it('should route configured HTTP error responses to output 2', async () => {
+      baseArgs.inputs.output2StatusCodes = '404';
+      const httpError = {
+        response: {
+          status: 404,
+          data: { error: 'Not Found' },
+        },
+        message: 'Request failed with status code 404',
+      };
+      mockAxios.mockRejectedValue(httpError);
+
+      const result = await plugin(baseArgs);
+
+      expect(result.outputNumber).toBe(2);
+      expect(baseArgs.jobLog).toHaveBeenCalledWith('Routing status code 404 to output 2');
+    });
+
+    it('should route network errors to output 2 when enabled', async () => {
+      baseArgs.inputs.output2OnNetworkError = 'true';
+      const networkError = new Error('Network Error');
+      mockAxios.mockRejectedValue(networkError);
+
+      const result = await plugin(baseArgs);
+
+      expect(result.outputNumber).toBe(2);
+      expect(baseArgs.jobLog).toHaveBeenCalledWith('Routing network error to output 2');
+    });
+
+    it('should not route unconfigured HTTP responses through the network error switch', async () => {
+      baseArgs.inputs.output2OnNetworkError = 'true';
+      const httpError = {
+        response: {
+          status: 500,
+          data: { error: 'Server Error' },
+        },
+        message: 'Request failed with status code 500',
+      };
+      mockAxios.mockRejectedValue(httpError);
+
+      await expect(plugin(baseArgs)).rejects.toThrow('Web Request Failed');
+
+      expect(baseArgs.jobLog).not.toHaveBeenCalledWith('Routing network error to output 2');
+    });
+
+    it('should not route response processing errors through the network error switch', async () => {
+      baseArgs.inputs.logResponseBody = 'true';
+      baseArgs.inputs.output2OnNetworkError = 'true';
+      const circularResponseData: Record<string, unknown> = {};
+      circularResponseData.self = circularResponseData;
+      const mockResponse = {
+        status: 200,
+        data: circularResponseData,
+      };
+      mockAxios.mockResolvedValue(mockResponse);
+
+      await expect(plugin(baseArgs)).rejects.toThrow('Converting circular structure to JSON');
+
+      expect(baseArgs.jobLog).not.toHaveBeenCalledWith('Routing network error to output 2');
+    });
+
+    it('should reject invalid output 2 status code configuration', async () => {
+      baseArgs.inputs.output2StatusCodes = '404,abc';
+
+      await expect(plugin(baseArgs)).rejects.toThrow('Invalid Output 2 Status Codes value: abc');
+
+      expect(mockAxios).not.toHaveBeenCalled();
+    });
   });
 
   describe('Input Validation and Edge Cases', () => {
@@ -336,7 +465,7 @@ describe('webRequest Plugin', () => {
       [201, 'Created'],
       [202, 'Accepted'],
       [204, 'No Content'],
-      [300, 'Multiple Choices'],
+      [299, 'Custom Success'],
     ])('should handle status code %d', async (statusCode, statusText) => {
       const mockResponse = {
         status: statusCode,


### PR DESCRIPTION
## Summary

Adds optional output 2 routing to the Flow `Send Web Request` plugin.

- Adds `Output 2 Status Codes` input for comma-separated HTTP codes or ranges, for example `404,429,500-599`
- Adds `Output 2 On Network Error` switch for connection, DNS, and timeout failures
- Keeps default behavior unchanged when both new inputs are left at defaults
- Adds output `2` for configured soft-fail request outcomes
- Updates generated JS and expands test coverage