### PR TITLE
Fix ensured audio stream metadata

### DIFF
--- a/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandEnsureAudioStream/1.0.0/index.js
+++ b/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandEnsureAudioStream/1.0.0/index.js
@@ -206,6 +206,9 @@ var attemptMakeStream = function (_a) {
     var streamCopy = JSON.parse(JSON.stringify(streamWithHighestChannel));
     streamCopy.removed = false;
     streamCopy.index = streams.length;
+    // Keep planned stream metadata aligned for subsequent command plugins.
+    streamCopy.codec_name = audioCodec;
+    streamCopy.channels = targetChannels;
     streamCopy.outputArgs.push('-c:{outputIndex}', audioEncoder);
     streamCopy.outputArgs.push('-ac', "".concat(targetChannels));
     if (enableBitrate) {

--- a/FlowPluginsTs/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandEnsureAudioStream/1.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandEnsureAudioStream/1.0.0/index.ts
@@ -245,6 +245,9 @@ const attemptMakeStream = ({
   const streamCopy: IffmpegCommandStream = JSON.parse(JSON.stringify(streamWithHighestChannel));
   streamCopy.removed = false;
   streamCopy.index = streams.length;
+  // Keep planned stream metadata aligned for subsequent command plugins.
+  streamCopy.codec_name = audioCodec;
+  streamCopy.channels = targetChannels;
   streamCopy.outputArgs.push('-c:{outputIndex}', audioEncoder);
   streamCopy.outputArgs.push('-ac', `${targetChannels}`);
 

--- a/tests/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandEnsureAudioStream/1.0.0/index.test.ts
+++ b/tests/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandEnsureAudioStream/1.0.0/index.test.ts
@@ -1,5 +1,7 @@
 import { plugin } from
   '../../../../../../FlowPluginsTs/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandEnsureAudioStream/1.0.0/index';
+import { plugin as removeStreamByPropertyPlugin } from
+  '../../../../../../FlowPluginsTs/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandRemoveStreamByProperty/1.0.0/index';
 import { IpluginInputArgs } from '../../../../../../FlowPluginsTs/FlowHelpers/1.0.0/interfaces/interfaces';
 
 const sampleH264 = require('../../../../../sampleData/media/sampleH264_1.json');
@@ -357,6 +359,34 @@ describe('ffmpegCommandEnsureAudioStream Plugin', () => {
         expect(audioStreams).toHaveLength(2); // Original + new one
         expect(audioStreams[1].outputArgs).toContain(encoder);
       });
+    });
+  });
+
+  it('should keep a planned EAC3 stream when a downstream plugin removes DTS streams', () => {
+    const { streams } = baseArgs.variables.ffmpegCommand;
+    const sourceAudioStream = streams[1];
+    sourceAudioStream.codec_name = 'dts';
+    sourceAudioStream.tags = { language: 'eng' };
+    baseArgs.inputs.audioEncoder = 'eac3';
+    baseArgs.inputs.language = 'eng';
+    baseArgs.inputs.channels = '2';
+
+    plugin(baseArgs);
+    const plannedStream = streams[2];
+
+    baseArgs.inputs = {
+      codecType: 'audio',
+      propertyToCheck: 'codec_name',
+      valuesToRemove: 'dts',
+      condition: 'includes',
+    };
+    removeStreamByPropertyPlugin(baseArgs);
+
+    expect(sourceAudioStream.removed).toBe(true);
+    expect(plannedStream).toMatchObject({
+      codec_name: 'eac3',
+      channels: 2,
+      removed: false,
     });
   });
 });


### PR DESCRIPTION
Updates planned audio stream metadata to match the configured codec and channel count. This prevents downstream stream filters from removing newly created streams.
