### PR TITLE
chore: require source deletion for move to directory

### DIFF
--- a/FlowPlugins/CommunityFlowPlugins/file/copyMoveFolderContent/1.0.0/index.js
+++ b/FlowPlugins/CommunityFlowPlugins/file/copyMoveFolderContent/1.0.0/index.js
@@ -167,6 +167,7 @@ var doOperation = function (_a) { return __awaiter(void 0, [_a], void 0, functio
                         sourcePath: sourcePath,
                         destinationPath: destinationPath,
                         args: args,
+                        requireSourceDeletion: operation === 'move',
                     })];
             case 2:
                 _c.sent();

--- a/FlowPlugins/CommunityFlowPlugins/file/moveToDirectory/2.0.0/index.js
+++ b/FlowPlugins/CommunityFlowPlugins/file/moveToDirectory/2.0.0/index.js
@@ -141,6 +141,7 @@ var plugin = function (args) { return __awaiter(void 0, void 0, void 0, function
                         sourcePath: args.inputFileObj._id,
                         destinationPath: ouputFilePath,
                         args: args,
+                        requireSourceDeletion: true,
                     })];
             case 1:
                 _a.sent();

--- a/FlowPlugins/CommunityFlowPlugins/file/moveToOriginalDirectory/1.0.0/index.js
+++ b/FlowPlugins/CommunityFlowPlugins/file/moveToOriginalDirectory/1.0.0/index.js
@@ -92,6 +92,7 @@ var plugin = function (args) { return __awaiter(void 0, void 0, void 0, function
                         sourcePath: args.inputFileObj._id,
                         destinationPath: ouputFilePath,
                         args: args,
+                        requireSourceDeletion: true,
                     })];
             case 1:
                 _a.sent();

--- a/FlowPlugins/CommunityFlowPlugins/file/renameFile/1.0.0/index.js
+++ b/FlowPlugins/CommunityFlowPlugins/file/renameFile/1.0.0/index.js
@@ -107,6 +107,7 @@ var plugin = function (args) { return __awaiter(void 0, void 0, void 0, function
                         sourcePath: args.inputFileObj._id,
                         destinationPath: newPath,
                         args: args,
+                        requireSourceDeletion: true,
                     })];
             case 1:
                 _a.sent();

--- a/FlowPlugins/CommunityFlowPlugins/tools/applyRadarrOrSonarrNamingPolicy/1.0.0/index.js
+++ b/FlowPlugins/CommunityFlowPlugins/tools/applyRadarrOrSonarrNamingPolicy/1.0.0/index.js
@@ -270,6 +270,7 @@ var plugin = function (args) { return __awaiter(void 0, void 0, void 0, function
                         sourcePath: currentFileName,
                         destinationPath: newPath,
                         args: args,
+                        requireSourceDeletion: true,
                     })];
             case 5:
                 isSuccessful = _e.sent();

