### PR TITLE
fix: avoid scale_cuda for classic 10-bit NVENC

### DIFF
--- a/Community/Tdarr_Plugin_00td_action_transcode.js
+++ b/Community/Tdarr_Plugin_00td_action_transcode.js
@@ -425,6 +425,13 @@ const plugin = async (file, librarySettings, inputs, otherArguments) => {
   let extraArguments = '';
   let genpts = '';
   let bitrateSettings = '';
+  const {
+    getNvdecHwaccelPreset,
+    getNvenc10BitFormatArg,
+  } = require('../methods/nvdecPreset');
+  const nvencDecodeOptions = inputs.enable_10bit === true
+    ? { softwareFrames: true }
+    : undefined;
 
   // Used from here https://blog.frame.io/2017/03/06/calculate-video-bitrates/
 
@@ -506,11 +513,7 @@ const plugin = async (file, librarySettings, inputs, otherArguments) => {
 
   // Check if 10bit variable is true.
   if (inputs.enable_10bit === true) {
-    // Use scale_cuda when CUDA hwaccel is active (frames live in GPU memory
-    // and `-pix_fmt p010le` fails on hwframes); fall back to `-pix_fmt
-    // p010le` for software decode paths.
-    const { getNvenc10BitFormatArg } = require('../methods/nvdecPreset');
-    extraArguments += getNvenc10BitFormatArg(file);
+    extraArguments += getNvenc10BitFormatArg(file, nvencDecodeOptions);
   }
 
   // Check if b frame variable is true.
@@ -579,8 +582,7 @@ const plugin = async (file, librarySettings, inputs, otherArguments) => {
   // which cause frame-ordering issues (stuttering) with FFmpeg 7+.
   // Helper returns '' for AV1 to keep older GPUs on software decode.
   if (encoderProperties.encoder.includes('nvenc')) {
-    const { getNvdecHwaccelPreset } = require('../methods/nvdecPreset');
-    response.preset = getNvdecHwaccelPreset(file);
+    response.preset = getNvdecHwaccelPreset(file, nvencDecodeOptions);
   }
 
   const vEncode = `-cq:v 19 ${bitrateSettings}`;

--- a/Community/Tdarr_Plugin_MC93_Migz1FFMPEG.js
+++ b/Community/Tdarr_Plugin_MC93_Migz1FFMPEG.js
@@ -162,6 +162,13 @@ const plugin = (file, librarySettings, inputs, otherArguments) => {
   let extraArguments = '';
   let genpts = '';
   let bitrateSettings = '';
+  const {
+    getNvdecHwaccelPreset,
+    getNvenc10BitFormatArg,
+  } = require('../methods/nvdecPreset');
+  const nvencDecodeOptions = inputs.enable_10bit === true
+    ? { softwareFrames: true }
+    : undefined;
   // Work out currentBitrate using "Bitrate = file size / (number of minutes * .0075)"
   // Used from here https://blog.frame.io/2017/03/06/calculate-video-bitrates/
   // eslint-disable-next-line no-bitwise
@@ -247,11 +254,7 @@ const plugin = (file, librarySettings, inputs, otherArguments) => {
 
   // Check if 10bit variable is true.
   if (inputs.enable_10bit === true) {
-    // Use scale_cuda when CUDA hwaccel is active (frames live in GPU memory
-    // and `-pix_fmt p010le` fails on hwframes); fall back to `-pix_fmt
-    // p010le` for software decode paths.
-    const { getNvenc10BitFormatArg } = require('../methods/nvdecPreset');
-    extraArguments += getNvenc10BitFormatArg(file);
+    extraArguments += getNvenc10BitFormatArg(file, nvencDecodeOptions);
   }
 
   // Check if b frame variable is true.
@@ -323,8 +326,7 @@ const plugin = (file, librarySettings, inputs, otherArguments) => {
   // Use modern CUDA hwaccel instead of legacy *_cuvid decoders
   // which cause frame-ordering issues (stuttering) with FFmpeg 7+.
   // Helper returns '' for AV1 to keep older GPUs on software decode.
-  const { getNvdecHwaccelPreset } = require('../methods/nvdecPreset');
-  response.preset = getNvdecHwaccelPreset(file);
+  response.preset = getNvdecHwaccelPreset(file, nvencDecodeOptions);
 
   response.preset += `${genpts}, -map 0 -c:v hevc_nvenc -cq:v 19 ${bitrateSettings} `
   + `-spatial_aq:v 1 -rc-lookahead:v 32 -c:a copy -c:s copy -max_muxing_queue_size 9999 ${extraArguments}`;

--- a/Community/Tdarr_Plugin_d5d3_iiDrakeii_FFMPEG_NVENC_Tiered_MKV.js
+++ b/Community/Tdarr_Plugin_d5d3_iiDrakeii_FFMPEG_NVENC_Tiered_MKV.js
@@ -59,8 +59,12 @@ const plugin = (file, librarySettings, inputs, otherArguments) => {
   // Use modern CUDA hwaccel instead of legacy *_cuvid decoders
   // which cause frame-ordering issues (stuttering) with FFmpeg 7+.
   // Helper returns '' for AV1 to keep older GPUs on software decode.
-  const { getNvdecHwaccelPreset } = require('../methods/nvdecPreset');
-  response.preset = getNvdecHwaccelPreset(file);
+  const nvencDecodeOptions = { softwareFrames: true };
+  const {
+    getNvdecHwaccelPreset,
+    getNvenc10BitFormatArg,
+  } = require('../methods/nvdecPreset');
+  response.preset = getNvdecHwaccelPreset(file, nvencDecodeOptions);
 
   //Set Subtitle Var before adding encode cli
   for (var i = 0; i < file.ffProbeData.streams.length; i++) {
@@ -97,11 +101,7 @@ const plugin = (file, librarySettings, inputs, otherArguments) => {
       }
     } catch (err) {}
   }
-  // Use scale_cuda when CUDA hwaccel is active (frames live in GPU memory and
-  // `-pix_fmt p010le` fails on hwframes); fall back to `-pix_fmt p010le` for
-  // software decode paths.
-  const { getNvenc10BitFormatArg } = require('../methods/nvdecPreset');
-  const tenBit = getNvenc10BitFormatArg(file).trim();
+  const tenBit = getNvenc10BitFormatArg(file, nvencDecodeOptions).trim();
 
   //file will be encoded if the resolution is 480p or 576p
   //codec will be checked so it can be transcoded correctly

--- a/tests/Community/Tdarr_Plugin_00td_action_transcode.js
+++ b/tests/Community/Tdarr_Plugin_00td_action_transcode.js
@@ -1,6 +1,18 @@
 /* eslint max-len: 0 */
 const _ = require('lodash');
+const childProcess = require('child_process');
 const run = require('../helpers/run');
+
+childProcess.exec = (command, callback) => {
+  callback(command.includes('hevc_nvenc') ? null : new Error('unsupported encoder'));
+};
+
+childProcess.execSync = (command) => {
+  if (command.includes('--query-gpu=name')) {
+    return 'Mock GPU';
+  }
+  return '7';
+};
 
 const tests = [
   {
@@ -70,6 +82,82 @@ const tests = [
       FFmpegMode: true,
       reQueueAfter: true,
       infoLog: 'Container for output selected as mkv. \n'
+        + 'Current bitrate = 1591143.0722891565 \n'
+        + 'Bitrate settings: \n'
+        + 'Target = 1193357.3042168673 \n'
+        + 'Minimum = 835350.1129518071 \n'
+        + 'Maximum = 1551364.4954819276 \n'
+        + 'File is not in hevc. Transcoding. \n',
+      container: '.mkv',
+    },
+  },
+
+  {
+    input: {
+      file: _.cloneDeep(require('../sampleData/media/sampleH264_1.json')),
+      librarySettings: {},
+      inputs: {
+        target_codec: 'hevc',
+        target_bitrate_multiplier: 0.75,
+        try_use_gpu: true,
+        container: 'mkv',
+        bitrate_cutoff: 0,
+
+        enable_10bit: true,
+        bframes_enabled: false,
+        bframes_value: 5,
+        force_conform: false,
+
+      },
+      otherArguments: {},
+    },
+    output: {
+      processFile: true,
+      preset: '  <io> -map 0 -c copy -c:v libx265  -cq:v 19 -b:v 1193357.3042168673 -minrate 835350.1129518071 -maxrate 1551364.4954819276 -bufsize 1591143.0722891565 -spatial_aq:v 1 -rc-lookahead:v 32 -max_muxing_queue_size 9999 -pix_fmt p010le ',
+      handBrakeMode: false,
+      FFmpegMode: true,
+      reQueueAfter: true,
+      infoLog: 'Container for output selected as mkv. \n'
+        + 'Current bitrate = 1591143.0722891565 \n'
+        + 'Bitrate settings: \n'
+        + 'Target = 1193357.3042168673 \n'
+        + 'Minimum = 835350.1129518071 \n'
+        + 'Maximum = 1551364.4954819276 \n'
+        + 'File is not in hevc. Transcoding. \n',
+      container: '.mkv',
+    },
+  },
+
+  {
+    input: {
+      file: _.cloneDeep(require('../sampleData/media/sampleH264_1.json')),
+      librarySettings: {},
+      inputs: {
+        target_codec: 'hevc',
+        target_bitrate_multiplier: 0.75,
+        try_use_gpu: true,
+        container: 'mkv',
+        bitrate_cutoff: 0,
+
+        enable_10bit: true,
+        bframes_enabled: false,
+        bframes_value: 5,
+        force_conform: false,
+
+      },
+      otherArguments: {
+        workerType: 'gpu',
+        ffmpegPath: 'ffmpeg',
+      },
+    },
+    output: {
+      processFile: true,
+      preset: '-hwaccel cuda -hwaccel_device 0 <io> -map 0 -c copy -c:v hevc_nvenc -gpu 0 -cq:v 19 -b:v 1193357.3042168673 -minrate 835350.1129518071 -maxrate 1551364.4954819276 -bufsize 1591143.0722891565 -spatial_aq:v 1 -rc-lookahead:v 32 -max_muxing_queue_size 9999 -pix_fmt p010le ',
+      handBrakeMode: false,
+      FFmpegMode: true,
+      reQueueAfter: true,
+      infoLog: 'GPU 0 : Utilization 7%\n'
+        + 'Container for output selected as mkv. \n'
         + 'Current bitrate = 1591143.0722891565 \n'
         + 'Bitrate settings: \n'
         + 'Target = 1193357.3042168673 \n'

--- a/tests/Community/Tdarr_Plugin_MC93_Migz1FFMPEG.js
+++ b/tests/Community/Tdarr_Plugin_MC93_Migz1FFMPEG.js
@@ -56,7 +56,7 @@ const tests = [
     },
     output: {
       processFile: true,
-      preset: '-hwaccel cuda -hwaccel_output_format cuda, -map 0 -c:v hevc_nvenc -cq:v 19 -b:v 758k -minrate 530k -maxrate 985k -bufsize 1517k -spatial_aq:v 1 -rc-lookahead:v 32 -c:a copy -c:s copy -max_muxing_queue_size 9999 -vf scale_cuda=format=p010le ',
+      preset: '-hwaccel cuda, -map 0 -c:v hevc_nvenc -cq:v 19 -b:v 758k -minrate 530k -maxrate 985k -bufsize 1517k -spatial_aq:v 1 -rc-lookahead:v 32 -c:a copy -c:s copy -max_muxing_queue_size 9999 -pix_fmt p010le ',
       handBrakeMode: false,
       FFmpegMode: true,
       reQueueAfter: true,
@@ -106,7 +106,7 @@ const tests = [
     },
     output: {
       processFile: true,
-      preset: '-hwaccel cuda -hwaccel_output_format cuda, -map 0 -c:v hevc_nvenc -cq:v 19 -b:v 758k -minrate 530k -maxrate 985k -bufsize 1517k -spatial_aq:v 1 -rc-lookahead:v 32 -c:a copy -c:s copy -max_muxing_queue_size 9999 -vf scale_cuda=format=p010le ',
+      preset: '-hwaccel cuda, -map 0 -c:v hevc_nvenc -cq:v 19 -b:v 758k -minrate 530k -maxrate 985k -bufsize 1517k -spatial_aq:v 1 -rc-lookahead:v 32 -c:a copy -c:s copy -max_muxing_queue_size 9999 -pix_fmt p010le ',
       handBrakeMode: false,
       FFmpegMode: true,
       reQueueAfter: true,
@@ -134,7 +134,7 @@ const tests = [
     },
     output: {
       processFile: true,
-      preset: '-hwaccel cuda -hwaccel_output_format cuda, -map 0 -c:v hevc_nvenc -cq:v 19 -b:v 3933k -minrate 2753k -maxrate 5112k -bufsize 7866k -spatial_aq:v 1 -rc-lookahead:v 32 -c:a copy -c:s copy -max_muxing_queue_size 9999 -map -0:d -vf scale_cuda=format=p010le ',
+      preset: '-hwaccel cuda, -map 0 -c:v hevc_nvenc -cq:v 19 -b:v 3933k -minrate 2753k -maxrate 5112k -bufsize 7866k -spatial_aq:v 1 -rc-lookahead:v 32 -c:a copy -c:s copy -max_muxing_queue_size 9999 -map -0:d -pix_fmt p010le ',
       handBrakeMode: false,
       FFmpegMode: true,
       reQueueAfter: true,

--- a/tests/Community/Tdarr_Plugin_d5d3_iiDrakeii_FFMPEG_NVENC_Tiered_MKV.js
+++ b/tests/Community/Tdarr_Plugin_d5d3_iiDrakeii_FFMPEG_NVENC_Tiered_MKV.js
@@ -12,7 +12,7 @@ const tests = [
     },
     output: {
       processFile: true,
-      preset: '-hwaccel cuda -hwaccel_output_format cuda,-map 0 -dn -c:v hevc_nvenc -vf scale_cuda=format=p010le -qmin 0 -cq:v 30 -b:v 964k -maxrate:v 2964k -preset slow -rc-lookahead 32 -spatial_aq:v 1 -aq-strength:v 8 -a53cc 0 -c:a copy -c:s copy',
+      preset: '-hwaccel cuda,-map 0 -dn -c:v hevc_nvenc -pix_fmt p010le -qmin 0 -cq:v 30 -b:v 964k -maxrate:v 2964k -preset slow -rc-lookahead 32 -spatial_aq:v 1 -aq-strength:v 8 -a53cc 0 -c:a copy -c:s copy',
       container: '.mkv',
       handBrakeMode: false,
       FFmpegMode: true,


### PR DESCRIPTION
Summary
- Use software-frame NVDEC mode for classic 10-bit NVENC paths.
- Emit -pix_fmt p010le instead of scale_cuda to avoid filter graph reinit failures.
- Add tests for affected classic plugins and action-transcode NVENC path.
