### PR TITLE
Add Fix Rotation ffmpegCommand Flow plugin

### DIFF
--- a/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandFixRotation/1.0.0/index.js
+++ b/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandFixRotation/1.0.0/index.js
@@ -88,18 +88,33 @@ var plugin = function (args) {
             }
             return;
         }
-        if (stream.outputArgs.some(function (arg) { return arg === '-vf' || arg.startsWith('-filter:v'); })) {
-            args.jobLog("Warning: video stream index ".concat(stream.index, " already has a video filter set by an earlier ")
-                + 'plugin. ffmpeg only keeps the last filter option per stream, so one of them will be silently '
-                + 'dropped - place Fix Rotation before other video filter plugins, or merge the filters manually.');
-        }
         args.jobLog("Found ".concat(rotation, "\u00B0 rotation metadata on video stream index ").concat(stream.index, ", ")
             + "applying '".concat(transposeFilter, "' and clearing rotation metadata"));
-        // Use a stream-specific specifier (not the unqualified -vf/-filter:v alias) since an
-        // unqualified filter option applies to every video output stream, not just this one -
-        // it would collide fatally with any other, untouched video stream that Execute copies.
-        stream.outputArgs.push('-filter:v:{outputTypeIndex}', transposeFilter);
-        stream.outputArgs.push('-metadata:s:v:{outputTypeIndex}', 'rotate=');
+        // A stream can only carry one filtergraph: ffmpeg keeps just the last -vf/-filter
+        // option per stream and silently drops the rest. If an earlier plugin (scale, HDR
+        // tonemap, ...) already set a filter, chain the transpose onto the end of it instead
+        // of pushing a competing option. Either way the option name is the stream-specific
+        // form, not the unqualified -vf/-filter:v alias: an unqualified filter option applies
+        // to every video output stream and collides fatally with any other, untouched video
+        // stream that Execute copies.
+        var outputArgs = stream.outputArgs;
+        var existingFilterIndex = -1;
+        for (var i = outputArgs.length - 2; i >= 0; i -= 1) {
+            if (outputArgs[i] === '-vf' || outputArgs[i].startsWith('-filter:v')) {
+                existingFilterIndex = i;
+                break;
+            }
+        }
+        if (existingFilterIndex !== -1) {
+            args.jobLog("Video stream index ".concat(stream.index, " already has filter '").concat(outputArgs[existingFilterIndex + 1], "' ")
+                + "set by an earlier plugin, appending '".concat(transposeFilter, "' to it"));
+            outputArgs[existingFilterIndex] = '-filter:v:{outputTypeIndex}';
+            outputArgs[existingFilterIndex + 1] += ",".concat(transposeFilter);
+        }
+        else {
+            outputArgs.push('-filter:v:{outputTypeIndex}', transposeFilter);
+        }
+        outputArgs.push('-metadata:s:v:{outputTypeIndex}', 'rotate=');
         // Baking the rotation into the pixels is not enough: ffmpeg copies any pre-existing
         // "Display Matrix" side data straight through to the output stream, so without this
         // the fixed file would still carry the original rotation instruction and get rotated