--- a/FlowPlugins/FlowHelpers/1.0.0/fileMoveOrCopy.js
+++ b/FlowPlugins/FlowHelpers/1.0.0/fileMoveOrCopy.js
@@ -219,8 +219,8 @@ var tryNormalCopy = function (_a) { return __awaiter(void 0, [_a], void 0, funct
     });
 }); };
 var cleanSourceFile = function (_a) { return __awaiter(void 0, [_a], void 0, function (_b) {
-    var err_4;
-    var args = _b.args, sourcePath = _b.sourcePath;
+    var err_4, message;
+    var args = _b.args, sourcePath = _b.sourcePath, requireSourceDeletion = _b.requireSourceDeletion;
     return __generator(this, function (_c) {
         switch (_c.label) {
             case 0:
@@ -232,7 +232,11 @@ var cleanSourceFile = function (_a) { return __awaiter(void 0, [_a], void 0, fun
                 return [3 /*break*/, 3];
             case 2:
                 err_4 = _c.sent();
-                args.jobLog("Failed to delete source file ".concat(sourcePath, ": ").concat(JSON.stringify(err_4)));
+                message = "Failed to delete source file ".concat(sourcePath, ": ").concat(JSON.stringify(err_4));
+                args.jobLog(message);
+                if (requireSourceDeletion) {
+                    throw new Error(message);
+                }
                 return [3 /*break*/, 3];
             case 3: return [2 /*return*/];
         }
@@ -240,14 +244,14 @@ var cleanSourceFile = function (_a) { return __awaiter(void 0, [_a], void 0, fun
 }); };
 var fileMoveOrCopy = function (_a) { return __awaiter(void 0, [_a], void 0, function (_b) {
     var sourceFileSize, moved, ncpd, copied;
-    var operation = _b.operation, sourcePath = _b.sourcePath, destinationPath = _b.destinationPath, args = _b.args;
-    return __generator(this, function (_c) {
-        switch (_c.label) {
+    var operation = _b.operation, sourcePath = _b.sourcePath, destinationPath = _b.destinationPath, args = _b.args, _c = _b.requireSourceDeletion, requireSourceDeletion = _c === void 0 ? false : _c;
+    return __generator(this, function (_d) {
+        switch (_d.label) {
             case 0:
                 args.jobLog('Calculating cache file size in bytes');
                 return [4 /*yield*/, getSizeBytes(sourcePath)];
             case 1:
-                sourceFileSize = _c.sent();
+                sourceFileSize = _d.sent();
                 args.jobLog("".concat(sourceFileSize));
                 if (sourceFileSize === 0) {
                     throw new Error("Source file ".concat(sourcePath, " has size 0 or does not exist, aborting ").concat(operation));
@@ -260,7 +264,7 @@ var fileMoveOrCopy = function (_a) { return __awaiter(void 0, [_a], void 0, func
                         sourceFileSize: sourceFileSize,
                     })];
             case 2:
-                moved = _c.sent();
+                moved = _d.sent();
                 if (moved) {
                     return [2 /*return*/, true];
                 }
@@ -275,7 +279,7 @@ var fileMoveOrCopy = function (_a) { return __awaiter(void 0, [_a], void 0, func
                 //   return true;
                 // }
                 args.jobLog('Failed to move file, trying copy');
-                _c.label = 3;
+                _d.label = 3;
             case 3: return [4 /*yield*/, tyNcp({
                     sourcePath: sourcePath,
                     destinationPath: destinationPath,
@@ -283,16 +287,17 @@ var fileMoveOrCopy = function (_a) { return __awaiter(void 0, [_a], void 0, func
                     sourceFileSize: sourceFileSize,
                 })];
             case 4:
-                ncpd = _c.sent();
+                ncpd = _d.sent();
                 if (!ncpd) return [3 /*break*/, 7];
                 if (!(operation === 'move')) return [3 /*break*/, 6];
                 return [4 /*yield*/, cleanSourceFile({
                         args: args,
                         sourcePath: sourcePath,
+                        requireSourceDeletion: requireSourceDeletion,
                     })];
             case 5:
-                _c.sent();
-                _c.label = 6;
+                _d.sent();
+                _d.label = 6;
             case 6: return [2 /*return*/, true];
             case 7: return [4 /*yield*/, tryNormalCopy({
                     sourcePath: sourcePath,
@@ -301,16 +306,17 @@ var fileMoveOrCopy = function (_a) { return __awaiter(void 0, [_a], void 0, func
                     sourceFileSize: sourceFileSize,
                 })];
             case 8:
-                copied = _c.sent();
+                copied = _d.sent();
                 if (!copied) return [3 /*break*/, 11];
                 if (!(operation === 'move')) return [3 /*break*/, 10];
                 return [4 /*yield*/, cleanSourceFile({
                         args: args,
                         sourcePath: sourcePath,
+                        requireSourceDeletion: requireSourceDeletion,
                     })];
             case 9:
-                _c.sent();
-                _c.label = 10;
+                _d.sent();
+                _d.label = 10;
             case 10: return [2 /*return*/, true];
             case 11: throw new Error("Failed to ".concat(operation, " file"));
         }

--- a/FlowPluginsTs/CommunityFlowPlugins/file/copyMoveFolderContent/1.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/file/copyMoveFolderContent/1.0.0/index.ts
@@ -143,6 +143,7 @@ const doOperation = async ({
       sourcePath,
       destinationPath,
       args,
+      requireSourceDeletion: operation === 'move',
     });
   }
 };

--- a/FlowPluginsTs/CommunityFlowPlugins/file/moveToDirectory/2.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/file/moveToDirectory/2.0.0/index.ts
@@ -138,6 +138,7 @@ const plugin = async (args:IpluginInputArgs):Promise<IpluginOutputArgs> => {
     sourcePath: args.inputFileObj._id,
     destinationPath: ouputFilePath,
     args,
+    requireSourceDeletion: true,
   });
 
   return {

--- a/FlowPluginsTs/CommunityFlowPlugins/file/moveToOriginalDirectory/1.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/file/moveToOriginalDirectory/1.0.0/index.ts
@@ -60,6 +60,7 @@ const plugin = async (args:IpluginInputArgs):Promise<IpluginOutputArgs> => {
     sourcePath: args.inputFileObj._id,
     destinationPath: ouputFilePath,
     args,
+    requireSourceDeletion: true,
   });
 
   return {

--- a/FlowPluginsTs/CommunityFlowPlugins/file/renameFile/1.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/file/renameFile/1.0.0/index.ts
@@ -75,6 +75,7 @@ const plugin = async (args: IpluginInputArgs): Promise<IpluginOutputArgs> => {
     sourcePath: args.inputFileObj._id,
     destinationPath: newPath,
     args,
+    requireSourceDeletion: true,
   });
 
   return {

--- a/FlowPluginsTs/CommunityFlowPlugins/tools/applyRadarrOrSonarrNamingPolicy/1.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/tools/applyRadarrOrSonarrNamingPolicy/1.0.0/index.ts
@@ -274,6 +274,7 @@ const plugin = async (args: IpluginInputArgs): Promise<IpluginOutputArgs> => {
         sourcePath: currentFileName,
         destinationPath: newPath,
         args,
+        requireSourceDeletion: true,
       });
     } else {
       isSuccessful = true;

--- a/FlowPluginsTs/FlowHelpers/1.0.0/fileMoveOrCopy.ts
+++ b/FlowPluginsTs/FlowHelpers/1.0.0/fileMoveOrCopy.ts
@@ -10,6 +10,14 @@ interface Imove {
     args:IpluginInputArgs,
   }
 
+interface IFileMoveOrCopy {
+    operation: 'move' | 'copy',
+    sourcePath: string,
+    destinationPath: string,
+    args: IpluginInputArgs,
+    requireSourceDeletion?: boolean,
+  }
+
 const getSizeBytes = async (fPath: string): Promise<number> => {
   let size = 0;
   try {
@@ -180,15 +188,21 @@ const tryNormalCopy = async ({
 const cleanSourceFile = async ({
   args,
   sourcePath,
+  requireSourceDeletion,
 }:{
     args:IpluginInputArgs,
     sourcePath: string,
-}) => {
+    requireSourceDeletion: boolean,
+}): Promise<void> => {
   try {
     args.jobLog(`Deleting source file ${sourcePath}`);
     await fsp.unlink(sourcePath);
   } catch (err) {
-    args.jobLog(`Failed to delete source file ${sourcePath}: ${JSON.stringify(err)}`);
+    const message = `Failed to delete source file ${sourcePath}: ${JSON.stringify(err)}`;
+    args.jobLog(message);
+    if (requireSourceDeletion) {
+      throw new Error(message);
+    }
   }
 };
 
@@ -197,12 +211,8 @@ const fileMoveOrCopy = async ({
   sourcePath,
   destinationPath,
   args,
-}: {
-    operation: 'move' | 'copy',
-    sourcePath: string,
-    destinationPath: string,
-    args: IpluginInputArgs,
-}):Promise<boolean> => {
+  requireSourceDeletion = false,
+}: IFileMoveOrCopy):Promise<boolean> => {
   args.jobLog('Calculating cache file size in bytes');
 
   const sourceFileSize = await getSizeBytes(sourcePath);
@@ -251,6 +261,7 @@ const fileMoveOrCopy = async ({
       await cleanSourceFile({
         args,
         sourcePath,
+        requireSourceDeletion,
       });
     }
 
@@ -269,6 +280,7 @@ const fileMoveOrCopy = async ({
       await cleanSourceFile({
         args,
         sourcePath,
+        requireSourceDeletion,
       });
     }
 

--- a/tests/FlowPlugins/CommunityFlowPlugins/file/copyMoveFolderContent/1.0.0/index.test.ts
+++ b/tests/FlowPlugins/CommunityFlowPlugins/file/copyMoveFolderContent/1.0.0/index.test.ts
@@ -97,12 +97,14 @@ describe('copyMoveFolderContent Plugin', () => {
         sourcePath: 'C:/Transcode/Source Folder/movie.srt',
         destinationPath: '/output/folder/code/Source Folder/movie.srt',
         args: baseArgs,
+        requireSourceDeletion: false,
       });
       expect(mockFileMoveOrCopy).toHaveBeenCalledWith({
         operation: 'copy',
         sourcePath: 'C:/Transcode/Source Folder/movie.ass',
         destinationPath: '/output/folder/code/Source Folder/movie.ass',
         args: baseArgs,
+        requireSourceDeletion: false,
       });
     });
 
@@ -143,6 +145,7 @@ describe('copyMoveFolderContent Plugin', () => {
       expect(mockFileMoveOrCopy).toHaveBeenCalledWith(
         expect.objectContaining({
           operation: 'move',
+          requireSourceDeletion: true,
         }),
       );
     });
@@ -266,6 +269,20 @@ describe('copyMoveFolderContent Plugin', () => {
 
       await expect(plugin(baseArgs)).rejects.toThrow('File operation failed');
     });
+
+    it('should fail move mode when source deletion fails after a fallback copy', async () => {
+      baseArgs.inputs.copyOrMove = 'move';
+      const error = new Error('Failed to delete source file C:/Transcode/Source Folder/movie.srt');
+      (fsp.readdir as jest.Mock).mockResolvedValue(['movie.srt']);
+      mockFileMoveOrCopy.mockRejectedValue(error);
+
+      await expect(plugin(baseArgs)).rejects.toThrow('Failed to delete source file');
+
+      expect(mockFileMoveOrCopy).toHaveBeenCalledWith(expect.objectContaining({
+        operation: 'move',
+        requireSourceDeletion: true,
+      }));
+    });
   });
 
   describe('Integration Tests', () => {
@@ -296,6 +313,7 @@ describe('copyMoveFolderContent Plugin', () => {
         sourcePath: 'C:/Transcode/Source Folder/subtitle.srt',
         destinationPath: '/output/folder/subtitle.srt',
         args: baseArgs,
+        requireSourceDeletion: true,
       });
     });
   });

--- a/tests/FlowPlugins/CommunityFlowPlugins/file/moveToDirectory/2.0.0/index.test.ts
+++ b/tests/FlowPlugins/CommunityFlowPlugins/file/moveToDirectory/2.0.0/index.test.ts
@@ -66,6 +66,7 @@ describe('moveToDirectory Plugin', () => {
         sourcePath: baseArgs.inputFileObj._id,
         destinationPath: '/output/directory/SampleVideo_1280x720_1mb.mp4',
         args: baseArgs,
+        requireSourceDeletion: true,
       });
       expect(result.outputNumber).toBe(1);
       expect(result.outputFileObj._id).toBe('/output/directory/SampleVideo_1280x720_1mb.mp4');
@@ -88,6 +89,7 @@ describe('moveToDirectory Plugin', () => {
         sourcePath: baseArgs.inputFileObj._id,
         destinationPath: '/output/directory/subfolder/SampleVideo_1280x720_1mb.mp4',
         args: baseArgs,
+        requireSourceDeletion: true,
       });
       expect(result.outputNumber).toBe(1);
       expect(result.outputFileObj._id).toBe('/output/directory/subfolder/SampleVideo_1280x720_1mb.mp4');

--- a/tests/FlowPlugins/CommunityFlowPlugins/file/moveToOriginalDirectory/1.0.0/index.test.ts
+++ b/tests/FlowPlugins/CommunityFlowPlugins/file/moveToOriginalDirectory/1.0.0/index.test.ts
@@ -17,6 +17,7 @@ describe('moveToOriginalDirectory Plugin', () => {
     sourcePath: string;
     destinationPath: string;
     args: IpluginInputArgs;
+    requireSourceDeletion?: boolean;
   }) => Promise<boolean>>;
 
   beforeEach(() => {
@@ -63,6 +64,7 @@ describe('moveToOriginalDirectory Plugin', () => {
         sourcePath: '/temp/workdir/SampleVideo_1280x720_1mb.mp4',
         destinationPath: '/original/directory/SampleVideo_1280x720_1mb.mp4',
         args: baseArgs,
+        requireSourceDeletion: true,
       });
 
       expect(result.outputNumber).toBe(1);
@@ -81,6 +83,7 @@ describe('moveToOriginalDirectory Plugin', () => {
         sourcePath: '/temp/workdir/processed_file.mp4',
         destinationPath: '/original/library/processed_file.mp4',
         args: baseArgs,
+        requireSourceDeletion: true,
       });
 
       expect(result.outputFileObj._id).toBe('/original/library/processed_file.mp4');
@@ -114,6 +117,7 @@ describe('moveToOriginalDirectory Plugin', () => {
         sourcePath: '/temp/work/processed.mp4',
         destinationPath: '/media/movies/action/processed.mp4',
         args: baseArgs,
+        requireSourceDeletion: true,
       });
     });
 
@@ -129,6 +133,7 @@ describe('moveToOriginalDirectory Plugin', () => {
         sourcePath: 'C:\\temp\\work\\processed.mp4',
         destinationPath: '/C:\\temp\\work\\processed.mp4',
         args: baseArgs,
+        requireSourceDeletion: true,
       });
     });
   });
@@ -155,6 +160,7 @@ describe('moveToOriginalDirectory Plugin', () => {
         sourcePath: inputPath,
         destinationPath: expectedPath,
         args: baseArgs,
+        requireSourceDeletion: true,
       });
     });
   });
@@ -167,13 +173,17 @@ describe('moveToOriginalDirectory Plugin', () => {
       expect(mockFileMoveOrCopy).toHaveBeenCalled();
     });
 
-    it('should still return output file path even if move fails', async () => {
-      // Mock fileMoveOrCopy to not throw but return false
-      mockFileMoveOrCopy.mockResolvedValue(false);
+    it('should fail when source deletion fails after a fallback copy', async () => {
+      mockFileMoveOrCopy.mockRejectedValue(
+        new Error('Failed to delete source file /temp/workdir/SampleVideo_1280x720_1mb.mp4'),
+      );
 
-      await plugin(baseArgs);
+      await expect(plugin(baseArgs)).rejects.toThrow('Failed to delete source file');
 
-      expect(mockFileMoveOrCopy).toHaveBeenCalled();
+      expect(mockFileMoveOrCopy).toHaveBeenCalledWith(expect.objectContaining({
+        operation: 'move',
+        requireSourceDeletion: true,
+      }));
     });
   });
 
@@ -189,6 +199,7 @@ describe('moveToOriginalDirectory Plugin', () => {
         sourcePath: '/temp/movie with spaces & symbols!.mp4',
         destinationPath: '/library/movie with spaces & symbols!.mp4',
         args: baseArgs,
+        requireSourceDeletion: true,
       });
     });
 
@@ -204,6 +215,7 @@ describe('moveToOriginalDirectory Plugin', () => {
         sourcePath: '/temp/filename',
         destinationPath: '/library/./temp/filename',
         args: baseArgs,
+        requireSourceDeletion: true,
       });
     });
   });

--- a/tests/FlowPlugins/CommunityFlowPlugins/file/renameFile/1.0.0/index.test.ts
+++ b/tests/FlowPlugins/CommunityFlowPlugins/file/renameFile/1.0.0/index.test.ts
@@ -53,6 +53,7 @@ describe('renameFile Plugin', () => {
         sourcePath: 'C:/Transcode/Source Folder/SampleVideo_1280x720_1mb.mp4',
         destinationPath: 'C:/Transcode/Source Folder/SampleVideo_1280x720_1mb_720p.mp4',
         args: baseArgs,
+        requireSourceDeletion: true,
       });
 
       expect(result.outputNumber).toBe(1);
@@ -72,6 +73,7 @@ describe('renameFile Plugin', () => {
         sourcePath: 'C:/Transcode/Source Folder/sample__-__-__libmp3lame__30s__audio.mkv',
         destinationPath: 'C:/Transcode/Source Folder/sample__-__-__libmp3lame__30s__audio_processed.mkv',
         args: baseArgs,
+        requireSourceDeletion: true,
       });
 
       expect(result.outputNumber).toBe(1);
@@ -94,6 +96,7 @@ describe('renameFile Plugin', () => {
         sourcePath: 'C:/Transcode/Source Folder/SampleVideo_1280x720_1mb.mp4',
         destinationPath: 'C:/Transcode/Source Folder/SampleVideo_1280x720_1mb_transcoded.mp4',
         args: baseArgs,
+        requireSourceDeletion: true,
       });
 
       expect(result.outputNumber).toBe(1);
@@ -111,6 +114,7 @@ describe('renameFile Plugin', () => {
         sourcePath: 'C:/Transcode/Source Folder/SampleVideo_1280x720_1mb.mp4',
         destinationPath: 'C:/Transcode/Source Folder/converted_file.mp4',
         args: baseArgs,
+        requireSourceDeletion: true,
       });
 
       expect(result.outputNumber).toBe(1);
@@ -128,6 +132,7 @@ describe('renameFile Plugin', () => {
         sourcePath: 'C:/Transcode/Source Folder/SampleVideo_1280x720_1mb.mp4',
         destinationPath: 'C:/Transcode/Source Folder/SampleVideo_1280x720_1mb_backup_SampleVideo_1280x720_1mb.mp4',
         args: baseArgs,
+        requireSourceDeletion: true,
       });
 
       expect(result.outputNumber).toBe(1);
@@ -143,6 +148,7 @@ describe('renameFile Plugin', () => {
         sourcePath: 'C:/Transcode/Source Folder/SampleVideo_1280x720_1mb.mp4',
         destinationPath: 'C:/Transcode/Source Folder/static_filename.mp4',
         args: baseArgs,
+        requireSourceDeletion: true,
       });
 
       expect(result.outputNumber).toBe(1);
@@ -178,6 +184,7 @@ describe('renameFile Plugin', () => {
         sourcePath: '/media/videos/subfolder/Movie (2023) [1080p].mp4',
         destinationPath: '/media/videos/subfolder/Movie (2023) [1080p]_renamed.mp4',
         args: baseArgs,
+        requireSourceDeletion: true,
       });
 
       expect(result.outputNumber).toBe(1);
@@ -199,6 +206,7 @@ describe('renameFile Plugin', () => {
         sourcePath: '/media/videos/filename_no_ext',
         destinationPath: '/media/videos/_new./media/videos/filename_no_ext',
         args: baseArgs,
+        requireSourceDeletion: true,
       });
 
       expect(result.outputNumber).toBe(1);
@@ -218,6 +226,7 @@ describe('renameFile Plugin', () => {
         sourcePath: '/media/videos/movie.part1.2023.mp4',
         destinationPath: '/media/videos/movie.part1.2023_complete.mp4',
         args: baseArgs,
+        requireSourceDeletion: true,
       });
 
       expect(result.outputNumber).toBe(1);
@@ -234,6 +243,7 @@ describe('renameFile Plugin', () => {
         sourcePath: 'C:/Transcode/Source Folder/SampleVideo_1280x720_1mb.mp4',
         destinationPath: 'C:/Transcode/Source Folder/SampleVideo_1280x720_1mb_trimmed.mp4',
         args: baseArgs,
+        requireSourceDeletion: true,
       });
 
       expect(result.outputNumber).toBe(1);
@@ -250,6 +260,7 @@ describe('renameFile Plugin', () => {
         sourcePath: 'C:/Transcode/Source Folder/SampleVideo_1280x720_1mb.mp4',
         destinationPath: 'C:/Transcode/Source Folder/SampleVideo_1280x720_1mb_720p.mp4',
         args: baseArgs,
+        requireSourceDeletion: true,
       });
 
       expect(result.outputNumber).toBe(1);
@@ -286,6 +297,7 @@ describe('renameFile Plugin', () => {
         sourcePath: 'D:\\Videos\\Movie.mp4',
         destinationPath: '/D:\\Videos\\Movie_win.mp4',
         args: baseArgs,
+        requireSourceDeletion: true,
       });
 
       expect(result.outputNumber).toBe(1);
@@ -305,9 +317,25 @@ describe('renameFile Plugin', () => {
         sourcePath: '/home/user/videos/movie.mp4',
         destinationPath: '/home/user/videos/movie_unix.mp4',
         args: baseArgs,
+        requireSourceDeletion: true,
       });
 
       expect(result.outputNumber).toBe(1);
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('should fail when source deletion fails after a fallback copy', async () => {
+      mockFileMoveOrCopy.mockRejectedValue(
+        new Error('Failed to delete source file C:/Transcode/Source Folder/SampleVideo_1280x720_1mb.mp4'),
+      );
+
+      await expect(plugin(baseArgs)).rejects.toThrow('Failed to delete source file');
+
+      expect(mockFileMoveOrCopy).toHaveBeenCalledWith(expect.objectContaining({
+        operation: 'move',
+        requireSourceDeletion: true,
+      }));
     });
   });
 });

