### PR TITLE
feat: add full GPU 10-bit NVENC option

### DIFF
--- a/Community/Tdarr_Plugin_MC93_Migz1FFMPEG.js
+++ b/Community/Tdarr_Plugin_MC93_Migz1FFMPEG.js
@@ -10,7 +10,7 @@ const details = () => ({
                   Working by the logic that H265 can support the same ammount of data at half the bitrate of H264.
                   NVDEC & NVENC compatable GPU required.
                   This plugin will skip any files that are in the VP9 codec.`,
-  Version: '3.1',
+  Version: '3.2',
   Tags: 'pre-processing,ffmpeg,video only,nvenc h265,configurable',
   Inputs: [{
     name: 'container',
@@ -59,6 +59,25 @@ const details = () => ({
       ],
     },
     tooltip: `Specify if output file should be 10bit. Default is false.
+                    \\nExample:\\n
+                    true
+
+                    \\nExample:\\n
+                    false`,
+  },
+  {
+    name: 'enable_full_gpu_10bit',
+    type: 'boolean',
+    defaultValue: false,
+    inputUI: {
+      type: 'dropdown',
+      options: [
+        'false',
+        'true',
+      ],
+    },
+    tooltip: `Use full GPU 10-bit conversion with scale_cuda. This can restore previous NVENC speeds,
+                    but may fail on files affected by CUDA filter graph issues. Default is false.
                     \\nExample:\\n
                     true
 
@@ -166,7 +185,9 @@ const plugin = (file, librarySettings, inputs, otherArguments) => {
     getNvdecHwaccelPreset,
     getNvenc10BitFormatArg,
   } = require('../methods/nvdecPreset');
-  const nvencDecodeOptions = inputs.enable_10bit === true
+  const useSoftwareFramesFor10Bit = inputs.enable_10bit === true
+    && inputs.enable_full_gpu_10bit === false;
+  const nvencDecodeOptions = useSoftwareFramesFor10Bit
     ? { softwareFrames: true }
     : undefined;
   // Work out currentBitrate using "Bitrate = file size / (number of minutes * .0075)"
@@ -252,17 +273,6 @@ const plugin = (file, librarySettings, inputs, otherArguments) => {
     }
   }
 
-  // Check if 10bit variable is true.
-  if (inputs.enable_10bit === true) {
-    extraArguments += getNvenc10BitFormatArg(file, nvencDecodeOptions);
-  }
-
-  // Check if b frame variable is true.
-  if (inputs.enable_bframes === true) {
-    // If set to true then add b frames argument
-    extraArguments += '-bf 5 ';
-  }
-
   // Go through each stream in the file.
   for (let i = 0; i < file.ffProbeData.streams.length; i++) {
     // Check if stream is a video.
@@ -312,6 +322,19 @@ const plugin = (file, librarySettings, inputs, otherArguments) => {
     }
   }
 
+  // Keep encoder/filter args out of remux commands; FFmpeg cannot combine them with `-c copy`.
+  let transcodeOnlyArguments = '';
+  // Check if 10bit variable is true.
+  if (inputs.enable_10bit === true) {
+    transcodeOnlyArguments += getNvenc10BitFormatArg(file, nvencDecodeOptions);
+  }
+
+  // Check if b frame variable is true.
+  if (inputs.enable_bframes === true) {
+    // If set to true then add b frames argument
+    transcodeOnlyArguments += '-bf 5 ';
+  }
+
   // Set bitrateSettings variable using bitrate information calulcated earlier.
   bitrateSettings = `-b:v ${targetBitrate}k -minrate ${minimumBitrate}k `
   + `-maxrate ${maximumBitrate}k -bufsize ${currentBitrate}k`;
@@ -328,8 +351,9 @@ const plugin = (file, librarySettings, inputs, otherArguments) => {
   // Helper returns '' for AV1 to keep older GPUs on software decode.
   response.preset = getNvdecHwaccelPreset(file, nvencDecodeOptions);
 
+  const outputArguments = `${extraArguments}${transcodeOnlyArguments}`;
   response.preset += `${genpts}, -map 0 -c:v hevc_nvenc -cq:v 19 ${bitrateSettings} `
-  + `-spatial_aq:v 1 -rc-lookahead:v 32 -c:a copy -c:s copy -max_muxing_queue_size 9999 ${extraArguments}`;
+  + `-spatial_aq:v 1 -rc-lookahead:v 32 -c:a copy -c:s copy -max_muxing_queue_size 9999 ${outputArguments}`;
   response.processFile = true;
   response.infoLog += 'File is not hevc or vp9. Transcoding. \n';
   return response;

--- a/tests/Community/Tdarr_Plugin_MC93_Migz1FFMPEG.js
+++ b/tests/Community/Tdarr_Plugin_MC93_Migz1FFMPEG.js
@@ -77,6 +77,35 @@ const tests = [
       inputs: {
         container: 'mp4',
         enable_10bit: 'true',
+        enable_full_gpu_10bit: 'true',
+        enable_bframes: 'true',
+        force_conform: 'true',
+      },
+      otherArguments: {},
+    },
+    output: {
+      processFile: true,
+      preset: '-hwaccel cuda -hwaccel_output_format cuda, -map 0 -c:v hevc_nvenc -cq:v 19 -b:v 758k -minrate 530k -maxrate 985k -bufsize 1517k -spatial_aq:v 1 -rc-lookahead:v 32 -c:a copy -c:s copy -max_muxing_queue_size 9999 -vf scale_cuda=format=p010le -bf 5 ',
+      handBrakeMode: false,
+      FFmpegMode: true,
+      reQueueAfter: true,
+      infoLog: 'Container for output selected as mp4. \n'
+        + 'Current bitrate = 1517 \n'
+        + 'Bitrate settings: \n'
+        + 'Target = 758 \n'
+        + 'Minimum = 530 \n'
+        + 'Maximum = 985 \n'
+        + 'File is not hevc or vp9. Transcoding. \n',
+      container: '.mp4',
+    },
+  },
+  {
+    input: {
+      file: _.cloneDeep(require('../sampleData/media/sampleH264_1.json')),
+      librarySettings: {},
+      inputs: {
+        container: 'mp4',
+        enable_10bit: 'true',
         force_conform: 'true',
         bitrate_cutoff: '10000',
       },
@@ -154,6 +183,29 @@ const tests = [
       librarySettings: {},
       inputs: {
         container: 'mp4',
+        force_conform: 'false',
+      },
+      otherArguments: {},
+    },
+    output: {
+      processFile: true,
+      preset: ', -map 0 -c copy ',
+      handBrakeMode: false,
+      FFmpegMode: true,
+      reQueueAfter: true,
+      infoLog: 'File is hevc or vp9 but is not in mp4 container. Remuxing. \n',
+      container: '.mp4',
+    },
+  },
+  {
+    input: {
+      file: _.cloneDeep(require('../sampleData/media/sampleH265_1.json')),
+      librarySettings: {},
+      inputs: {
+        container: 'mp4',
+        enable_10bit: 'true',
+        enable_full_gpu_10bit: 'true',
+        enable_bframes: 'true',
         force_conform: 'false',
       },
       otherArguments: {},


### PR DESCRIPTION
## Summary

Adds an opt-in `enable_full_gpu_10bit` option to `Tdarr_Plugin_MC93_Migz1FFMPEG`.

When enabled with `enable_10bit`, the plugin uses CUDA hwframes and `scale_cuda` for 10-bit NVENC conversion:

```text
-hwaccel cuda -hwaccel_output_format cuda ... -vf scale_cuda=format=p010le
```

The default remains disabled, preserving the current compatibility path:

```text
-hwaccel cuda ... -pix_fmt p010le
```

## Why

Some inputs can fail with the `scale_cuda` path, so the compatibility path remains the default. This exposes the full GPU 10-bit conversion path explicitly for environments where that mode is desired and known to work.

## Notes

- Default behavior is unchanged.
- Full GPU mode is opt-in.
- Transcode-only args are kept out of remux commands so `-c copy` paths are not broken.
- Plugin version bumped to `3.2`.