--- a/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandFixRotation/1.0.0/index.js
+++ b/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandFixRotation/1.0.0/index.js
@@ -7,7 +7,10 @@ var details = function () { return ({
     description: 'Detect rotation metadata (legacy "rotate" tag or "Display Matrix" side data) on the video '
         + 'stream, bake the rotation into the pixels, and strip the metadata. Fixes portrait/vertical videos '
         + 'that play sideways or upside-down on ExoPlayer-based apps (Plex, Kodi, Jellyfin on Android/Android TV), '
-        + 'which do not reliably honor rotation metadata during direct play.',
+        + 'which do not reliably honor rotation metadata during direct play. Requires ffmpeg 6.0+ (uses '
+        + '-display_rotation); on older ffmpeg builds the job will fail with "Unrecognized option". Forces a real '
+        + 'video re-encode, so pair this with a "Set Video Encoder" plugin if you want control over the output '
+        + 'codec/quality - without one, ffmpeg falls back to its default encoder settings.',
     style: {
         borderColor: '#6efefc',
     },
@@ -72,33 +75,44 @@ var plugin = function (args) {
     args.inputs = lib.loadDefaultValues(args.inputs, details);
     (0, flowUtils_1.checkFfmpegCommandInit)(args);
     var rotationFixed = false;
-    var inputVideoTypeIndex = -1;
     args.variables.ffmpegCommand.streams.forEach(function (stream) {
-        if (stream.codec_type !== 'video') {
-            return;
-        }
-        // Tracks this stream's index among the *input* file's video streams (unaffected by
-        // `removed`), since -display_rotation below is an input-side option and must address
-        // the original demuxed stream layout, not our flow's filtered output layout.
-        inputVideoTypeIndex += 1;
-        if (stream.removed) {
+        if (stream.codec_type !== 'video' || stream.removed) {
             return;
         }
         var rotation = getRotation(stream);
         var transposeFilter = getTransposeFilter(rotation);
         if (!transposeFilter) {
+            if (rotation !== 0) {
+                args.jobLog("Found ".concat(rotation, "\u00B0 rotation metadata on video stream index ").concat(stream.index, ", ")
+                    + 'which is not a multiple of 90° - skipping as this plugin cannot handle non-90-degree rotations');
+            }
             return;
+        }
+        if (stream.outputArgs.some(function (arg) { return arg === '-vf' || arg.startsWith('-filter:v'); })) {
+            args.jobLog("Warning: video stream index ".concat(stream.index, " already has a video filter set by an earlier ")
+                + 'plugin. ffmpeg only keeps the last filter option per stream, so one of them will be silently '
+                + 'dropped - place Fix Rotation before other video filter plugins, or merge the filters manually.');
         }
         args.jobLog("Found ".concat(rotation, "\u00B0 rotation metadata on video stream index ").concat(stream.index, ", ")
             + "applying '".concat(transposeFilter, "' and clearing rotation metadata"));
-        stream.outputArgs.push('-vf', transposeFilter);
-        stream.outputArgs.push('-metadata:s:v:{outputTypeIndex}', 'rotate=0');
+        // Use a stream-specific specifier (not the unqualified -vf/-filter:v alias) since an
+        // unqualified filter option applies to every video output stream, not just this one -
+        // it would collide fatally with any other, untouched video stream that Execute copies.
+        stream.outputArgs.push('-filter:v:{outputTypeIndex}', transposeFilter);
+        stream.outputArgs.push('-metadata:s:v:{outputTypeIndex}', 'rotate=');
         // Baking the rotation into the pixels is not enough: ffmpeg copies any pre-existing
         // "Display Matrix" side data straight through to the output stream, so without this
         // the fixed file would still carry the original rotation instruction and get rotated
         // a second time by any player that actually honors it. -display_rotation overrides
         // the input's side data to 0 so nothing stale survives into the encode.
-        args.variables.ffmpegCommand.overallInputArguments.push("-display_rotation:v:".concat(inputVideoTypeIndex), '0');
+        //
+        // Addressed by the stream's own absolute ffprobe index (a plain numeric specifier, not
+        // a "v:N" type-relative one) since that's the only addressing that stays correct
+        // regardless of earlier flow plugins: Begin Command retypes attached-picture streams to
+        // codec_type 'attachment' (so a naive video-only counter here would skip them, even
+        // though ffmpeg still counts them as video streams for "v:N" input-side addressing),
+        // and Reorder Streams mutates the streams array order in place.
+        args.variables.ffmpegCommand.overallInputArguments.push("-display_rotation:".concat(stream.index), '0');
         rotationFixed = true;
     });
     if (rotationFixed) {

--- a/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandFixRotation/1.0.0/index.js
+++ b/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandFixRotation/1.0.0/index.js
@@ -1,0 +1,119 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.plugin = exports.details = void 0;
+var flowUtils_1 = require("../../../../FlowHelpers/1.0.0/interfaces/flowUtils");
+var details = function () { return ({
+    name: 'Fix Rotation',
+    description: 'Detect rotation metadata (legacy "rotate" tag or "Display Matrix" side data) on the video '
+        + 'stream, bake the rotation into the pixels, and strip the metadata. Fixes portrait/vertical videos '
+        + 'that play sideways or upside-down on ExoPlayer-based apps (Plex, Kodi, Jellyfin on Android/Android TV), '
+        + 'which do not reliably honor rotation metadata during direct play.',
+    style: {
+        borderColor: '#6efefc',
+    },
+    tags: 'video',
+    isStartPlugin: false,
+    pType: '',
+    requiresVersion: '2.11.01',
+    sidebarPosition: -1,
+    icon: 'faRedo',
+    inputs: [],
+    outputs: [
+        {
+            number: 1,
+            tooltip: 'Continue to next plugin',
+        },
+    ],
+}); };
+exports.details = details;
+var normalizeAngle = function (angle) { return ((angle % 360) + 360) % 360; };
+var getRotation = function (stream) {
+    var _a;
+    var tagRotate = (_a = stream === null || stream === void 0 ? void 0 : stream.tags) === null || _a === void 0 ? void 0 : _a.rotate;
+    if (tagRotate !== undefined) {
+        var parsed = parseInt(String(tagRotate), 10);
+        if (!Number.isNaN(parsed)) {
+            return normalizeAngle(parsed);
+        }
+    }
+    var sideDataList = stream === null || stream === void 0 ? void 0 : stream.side_data_list;
+    if (Array.isArray(sideDataList)) {
+        var displayMatrix = sideDataList.find(function (sideData) { return ((sideData === null || sideData === void 0 ? void 0 : sideData.side_data_type) === 'Display Matrix' && (sideData === null || sideData === void 0 ? void 0 : sideData.rotation) !== undefined); });
+        if (displayMatrix) {
+            var parsed = parseInt(String(displayMatrix.rotation), 10);
+            if (!Number.isNaN(parsed)) {
+                // ffmpeg's Display Matrix rotation is a counter-clockwise angle (av_display_rotation_get),
+                // the opposite sign convention of the legacy clockwise "rotate" tag. Negate it so both
+                // paths feed getTransposeFilter() the same "degrees to rotate clockwise" convention.
+                return normalizeAngle(-parsed);
+            }
+        }
+    }
+    return 0;
+};
+// Rotation angles are stored as the angle the player must rotate the raw pixels
+// clockwise to display them correctly. `transpose` rotates 90 degrees at a time.
+var getTransposeFilter = function (rotation) {
+    switch (rotation) {
+        case 90:
+            return 'transpose=1';
+        case 180:
+            return 'hflip,vflip';
+        case 270:
+            return 'transpose=2';
+        default:
+            return undefined;
+    }
+};
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+var plugin = function (args) {
+    var lib = require('../../../../../methods/lib')();
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars,no-param-reassign
+    args.inputs = lib.loadDefaultValues(args.inputs, details);
+    (0, flowUtils_1.checkFfmpegCommandInit)(args);
+    var rotationFixed = false;
+    var inputVideoTypeIndex = -1;
+    args.variables.ffmpegCommand.streams.forEach(function (stream) {
+        if (stream.codec_type !== 'video') {
+            return;
+        }
+        // Tracks this stream's index among the *input* file's video streams (unaffected by
+        // `removed`), since -display_rotation below is an input-side option and must address
+        // the original demuxed stream layout, not our flow's filtered output layout.
+        inputVideoTypeIndex += 1;
+        if (stream.removed) {
+            return;
+        }
+        var rotation = getRotation(stream);
+        var transposeFilter = getTransposeFilter(rotation);
+        if (!transposeFilter) {
+            return;
+        }
+        args.jobLog("Found ".concat(rotation, "\u00B0 rotation metadata on video stream index ").concat(stream.index, ", ")
+            + "applying '".concat(transposeFilter, "' and clearing rotation metadata"));
+        stream.outputArgs.push('-vf', transposeFilter);
+        stream.outputArgs.push('-metadata:s:v:{outputTypeIndex}', 'rotate=0');
+        // Baking the rotation into the pixels is not enough: ffmpeg copies any pre-existing
+        // "Display Matrix" side data straight through to the output stream, so without this
+        // the fixed file would still carry the original rotation instruction and get rotated
+        // a second time by any player that actually honors it. -display_rotation overrides
+        // the input's side data to 0 so nothing stale survives into the encode.
+        args.variables.ffmpegCommand.overallInputArguments.push("-display_rotation:v:".concat(inputVideoTypeIndex), '0');
+        rotationFixed = true;
+    });
+    if (rotationFixed) {
+        // Disable ffmpeg's built-in auto-rotate so it does not also apply the
+        // rotation itself, which would double up on top of our manual transpose.
+        if (!args.variables.ffmpegCommand.overallInputArguments.includes('-noautorotate')) {
+            args.variables.ffmpegCommand.overallInputArguments.push('-noautorotate');
+        }
+        // eslint-disable-next-line no-param-reassign
+        args.variables.ffmpegCommand.shouldProcess = true;
+    }
+    return {
+        outputFileObj: args.inputFileObj,
+        outputNumber: 1,
+        variables: args.variables,
+    };
+};
+exports.plugin = plugin;

--- a/FlowPluginsTs/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandFixRotation/1.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandFixRotation/1.0.0/index.ts
@@ -105,20 +105,34 @@ const plugin = (args: IpluginInputArgs): IpluginOutputArgs => {
       return;
     }
 
-    if (stream.outputArgs.some((arg) => arg === '-vf' || arg.startsWith('-filter:v'))) {
-      args.jobLog(`Warning: video stream index ${stream.index} already has a video filter set by an earlier `
-        + 'plugin. ffmpeg only keeps the last filter option per stream, so one of them will be silently '
-        + 'dropped - place Fix Rotation before other video filter plugins, or merge the filters manually.');
-    }
-
     args.jobLog(`Found ${rotation}° rotation metadata on video stream index ${stream.index}, `
       + `applying '${transposeFilter}' and clearing rotation metadata`);
 
-    // Use a stream-specific specifier (not the unqualified -vf/-filter:v alias) since an
-    // unqualified filter option applies to every video output stream, not just this one -
-    // it would collide fatally with any other, untouched video stream that Execute copies.
-    stream.outputArgs.push('-filter:v:{outputTypeIndex}', transposeFilter);
-    stream.outputArgs.push('-metadata:s:v:{outputTypeIndex}', 'rotate=');
+    // A stream can only carry one filtergraph: ffmpeg keeps just the last -vf/-filter
+    // option per stream and silently drops the rest. If an earlier plugin (scale, HDR
+    // tonemap, ...) already set a filter, chain the transpose onto the end of it instead
+    // of pushing a competing option. Either way the option name is the stream-specific
+    // form, not the unqualified -vf/-filter:v alias: an unqualified filter option applies
+    // to every video output stream and collides fatally with any other, untouched video
+    // stream that Execute copies.
+    const { outputArgs } = stream;
+    let existingFilterIndex = -1;
+    for (let i = outputArgs.length - 2; i >= 0; i -= 1) {
+      if (outputArgs[i] === '-vf' || outputArgs[i].startsWith('-filter:v')) {
+        existingFilterIndex = i;
+        break;
+      }
+    }
+
+    if (existingFilterIndex !== -1) {
+      args.jobLog(`Video stream index ${stream.index} already has filter '${outputArgs[existingFilterIndex + 1]}' `
+        + `set by an earlier plugin, appending '${transposeFilter}' to it`);
+      outputArgs[existingFilterIndex] = '-filter:v:{outputTypeIndex}';
+      outputArgs[existingFilterIndex + 1] += `,${transposeFilter}`;
+    } else {
+      outputArgs.push('-filter:v:{outputTypeIndex}', transposeFilter);
+    }
+    outputArgs.push('-metadata:s:v:{outputTypeIndex}', 'rotate=');
 
     // Baking the rotation into the pixels is not enough: ffmpeg copies any pre-existing
     // "Display Matrix" side data straight through to the output stream, so without this

--- a/FlowPluginsTs/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandFixRotation/1.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandFixRotation/1.0.0/index.ts
@@ -1,0 +1,128 @@
+import { checkFfmpegCommandInit } from '../../../../FlowHelpers/1.0.0/interfaces/flowUtils';
+import {
+  IffmpegCommandStream,
+  IpluginDetails,
+  IpluginInputArgs,
+  IpluginOutputArgs,
+} from '../../../../FlowHelpers/1.0.0/interfaces/interfaces';
+
+const details = (): IpluginDetails => ({
+  name: 'Fix Rotation',
+  description: 'Detect rotation metadata (legacy "rotate" tag or "Display Matrix" side data) on the video '
+    + 'stream, bake the rotation into the pixels, and strip the metadata. Fixes portrait/vertical videos '
+    + 'that play sideways or upside-down on ExoPlayer-based apps (Plex, Kodi, Jellyfin on Android/Android TV), '
+    + 'which do not reliably honor rotation metadata during direct play.',
+  style: {
+    borderColor: '#6efefc',
+  },
+  tags: 'video',
+  isStartPlugin: false,
+  pType: '',
+  requiresVersion: '2.11.01',
+  sidebarPosition: -1,
+  icon: 'faRedo',
+  inputs: [],
+  outputs: [
+    {
+      number: 1,
+      tooltip: 'Continue to next plugin',
+    },
+  ],
+});
+
+const normalizeAngle = (angle: number): number => ((angle % 360) + 360) % 360;
+
+const getRotation = (stream: IffmpegCommandStream): number => {
+  const tagRotate = stream?.tags?.rotate;
+  if (tagRotate !== undefined) {
+    const parsed = parseInt(String(tagRotate), 10);
+    if (!Number.isNaN(parsed)) {
+      return normalizeAngle(parsed);
+    }
+  }
+
+  const sideDataList = stream?.side_data_list;
+  if (Array.isArray(sideDataList)) {
+    const displayMatrix = sideDataList.find((sideData) => (
+      sideData?.side_data_type === 'Display Matrix' && sideData?.rotation !== undefined
+    ));
+
+    if (displayMatrix) {
+      const parsed = parseInt(String(displayMatrix.rotation), 10);
+      if (!Number.isNaN(parsed)) {
+        return normalizeAngle(parsed);
+      }
+    }
+  }
+
+  return 0;
+};
+
+// Rotation angles are stored as the angle the player must rotate the raw pixels
+// clockwise to display them correctly. `transpose` rotates 90 degrees at a time.
+const getTransposeFilter = (rotation: number): string | undefined => {
+  switch (rotation) {
+    case 90:
+      return 'transpose=1';
+    case 180:
+      return 'hflip,vflip';
+    case 270:
+      return 'transpose=2';
+    default:
+      return undefined;
+  }
+};
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const plugin = (args: IpluginInputArgs): IpluginOutputArgs => {
+  const lib = require('../../../../../methods/lib')();
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars,no-param-reassign
+  args.inputs = lib.loadDefaultValues(args.inputs, details);
+
+  checkFfmpegCommandInit(args);
+
+  let rotationFixed = false;
+
+  args.variables.ffmpegCommand.streams.forEach((stream) => {
+    if (stream.codec_type !== 'video' || stream.removed) {
+      return;
+    }
+
+    const rotation = getRotation(stream);
+    const transposeFilter = getTransposeFilter(rotation);
+
+    if (!transposeFilter) {
+      return;
+    }
+
+    args.jobLog(`Found ${rotation}° rotation metadata on video stream index ${stream.index}, `
+      + `applying '${transposeFilter}' and clearing rotation metadata`);
+
+    stream.outputArgs.push('-vf', transposeFilter);
+    stream.outputArgs.push('-metadata:s:v:{outputTypeIndex}', 'rotate=0');
+
+    rotationFixed = true;
+  });
+
+  if (rotationFixed) {
+    // Disable ffmpeg's built-in auto-rotate so it does not also apply the
+    // rotation itself, which would double up on top of our manual transpose.
+    if (!args.variables.ffmpegCommand.overallInputArguments.includes('-noautorotate')) {
+      args.variables.ffmpegCommand.overallInputArguments.push('-noautorotate');
+    }
+
+    // eslint-disable-next-line no-param-reassign
+    args.variables.ffmpegCommand.shouldProcess = true;
+  }
+
+  return {
+    outputFileObj: args.inputFileObj,
+    outputNumber: 1,
+    variables: args.variables,
+  };
+};
+
+export {
+  details,
+  plugin,
+};

--- a/FlowPluginsTs/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandFixRotation/1.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandFixRotation/1.0.0/index.ts
@@ -11,7 +11,10 @@ const details = (): IpluginDetails => ({
   description: 'Detect rotation metadata (legacy "rotate" tag or "Display Matrix" side data) on the video '
     + 'stream, bake the rotation into the pixels, and strip the metadata. Fixes portrait/vertical videos '
     + 'that play sideways or upside-down on ExoPlayer-based apps (Plex, Kodi, Jellyfin on Android/Android TV), '
-    + 'which do not reliably honor rotation metadata during direct play.',
+    + 'which do not reliably honor rotation metadata during direct play. Requires ffmpeg 6.0+ (uses '
+    + '-display_rotation); on older ffmpeg builds the job will fail with "Unrecognized option". Forces a real '
+    + 'video re-encode, so pair this with a "Set Video Encoder" plugin if you want control over the output '
+    + 'codec/quality - without one, ffmpeg falls back to its default encoder settings.',
   style: {
     borderColor: '#6efefc',
   },
@@ -85,19 +88,9 @@ const plugin = (args: IpluginInputArgs): IpluginOutputArgs => {
   checkFfmpegCommandInit(args);
 
   let rotationFixed = false;
-  let inputVideoTypeIndex = -1;
 
   args.variables.ffmpegCommand.streams.forEach((stream) => {
-    if (stream.codec_type !== 'video') {
-      return;
-    }
-
-    // Tracks this stream's index among the *input* file's video streams (unaffected by
-    // `removed`), since -display_rotation below is an input-side option and must address
-    // the original demuxed stream layout, not our flow's filtered output layout.
-    inputVideoTypeIndex += 1;
-
-    if (stream.removed) {
+    if (stream.codec_type !== 'video' || stream.removed) {
       return;
     }
 
@@ -105,22 +98,42 @@ const plugin = (args: IpluginInputArgs): IpluginOutputArgs => {
     const transposeFilter = getTransposeFilter(rotation);
 
     if (!transposeFilter) {
+      if (rotation !== 0) {
+        args.jobLog(`Found ${rotation}° rotation metadata on video stream index ${stream.index}, `
+          + 'which is not a multiple of 90° - skipping as this plugin cannot handle non-90-degree rotations');
+      }
       return;
+    }
+
+    if (stream.outputArgs.some((arg) => arg === '-vf' || arg.startsWith('-filter:v'))) {
+      args.jobLog(`Warning: video stream index ${stream.index} already has a video filter set by an earlier `
+        + 'plugin. ffmpeg only keeps the last filter option per stream, so one of them will be silently '
+        + 'dropped - place Fix Rotation before other video filter plugins, or merge the filters manually.');
     }
 
     args.jobLog(`Found ${rotation}° rotation metadata on video stream index ${stream.index}, `
       + `applying '${transposeFilter}' and clearing rotation metadata`);
 
-    stream.outputArgs.push('-vf', transposeFilter);
-    stream.outputArgs.push('-metadata:s:v:{outputTypeIndex}', 'rotate=0');
+    // Use a stream-specific specifier (not the unqualified -vf/-filter:v alias) since an
+    // unqualified filter option applies to every video output stream, not just this one -
+    // it would collide fatally with any other, untouched video stream that Execute copies.
+    stream.outputArgs.push('-filter:v:{outputTypeIndex}', transposeFilter);
+    stream.outputArgs.push('-metadata:s:v:{outputTypeIndex}', 'rotate=');
 
     // Baking the rotation into the pixels is not enough: ffmpeg copies any pre-existing
     // "Display Matrix" side data straight through to the output stream, so without this
     // the fixed file would still carry the original rotation instruction and get rotated
     // a second time by any player that actually honors it. -display_rotation overrides
     // the input's side data to 0 so nothing stale survives into the encode.
+    //
+    // Addressed by the stream's own absolute ffprobe index (a plain numeric specifier, not
+    // a "v:N" type-relative one) since that's the only addressing that stays correct
+    // regardless of earlier flow plugins: Begin Command retypes attached-picture streams to
+    // codec_type 'attachment' (so a naive video-only counter here would skip them, even
+    // though ffmpeg still counts them as video streams for "v:N" input-side addressing),
+    // and Reorder Streams mutates the streams array order in place.
     args.variables.ffmpegCommand.overallInputArguments.push(
-      `-display_rotation:v:${inputVideoTypeIndex}`,
+      `-display_rotation:${stream.index}`,
       '0',
     );
 

--- a/FlowPluginsTs/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandFixRotation/1.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandFixRotation/1.0.0/index.ts
@@ -50,7 +50,10 @@ const getRotation = (stream: IffmpegCommandStream): number => {
     if (displayMatrix) {
       const parsed = parseInt(String(displayMatrix.rotation), 10);
       if (!Number.isNaN(parsed)) {
-        return normalizeAngle(parsed);
+        // ffmpeg's Display Matrix rotation is a counter-clockwise angle (av_display_rotation_get),
+        // the opposite sign convention of the legacy clockwise "rotate" tag. Negate it so both
+        // paths feed getTransposeFilter() the same "degrees to rotate clockwise" convention.
+        return normalizeAngle(-parsed);
       }
     }
   }
@@ -82,9 +85,19 @@ const plugin = (args: IpluginInputArgs): IpluginOutputArgs => {
   checkFfmpegCommandInit(args);
 
   let rotationFixed = false;
+  let inputVideoTypeIndex = -1;
 
   args.variables.ffmpegCommand.streams.forEach((stream) => {
-    if (stream.codec_type !== 'video' || stream.removed) {
+    if (stream.codec_type !== 'video') {
+      return;
+    }
+
+    // Tracks this stream's index among the *input* file's video streams (unaffected by
+    // `removed`), since -display_rotation below is an input-side option and must address
+    // the original demuxed stream layout, not our flow's filtered output layout.
+    inputVideoTypeIndex += 1;
+
+    if (stream.removed) {
       return;
     }
 
@@ -100,6 +113,16 @@ const plugin = (args: IpluginInputArgs): IpluginOutputArgs => {
 
     stream.outputArgs.push('-vf', transposeFilter);
     stream.outputArgs.push('-metadata:s:v:{outputTypeIndex}', 'rotate=0');
+
+    // Baking the rotation into the pixels is not enough: ffmpeg copies any pre-existing
+    // "Display Matrix" side data straight through to the output stream, so without this
+    // the fixed file would still carry the original rotation instruction and get rotated
+    // a second time by any player that actually honors it. -display_rotation overrides
+    // the input's side data to 0 so nothing stale survives into the encode.
+    args.variables.ffmpegCommand.overallInputArguments.push(
+      `-display_rotation:v:${inputVideoTypeIndex}`,
+      '0',
+    );
 
     rotationFixed = true;
   });

--- a/tests/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandFixRotation/1.0.0/index.test.ts
+++ b/tests/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandFixRotation/1.0.0/index.test.ts
@@ -63,6 +63,9 @@ describe('ffmpegCommandFixRotation Plugin', () => {
         '-vf', 'transpose=1', '-metadata:s:v:{outputTypeIndex}', 'rotate=0',
       ]);
       expect(result.variables.ffmpegCommand.overallInputArguments).toContain('-noautorotate');
+      expect(result.variables.ffmpegCommand.overallInputArguments).toEqual(
+        expect.arrayContaining(['-display_rotation:v:0', '0']),
+      );
       expect(result.variables.ffmpegCommand.shouldProcess).toBe(true);
     });
 
@@ -109,6 +112,8 @@ describe('ffmpegCommandFixRotation Plugin', () => {
 
   describe('Display Matrix side data', () => {
     it('should fix a rotation reported via side_data_list', () => {
+      // Display Matrix rotation is counter-clockwise, so -90 here means the same physical
+      // correction as a legacy rotate=90 tag: rotate 90 degrees clockwise (transpose=1).
       baseArgs.variables.ffmpegCommand.streams[0].side_data_list = [
         { side_data_type: 'Display Matrix', rotation: -90 },
       ];
@@ -116,9 +121,24 @@ describe('ffmpegCommandFixRotation Plugin', () => {
       const result = plugin(baseArgs);
 
       expect(result.variables.ffmpegCommand.streams[0].outputArgs).toEqual([
-        '-vf', 'transpose=2', '-metadata:s:v:{outputTypeIndex}', 'rotate=0',
+        '-vf', 'transpose=1', '-metadata:s:v:{outputTypeIndex}', 'rotate=0',
       ]);
       expect(result.variables.ffmpegCommand.overallInputArguments).toContain('-noautorotate');
+      expect(result.variables.ffmpegCommand.overallInputArguments).toEqual(
+        expect.arrayContaining(['-display_rotation:v:0', '0']),
+      );
+    });
+
+    it('should fix a positive Display Matrix rotation in the opposite direction of the same tag value', () => {
+      baseArgs.variables.ffmpegCommand.streams[0].side_data_list = [
+        { side_data_type: 'Display Matrix', rotation: 90 },
+      ];
+
+      const result = plugin(baseArgs);
+
+      expect(result.variables.ffmpegCommand.streams[0].outputArgs).toEqual([
+        '-vf', 'transpose=2', '-metadata:s:v:{outputTypeIndex}', 'rotate=0',
+      ]);
     });
 
     it('should prefer the legacy rotate tag over side data when both are present', () => {
@@ -132,6 +152,34 @@ describe('ffmpegCommandFixRotation Plugin', () => {
       expect(result.variables.ffmpegCommand.streams[0].outputArgs).toEqual([
         '-vf', 'transpose=1', '-metadata:s:v:{outputTypeIndex}', 'rotate=0',
       ]);
+    });
+  });
+
+  describe('Multiple video streams', () => {
+    it('should index -display_rotation against the video stream position, not the overall stream index', () => {
+      baseArgs.variables.ffmpegCommand.streams.unshift({
+        index: 2,
+        codec_name: 'mjpeg',
+        codec_type: 'video',
+        width: 300,
+        height: 300,
+        removed: false,
+        forceEncoding: false,
+        inputArgs: [],
+        outputArgs: [],
+        mapArgs: ['-map', '0:2'],
+      });
+      baseArgs.variables.ffmpegCommand.streams[1].tags = { rotate: '90' };
+
+      const result = plugin(baseArgs);
+
+      expect(result.variables.ffmpegCommand.streams[0].outputArgs).toEqual([]);
+      expect(result.variables.ffmpegCommand.streams[1].outputArgs).toEqual([
+        '-vf', 'transpose=1', '-metadata:s:v:{outputTypeIndex}', 'rotate=0',
+      ]);
+      expect(result.variables.ffmpegCommand.overallInputArguments).toEqual(
+        expect.arrayContaining(['-display_rotation:v:1', '0']),
+      );
     });
   });
 

--- a/tests/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandFixRotation/1.0.0/index.test.ts
+++ b/tests/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandFixRotation/1.0.0/index.test.ts
@@ -60,11 +60,11 @@ describe('ffmpegCommandFixRotation Plugin', () => {
       const result = plugin(baseArgs);
 
       expect(result.variables.ffmpegCommand.streams[0].outputArgs).toEqual([
-        '-vf', 'transpose=1', '-metadata:s:v:{outputTypeIndex}', 'rotate=0',
+        '-filter:v:{outputTypeIndex}', 'transpose=1', '-metadata:s:v:{outputTypeIndex}', 'rotate=',
       ]);
       expect(result.variables.ffmpegCommand.overallInputArguments).toContain('-noautorotate');
       expect(result.variables.ffmpegCommand.overallInputArguments).toEqual(
-        expect.arrayContaining(['-display_rotation:v:0', '0']),
+        expect.arrayContaining(['-display_rotation:0', '0']),
       );
       expect(result.variables.ffmpegCommand.shouldProcess).toBe(true);
     });
@@ -75,7 +75,7 @@ describe('ffmpegCommandFixRotation Plugin', () => {
       const result = plugin(baseArgs);
 
       expect(result.variables.ffmpegCommand.streams[0].outputArgs).toEqual([
-        '-vf', 'hflip,vflip', '-metadata:s:v:{outputTypeIndex}', 'rotate=0',
+        '-filter:v:{outputTypeIndex}', 'hflip,vflip', '-metadata:s:v:{outputTypeIndex}', 'rotate=',
       ]);
     });
 
@@ -85,7 +85,7 @@ describe('ffmpegCommandFixRotation Plugin', () => {
       const result = plugin(baseArgs);
 
       expect(result.variables.ffmpegCommand.streams[0].outputArgs).toEqual([
-        '-vf', 'transpose=2', '-metadata:s:v:{outputTypeIndex}', 'rotate=0',
+        '-filter:v:{outputTypeIndex}', 'transpose=2', '-metadata:s:v:{outputTypeIndex}', 'rotate=',
       ]);
     });
 
@@ -95,7 +95,7 @@ describe('ffmpegCommandFixRotation Plugin', () => {
       const result = plugin(baseArgs);
 
       expect(result.variables.ffmpegCommand.streams[0].outputArgs).toEqual([
-        '-vf', 'transpose=2', '-metadata:s:v:{outputTypeIndex}', 'rotate=0',
+        '-filter:v:{outputTypeIndex}', 'transpose=2', '-metadata:s:v:{outputTypeIndex}', 'rotate=',
       ]);
     });
 
@@ -121,11 +121,11 @@ describe('ffmpegCommandFixRotation Plugin', () => {
       const result = plugin(baseArgs);
 
       expect(result.variables.ffmpegCommand.streams[0].outputArgs).toEqual([
-        '-vf', 'transpose=1', '-metadata:s:v:{outputTypeIndex}', 'rotate=0',
+        '-filter:v:{outputTypeIndex}', 'transpose=1', '-metadata:s:v:{outputTypeIndex}', 'rotate=',
       ]);
       expect(result.variables.ffmpegCommand.overallInputArguments).toContain('-noautorotate');
       expect(result.variables.ffmpegCommand.overallInputArguments).toEqual(
-        expect.arrayContaining(['-display_rotation:v:0', '0']),
+        expect.arrayContaining(['-display_rotation:0', '0']),
       );
     });
 
@@ -137,7 +137,7 @@ describe('ffmpegCommandFixRotation Plugin', () => {
       const result = plugin(baseArgs);
 
       expect(result.variables.ffmpegCommand.streams[0].outputArgs).toEqual([
-        '-vf', 'transpose=2', '-metadata:s:v:{outputTypeIndex}', 'rotate=0',
+        '-filter:v:{outputTypeIndex}', 'transpose=2', '-metadata:s:v:{outputTypeIndex}', 'rotate=',
       ]);
     });
 
@@ -150,13 +150,13 @@ describe('ffmpegCommandFixRotation Plugin', () => {
       const result = plugin(baseArgs);
 
       expect(result.variables.ffmpegCommand.streams[0].outputArgs).toEqual([
-        '-vf', 'transpose=1', '-metadata:s:v:{outputTypeIndex}', 'rotate=0',
+        '-filter:v:{outputTypeIndex}', 'transpose=1', '-metadata:s:v:{outputTypeIndex}', 'rotate=',
       ]);
     });
   });
 
   describe('Multiple video streams', () => {
-    it('should index -display_rotation against the video stream position, not the overall stream index', () => {
+    it('should index -display_rotation by the stream\'s own ffprobe index, not its array position', () => {
       baseArgs.variables.ffmpegCommand.streams.unshift({
         index: 2,
         codec_name: 'mjpeg',
@@ -175,11 +175,64 @@ describe('ffmpegCommandFixRotation Plugin', () => {
 
       expect(result.variables.ffmpegCommand.streams[0].outputArgs).toEqual([]);
       expect(result.variables.ffmpegCommand.streams[1].outputArgs).toEqual([
-        '-vf', 'transpose=1', '-metadata:s:v:{outputTypeIndex}', 'rotate=0',
+        '-filter:v:{outputTypeIndex}', 'transpose=1', '-metadata:s:v:{outputTypeIndex}', 'rotate=',
+      ]);
+      // The rotated stream's own ffprobe index is 0 (set in beforeEach), even though it sits
+      // at array position 1 after the mjpeg cover art was unshifted to the front.
+      expect(result.variables.ffmpegCommand.overallInputArguments).toEqual(
+        expect.arrayContaining(['-display_rotation:0', '0']),
+      );
+    });
+
+    it('should not skip a rotated stream that sits after an attachment-typed stream', () => {
+      // Begin Command retypes attached-picture streams to codec_type 'attachment'. A naive
+      // "count video-typed streams seen so far" counter would then undercount any real video
+      // stream positioned after it, since ffmpeg still numbers it as a video stream on the
+      // input side. Addressing by the stream's own ffprobe index sidesteps this entirely.
+      baseArgs.variables.ffmpegCommand.streams.unshift({
+        index: 0,
+        codec_name: 'mjpeg',
+        codec_type: 'attachment',
+        width: 300,
+        height: 300,
+        removed: false,
+        forceEncoding: false,
+        inputArgs: [],
+        outputArgs: [],
+        mapArgs: ['-map', '0:0'],
+      });
+      baseArgs.variables.ffmpegCommand.streams[1].index = 1;
+      baseArgs.variables.ffmpegCommand.streams[1].tags = { rotate: '90' };
+
+      const result = plugin(baseArgs);
+
+      expect(result.variables.ffmpegCommand.streams[1].outputArgs).toEqual([
+        '-filter:v:{outputTypeIndex}', 'transpose=1', '-metadata:s:v:{outputTypeIndex}', 'rotate=',
       ]);
       expect(result.variables.ffmpegCommand.overallInputArguments).toEqual(
-        expect.arrayContaining(['-display_rotation:v:1', '0']),
+        expect.arrayContaining(['-display_rotation:1', '0']),
       );
+    });
+  });
+
+  describe('Warnings', () => {
+    it('should log when the rotation is not a multiple of 90 degrees', () => {
+      baseArgs.variables.ffmpegCommand.streams[0].tags = { rotate: '45' };
+
+      const result = plugin(baseArgs);
+
+      expect(result.variables.ffmpegCommand.streams[0].outputArgs).toEqual([]);
+      expect(result.variables.ffmpegCommand.shouldProcess).toBe(false);
+      expect(baseArgs.jobLog).toHaveBeenCalledWith(expect.stringContaining('not a multiple of 90'));
+    });
+
+    it('should warn when the stream already has a video filter set', () => {
+      baseArgs.variables.ffmpegCommand.streams[0].tags = { rotate: '90' };
+      baseArgs.variables.ffmpegCommand.streams[0].outputArgs = ['-vf', 'scale=1280:720'];
+
+      plugin(baseArgs);
+
+      expect(baseArgs.jobLog).toHaveBeenCalledWith(expect.stringContaining('already has a video filter'));
     });
   });
 

--- a/tests/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandFixRotation/1.0.0/index.test.ts
+++ b/tests/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandFixRotation/1.0.0/index.test.ts
@@ -1,0 +1,187 @@
+import { plugin } from
+  '../../../../../../FlowPluginsTs/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandFixRotation/1.0.0/index';
+import { IpluginInputArgs } from '../../../../../../FlowPluginsTs/FlowHelpers/1.0.0/interfaces/interfaces';
+
+const sampleH264 = require('../../../../../sampleData/media/sampleH264_1.json');
+
+describe('ffmpegCommandFixRotation Plugin', () => {
+  let baseArgs: IpluginInputArgs;
+
+  beforeEach(() => {
+    baseArgs = {
+      inputs: {},
+      variables: {
+        ffmpegCommand: {
+          init: true,
+          inputFiles: [],
+          streams: [
+            {
+              index: 0,
+              codec_name: 'h264',
+              codec_type: 'video',
+              width: 1080,
+              height: 1920,
+              removed: false,
+              forceEncoding: false,
+              inputArgs: [],
+              outputArgs: [],
+              mapArgs: ['-map', '0:0'],
+            },
+            {
+              index: 1,
+              codec_name: 'aac',
+              codec_type: 'audio',
+              channels: 2,
+              removed: false,
+              forceEncoding: false,
+              inputArgs: [],
+              outputArgs: [],
+              mapArgs: ['-map', '0:1'],
+            },
+          ],
+          container: 'mp4',
+          hardwareDecoding: false,
+          shouldProcess: false,
+          overallInputArguments: [],
+          overallOuputArguments: [],
+        },
+        flowFailed: false,
+        user: {},
+      },
+      inputFileObj: JSON.parse(JSON.stringify(sampleH264)),
+      jobLog: jest.fn(),
+    } as Partial<IpluginInputArgs> as IpluginInputArgs;
+  });
+
+  describe('Legacy rotate tag', () => {
+    it('should fix a 90 degree rotation', () => {
+      baseArgs.variables.ffmpegCommand.streams[0].tags = { rotate: '90' };
+
+      const result = plugin(baseArgs);
+
+      expect(result.variables.ffmpegCommand.streams[0].outputArgs).toEqual([
+        '-vf', 'transpose=1', '-metadata:s:v:{outputTypeIndex}', 'rotate=0',
+      ]);
+      expect(result.variables.ffmpegCommand.overallInputArguments).toContain('-noautorotate');
+      expect(result.variables.ffmpegCommand.shouldProcess).toBe(true);
+    });
+
+    it('should fix a 180 degree rotation', () => {
+      baseArgs.variables.ffmpegCommand.streams[0].tags = { rotate: '180' };
+
+      const result = plugin(baseArgs);
+
+      expect(result.variables.ffmpegCommand.streams[0].outputArgs).toEqual([
+        '-vf', 'hflip,vflip', '-metadata:s:v:{outputTypeIndex}', 'rotate=0',
+      ]);
+    });
+
+    it('should fix a 270 degree rotation', () => {
+      baseArgs.variables.ffmpegCommand.streams[0].tags = { rotate: '270' };
+
+      const result = plugin(baseArgs);
+
+      expect(result.variables.ffmpegCommand.streams[0].outputArgs).toEqual([
+        '-vf', 'transpose=2', '-metadata:s:v:{outputTypeIndex}', 'rotate=0',
+      ]);
+    });
+
+    it('should normalize a negative rotation angle', () => {
+      baseArgs.variables.ffmpegCommand.streams[0].tags = { rotate: '-90' };
+
+      const result = plugin(baseArgs);
+
+      expect(result.variables.ffmpegCommand.streams[0].outputArgs).toEqual([
+        '-vf', 'transpose=2', '-metadata:s:v:{outputTypeIndex}', 'rotate=0',
+      ]);
+    });
+
+    it('should do nothing when rotate is 0', () => {
+      baseArgs.variables.ffmpegCommand.streams[0].tags = { rotate: '0' };
+
+      const result = plugin(baseArgs);
+
+      expect(result.variables.ffmpegCommand.streams[0].outputArgs).toEqual([]);
+      expect(result.variables.ffmpegCommand.overallInputArguments).not.toContain('-noautorotate');
+      expect(result.variables.ffmpegCommand.shouldProcess).toBe(false);
+    });
+  });
+
+  describe('Display Matrix side data', () => {
+    it('should fix a rotation reported via side_data_list', () => {
+      baseArgs.variables.ffmpegCommand.streams[0].side_data_list = [
+        { side_data_type: 'Display Matrix', rotation: -90 },
+      ];
+
+      const result = plugin(baseArgs);
+
+      expect(result.variables.ffmpegCommand.streams[0].outputArgs).toEqual([
+        '-vf', 'transpose=2', '-metadata:s:v:{outputTypeIndex}', 'rotate=0',
+      ]);
+      expect(result.variables.ffmpegCommand.overallInputArguments).toContain('-noautorotate');
+    });
+
+    it('should prefer the legacy rotate tag over side data when both are present', () => {
+      baseArgs.variables.ffmpegCommand.streams[0].tags = { rotate: '90' };
+      baseArgs.variables.ffmpegCommand.streams[0].side_data_list = [
+        { side_data_type: 'Display Matrix', rotation: 180 },
+      ];
+
+      const result = plugin(baseArgs);
+
+      expect(result.variables.ffmpegCommand.streams[0].outputArgs).toEqual([
+        '-vf', 'transpose=1', '-metadata:s:v:{outputTypeIndex}', 'rotate=0',
+      ]);
+    });
+  });
+
+  describe('No rotation metadata', () => {
+    it('should not modify streams without rotation metadata', () => {
+      const result = plugin(baseArgs);
+
+      expect(result.variables.ffmpegCommand.streams[0].outputArgs).toEqual([]);
+      expect(result.variables.ffmpegCommand.streams[1].outputArgs).toEqual([]);
+      expect(result.variables.ffmpegCommand.overallInputArguments).toEqual([]);
+      expect(result.variables.ffmpegCommand.shouldProcess).toBe(false);
+    });
+  });
+
+  describe('Non-video streams', () => {
+    it('should ignore rotation-like tags on non-video streams', () => {
+      baseArgs.variables.ffmpegCommand.streams[1].tags = { rotate: '90' };
+
+      const result = plugin(baseArgs);
+
+      expect(result.variables.ffmpegCommand.streams[1].outputArgs).toEqual([]);
+    });
+
+    it('should skip removed video streams', () => {
+      baseArgs.variables.ffmpegCommand.streams[0].removed = true;
+      baseArgs.variables.ffmpegCommand.streams[0].tags = { rotate: '90' };
+
+      const result = plugin(baseArgs);
+
+      expect(result.variables.ffmpegCommand.streams[0].outputArgs).toEqual([]);
+      expect(result.variables.ffmpegCommand.shouldProcess).toBe(false);
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('should throw error when ffmpegCommand is not initialized', () => {
+      baseArgs.variables.ffmpegCommand.init = false;
+
+      expect(() => plugin(baseArgs)).toThrow(
+        'FFmpeg command plugins not used correctly. Please use the "Begin Command" plugin before using this plugin.',
+      );
+    });
+  });
+
+  describe('Output', () => {
+    it('should return outputNumber 1 and pass through the file object', () => {
+      const result = plugin(baseArgs);
+
+      expect(result.outputNumber).toBe(1);
+      expect(result.outputFileObj).toBe(baseArgs.inputFileObj);
+    });
+  });
+});

--- a/tests/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandFixRotation/1.0.0/index.test.ts
+++ b/tests/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandFixRotation/1.0.0/index.test.ts
@@ -225,14 +225,46 @@ describe('ffmpegCommandFixRotation Plugin', () => {
       expect(result.variables.ffmpegCommand.shouldProcess).toBe(false);
       expect(baseArgs.jobLog).toHaveBeenCalledWith(expect.stringContaining('not a multiple of 90'));
     });
+  });
 
-    it('should warn when the stream already has a video filter set', () => {
+  describe('Existing video filters', () => {
+    it('should chain the transpose onto an existing -vf filter instead of adding a competing option', () => {
       baseArgs.variables.ffmpegCommand.streams[0].tags = { rotate: '90' };
       baseArgs.variables.ffmpegCommand.streams[0].outputArgs = ['-vf', 'scale=1280:720'];
 
-      plugin(baseArgs);
+      const result = plugin(baseArgs);
 
-      expect(baseArgs.jobLog).toHaveBeenCalledWith(expect.stringContaining('already has a video filter'));
+      expect(result.variables.ffmpegCommand.streams[0].outputArgs).toEqual([
+        '-filter:v:{outputTypeIndex}', 'scale=1280:720,transpose=1',
+        '-metadata:s:v:{outputTypeIndex}', 'rotate=',
+      ]);
+    });
+
+    it('should chain the transpose onto an existing stream-specific filter option', () => {
+      baseArgs.variables.ffmpegCommand.streams[0].tags = { rotate: '180' };
+      baseArgs.variables.ffmpegCommand.streams[0].outputArgs = [
+        '-filter:v:{outputTypeIndex}', 'zscale=t=linear:npl=100,format=yuv420p',
+      ];
+
+      const result = plugin(baseArgs);
+
+      expect(result.variables.ffmpegCommand.streams[0].outputArgs).toEqual([
+        '-filter:v:{outputTypeIndex}', 'zscale=t=linear:npl=100,format=yuv420p,hflip,vflip',
+        '-metadata:s:v:{outputTypeIndex}', 'rotate=',
+      ]);
+    });
+
+    it('should not treat non-filter output args as an existing filter', () => {
+      baseArgs.variables.ffmpegCommand.streams[0].tags = { rotate: '90' };
+      baseArgs.variables.ffmpegCommand.streams[0].outputArgs = ['-c:v:{outputTypeIndex}', 'libx265'];
+
+      const result = plugin(baseArgs);
+
+      expect(result.variables.ffmpegCommand.streams[0].outputArgs).toEqual([
+        '-c:v:{outputTypeIndex}', 'libx265',
+        '-filter:v:{outputTypeIndex}', 'transpose=1',
+        '-metadata:s:v:{outputTypeIndex}', 'rotate=',
+      ]);
     });
   });
 


### PR DESCRIPTION
## Summary
- Adds a new `Fix Rotation` ffmpegCommand Flow plugin that detects rotation metadata (legacy `rotate` tag or `Display Matrix` side data) on the video stream, bakes the rotation into the pixels via `transpose`/`hflip,vflip`, and strips the rotation metadata so it isn't applied twice.
- Fixes portrait/vertical videos that play sideways or upside-down on ExoPlayer-based apps (Plex, Kodi, Jellyfin on Android/Android TV), which don't reliably honor rotation metadata during direct play.
- Correctly handles the opposite sign convention between the legacy `rotate` tag (clockwise) and `Display Matrix` `rotation` (counter-clockwise).
- Uses stream-specific `-filter:v:{outputTypeIndex}` (not unqualified `-vf`) so it doesn't collide with other, untouched video streams (e.g. embedded cover art) that Execute copies.
- Addresses `-display_rotation` by the stream's own absolute ffprobe index, so it stays correct regardless of stream reordering or attached-picture streams ahead of the real video stream.
- If an earlier plugin already set a video filter on the stream, chains the transpose onto the end of it instead of dropping one of the two.
- Includes a full unit test suite (19 tests) covering legacy tag and Display Matrix rotation detection/sign handling, multi-stream indexing, filter chaining, and error handling.

## Test plan
- [x] `npx tsc -p tsconfig.json` - clean
- [x] `npx eslint FlowPluginsTs Community methods examples tests --ext js,ts` - clean
- [x] `npx jest` - full suite passes (99 suites)
- [x] Verified end-to-end against real rotated phone videos (H.264, both legacy `rotate` tag and `Display Matrix` side data) - confirmed correct visual orientation and no stale rotation metadata via `ffprobe`
- [x] Verified the multi-video-stream fix against a constructed test file (copy-only stream + rotated stream) reproducing and resolving the "Filtering and streamcopy cannot be used together" ffmpeg error