--- a/tests/FlowPlugins/CommunityFlowPlugins/tools/applyRadarrOrSonarrNamingPolicy/1.0.0/index.test.ts
+++ b/tests/FlowPlugins/CommunityFlowPlugins/tools/applyRadarrOrSonarrNamingPolicy/1.0.0/index.test.ts
@@ -76,7 +76,33 @@ describe('applyRadarrOrSonarrNamingPolicy Plugin', () => {
       expect(result.outputNumber).toBe(1);
       expect(mockAxios).toHaveBeenCalledTimes(2);
       expect(baseArgs.jobLog).toHaveBeenCalledWith('Movie \'123\' found for imdb \'tt1234567\'');
-      expect(mockFileMoveOrCopy).toHaveBeenCalled();
+      expect(mockFileMoveOrCopy).toHaveBeenCalledWith(expect.objectContaining({
+        operation: 'move',
+        sourcePath: 'C:/Transcode/Source Folder/SampleVideo_1280x720_1mb.mp4',
+        destinationPath: 'C:/Transcode/Source Folder/Movie Title (2021) - 1080p BluRay.mkv',
+        requireSourceDeletion: true,
+      }));
+    });
+
+    it('should fail when source deletion fails after a fallback copy', async () => {
+      const mockAxios = baseArgs.deps.axios as jest.MockedFunction<() => Promise<unknown>>;
+      mockAxios
+        .mockResolvedValueOnce({
+          data: [{ id: 123 }],
+        })
+        .mockResolvedValueOnce({
+          data: [{ newPath: '/movies/Movie Title (2021)/Movie Title (2021) - 1080p BluRay.mkv' }],
+        });
+      mockFileMoveOrCopy.mockRejectedValue(
+        new Error('Failed to delete source file C:/Transcode/Source Folder/SampleVideo_1280x720_1mb.mp4'),
+      );
+
+      await expect(plugin(baseArgs)).rejects.toThrow('Failed to delete source file');
+
+      expect(mockFileMoveOrCopy).toHaveBeenCalledWith(expect.objectContaining({
+        operation: 'move',
+        requireSourceDeletion: true,
+      }));
     });
 
     it('should handle movie not found in Radarr', async () => {

--- a/tests/FlowPlugins/FlowHelpers/1.0.0/fileMoveOrCopy.test.ts
+++ b/tests/FlowPlugins/FlowHelpers/1.0.0/fileMoveOrCopy.test.ts
@@ -1,0 +1,83 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import fileMoveOrCopy from '../../../../FlowPluginsTs/FlowHelpers/1.0.0/fileMoveOrCopy';
+import { IpluginInputArgs } from '../../../../FlowPluginsTs/FlowHelpers/1.0.0/interfaces/interfaces';
+
+describe('fileMoveOrCopy', () => {
+  let tmpDir = '';
+  let sourcePath = '';
+  let destinationPath = '';
+  let args: IpluginInputArgs;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fileMoveOrCopy-test-'));
+    sourcePath = path.join(tmpDir, 'source.mkv');
+    destinationPath = path.join(tmpDir, 'destination.mkv');
+    fs.writeFileSync(sourcePath, Buffer.from('sample video data'));
+
+    args = {
+      deps: {},
+      jobLog: jest.fn(),
+    } as unknown as IpluginInputArgs;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('should keep legacy best-effort cleanup behavior by default', async () => {
+    jest.spyOn(fs.promises, 'rename').mockRejectedValue({
+      code: 'EACCES',
+      syscall: 'rename',
+      path: sourcePath,
+      dest: destinationPath,
+    });
+    jest.spyOn(fs.promises, 'unlink').mockRejectedValue({
+      code: 'EACCES',
+      syscall: 'unlink',
+      path: sourcePath,
+    });
+
+    await expect(fileMoveOrCopy({
+      operation: 'move',
+      sourcePath,
+      destinationPath,
+      args,
+    })).resolves.toBe(true);
+
+    expect(args.jobLog).toHaveBeenCalledWith(
+      expect.stringContaining(`Failed to delete source file ${sourcePath}`),
+    );
+    expect(fs.existsSync(destinationPath)).toBe(true);
+  });
+
+  it('should reject a strict fallback move when the copied source cannot be deleted', async () => {
+    jest.spyOn(fs.promises, 'rename').mockRejectedValue({
+      code: 'EACCES',
+      syscall: 'rename',
+      path: sourcePath,
+      dest: destinationPath,
+    });
+    jest.spyOn(fs.promises, 'unlink').mockRejectedValue({
+      code: 'EACCES',
+      syscall: 'unlink',
+      path: sourcePath,
+    });
+
+    await expect(fileMoveOrCopy({
+      operation: 'move',
+      sourcePath,
+      destinationPath,
+      args,
+      requireSourceDeletion: true,
+    })).rejects.toThrow(`Failed to delete source file ${sourcePath}`);
+
+    expect(args.jobLog).toHaveBeenCalledWith(
+      expect.stringContaining(`Failed to delete source file ${sourcePath}`),
+    );
+    expect(fs.existsSync(destinationPath)).toBe(true);
+  });
+});


### PR DESCRIPTION
During a move, if a direct moved fails, then a copy/delete is used. Previously, the delete would intentionally not throw an error on failure as it was treated as a non-critical error as the source would typically be in the cache which is auto cleaned by the server/node periodically.

This PR adjusts this.