### PR TITLE
feat: add VC-1 to video codec check

### DIFF
--- a/FlowPlugins/CommunityFlowPlugins/video/checkVideoCodec/1.0.0/index.js
+++ b/FlowPlugins/CommunityFlowPlugins/video/checkVideoCodec/1.0.0/index.js
@@ -27,6 +27,7 @@ var details = function () { return ({
                     'av1',
                     'vp9',
                     'h264',
+                    'vc1',
                     'vp8',
                     'wmv2',
                     'wmv3',

--- a/FlowPluginsTs/CommunityFlowPlugins/video/checkVideoCodec/1.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/video/checkVideoCodec/1.0.0/index.ts
@@ -30,6 +30,7 @@ const details = ():IpluginDetails => ({
           'av1',
           'vp9',
           'h264',
+          'vc1',
           'vp8',
           'wmv2',
           'wmv3',

--- a/tests/FlowPlugins/CommunityFlowPlugins/video/checkVideoCodec/1.0.0/index.test.ts
+++ b/tests/FlowPlugins/CommunityFlowPlugins/video/checkVideoCodec/1.0.0/index.test.ts
@@ -1,4 +1,4 @@
-import { plugin } from
+import { details, plugin } from
   '../../../../../../FlowPluginsTs/CommunityFlowPlugins/video/checkVideoCodec/1.0.0/index';
 import { IpluginInputArgs } from '../../../../../../FlowPluginsTs/FlowHelpers/1.0.0/interfaces/interfaces';
 import { IFileObject } from '../../../../../../FlowPluginsTs/FlowHelpers/1.0.0/interfaces/synced/IFileObject';
@@ -18,6 +18,16 @@ describe('checkVideoCodec Plugin', () => {
       inputFileObj: JSON.parse(JSON.stringify(sampleH264)),
       jobLog: jest.fn(),
     } as Partial<IpluginInputArgs> as IpluginInputArgs;
+  });
+
+  describe('Plugin Details', () => {
+    it('should include VC-1 in the codec dropdown', () => {
+      const [{ inputUI: { options } }] = details().inputs;
+
+      expect(options).toEqual(expect.arrayContaining([
+        'vc1',
+      ]));
+    });
   });
 
   describe('Basic Codec Detection', () => {
@@ -52,6 +62,21 @@ describe('checkVideoCodec Plugin', () => {
 
       expect(result.outputNumber).toBe(2);
     });
+
+    it('should detect matching codec (VC-1)', () => {
+      baseArgs.inputFileObj.ffProbeData.streams = [
+        {
+          index: 0,
+          codec_name: 'vc1',
+          codec_type: 'video',
+        },
+      ];
+      baseArgs.inputs.codec = 'vc1';
+
+      const result = plugin(baseArgs);
+
+      expect(result.outputNumber).toBe(1);
+    });
   });
 
   describe('Multiple Video Codec Types', () => {
@@ -60,6 +85,7 @@ describe('checkVideoCodec Plugin', () => {
       'av1',
       'vp9',
       'h264',
+      'vc1',
       'vp8',
       'wmv2',
       'wmv3',


### PR DESCRIPTION
Summary
- Add `vc1` to the Check Video Codec dropdown in TS source and generated JS.
- Add Jest coverage for the dropdown option and VC-1 detection.
