### PR TITLE
feat: add FFmpeg stream mapping toggle

### DIFF
--- a/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandExecute/1.0.0/index.js
+++ b/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandExecute/1.0.0/index.js
@@ -115,9 +115,9 @@ var shouldAddCopyCodec = function (outputArgs) { return (outputArgs.length === 0
     || (!hasCodecOutputArg(outputArgs) && hasOnlyCopyCompatibleOutputArgs(outputArgs))); };
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 var plugin = function (args) { return __awaiter(void 0, void 0, void 0, function () {
-    var lib, cliArgs, _a, shouldProcess, streams, inputArgs, _loop_1, i, idx, outputFilePath, spawnArgs, cli, res;
-    return __generator(this, function (_b) {
-        switch (_b.label) {
+    var lib, cliArgs, shouldProcess, shouldMapAllStreams, inputArgs, streams, _loop_1, i, idx, outputFilePath, spawnArgs, cli, res;
+    return __generator(this, function (_a) {
+        switch (_a.label) {
             case 0:
                 lib = require('../../../../../methods/lib')();
                 // eslint-disable-next-line @typescript-eslint/no-unused-vars,no-param-reassign
@@ -127,18 +127,20 @@ var plugin = function (args) { return __awaiter(void 0, void 0, void 0, function
                 cliArgs.push('-y');
                 cliArgs.push('-i');
                 cliArgs.push(args.inputFileObj._id);
-                _a = args.variables.ffmpegCommand, shouldProcess = _a.shouldProcess, streams = _a.streams;
+                shouldProcess = args.variables.ffmpegCommand.shouldProcess;
+                shouldMapAllStreams = args.variables.ffmpegCommand.mapAllStreams !== false;
                 if (args.variables.ffmpegCommand.overallInputArguments.length > 0) {
                     shouldProcess = true;
                 }
                 inputArgs = __spreadArray([], args.variables.ffmpegCommand.overallInputArguments, true);
-                streams = streams.filter(function (stream) {
-                    if (stream.removed) {
-                        shouldProcess = true;
-                    }
-                    return !stream.removed;
-                });
-                if (streams.length === 0) {
+                streams = shouldMapAllStreams
+                    ? args.variables.ffmpegCommand.streams.filter(function (stream) {
+                        if (stream.removed) {
+                            shouldProcess = true;
+                        }
+                        return !stream.removed;
+                    }) : [];
+                if (shouldMapAllStreams && streams.length === 0) {
                     args.jobLog('No streams mapped for new file');
                     throw new Error('No streams mapped for new file');
                 }
@@ -205,7 +207,7 @@ var plugin = function (args) { return __awaiter(void 0, void 0, void 0, function
                 });
                 return [4 /*yield*/, cli.runCli()];
             case 1:
-                res = _b.sent();
+                res = _a.sent();
                 if (res.cliExitCode !== 0) {
                     args.jobLog('Running FFmpeg failed');
                     throw new Error('FFmpeg failed');

--- a/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandStart/1.0.0/index.js
+++ b/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandStart/1.0.0/index.js
@@ -28,7 +28,19 @@ var details = function () { return ({
     requiresVersion: '2.11.01',
     sidebarPosition: 1,
     icon: '',
-    inputs: [],
+    inputs: [
+        {
+            label: 'Map All Streams',
+            name: 'mapAllStreams',
+            type: 'boolean',
+            defaultValue: 'true',
+            inputUI: {
+                type: 'switch',
+            },
+            tooltip: 'Generate mapping and copy arguments for every input stream. Disable this when providing complete '
+                + 'stream mapping and codec arguments with the Custom Arguments plugin.',
+        },
+    ],
     outputs: [
         {
             number: 1,
@@ -67,6 +79,7 @@ var plugin = function (args) {
                 ], inputArgs: [], outputArgs: [] });
         }),
         container: container,
+        mapAllStreams: args.inputs.mapAllStreams === true,
         hardwareDecoding: false,
         shouldProcess: false,
         overallInputArguments: [],

--- a/FlowPluginsTs/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandExecute/1.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandExecute/1.0.0/index.ts
@@ -108,7 +108,8 @@ const plugin = async (args: IpluginInputArgs): Promise<IpluginOutputArgs> => {
   cliArgs.push('-i');
   cliArgs.push(args.inputFileObj._id);
 
-  let { shouldProcess, streams } = args.variables.ffmpegCommand;
+  let { shouldProcess } = args.variables.ffmpegCommand;
+  const shouldMapAllStreams = args.variables.ffmpegCommand.mapAllStreams !== false;
 
   if (args.variables.ffmpegCommand.overallInputArguments.length > 0) {
     shouldProcess = true;
@@ -118,14 +119,15 @@ const plugin = async (args: IpluginInputArgs): Promise<IpluginOutputArgs> => {
     ...args.variables.ffmpegCommand.overallInputArguments,
   ];
 
-  streams = streams.filter((stream) => {
-    if (stream.removed) {
-      shouldProcess = true;
-    }
-    return !stream.removed;
-  });
+  const streams = shouldMapAllStreams
+    ? args.variables.ffmpegCommand.streams.filter((stream) => {
+      if (stream.removed) {
+        shouldProcess = true;
+      }
+      return !stream.removed;
+    }) : [];
 
-  if (streams.length === 0) {
+  if (shouldMapAllStreams && streams.length === 0) {
     args.jobLog('No streams mapped for new file');
     throw new Error('No streams mapped for new file');
   }

--- a/FlowPluginsTs/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandStart/1.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandStart/1.0.0/index.ts
@@ -22,7 +22,19 @@ const details = () :IpluginDetails => ({
   requiresVersion: '2.11.01',
   sidebarPosition: 1,
   icon: '',
-  inputs: [],
+  inputs: [
+    {
+      label: 'Map All Streams',
+      name: 'mapAllStreams',
+      type: 'boolean',
+      defaultValue: 'true',
+      inputUI: {
+        type: 'switch',
+      },
+      tooltip: 'Generate mapping and copy arguments for every input stream. Disable this when providing complete '
+        + 'stream mapping and codec arguments with the Custom Arguments plugin.',
+    },
+  ],
   outputs: [
     {
       number: 1,
@@ -73,6 +85,7 @@ const plugin = (args:IpluginInputArgs):IpluginOutputArgs => {
       };
     }),
     container,
+    mapAllStreams: args.inputs.mapAllStreams === true,
     hardwareDecoding: false,
     shouldProcess: false,
     overallInputArguments: [],

--- a/FlowPluginsTs/FlowHelpers/1.0.0/interfaces/interfaces.ts
+++ b/FlowPluginsTs/FlowHelpers/1.0.0/interfaces/interfaces.ts
@@ -89,8 +89,9 @@ export interface IffmpegCommandStream extends Istreams {
 export interface IffmpegCommand {
     init: boolean,
     inputFiles: string[],
-    streams: IffmpegCommandStream[]
+    streams: IffmpegCommandStream[],
     container: string,
+    mapAllStreams?: boolean,
     hardwareDecoding: boolean,
     shouldProcess: boolean,
     overallInputArguments: string[],

--- a/tests/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandExecute/1.0.0/index.test.ts
+++ b/tests/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandExecute/1.0.0/index.test.ts
@@ -317,6 +317,33 @@ describe('ffmpegCommandExecute Plugin', () => {
   });
 
   describe('Input and Output Arguments', () => {
+    it('should use only custom stream arguments when generated mapping is disabled', async () => {
+      baseArgs.variables.ffmpegCommand.mapAllStreams = false;
+      baseArgs.variables.ffmpegCommand.overallOuputArguments = [
+        '-map', '0:v:0', '-map', '0:a:0', '-c', 'copy', '-sn',
+      ];
+
+      const result = await plugin(baseArgs);
+
+      const { CLI } = require('../../../../../../FlowPluginsTs/FlowHelpers/1.0.0/cliUtils');
+      const [cliOptions] = CLI.mock.calls[0];
+      const { spawnArgs } = cliOptions;
+
+      expect(result.outputNumber).toBe(1);
+      expect(spawnArgs.slice(0, -1)).toEqual([
+        '-y',
+        '-i',
+        baseArgs.inputFileObj._id,
+        '-map',
+        '0:v:0',
+        '-map',
+        '0:a:0',
+        '-c',
+        'copy',
+        '-sn',
+      ]);
+    });
+
     it('should handle overall input arguments', async () => {
       baseArgs.variables.ffmpegCommand.overallInputArguments = ['-threads', '4'];
 

--- a/tests/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandStart/1.0.0/index.test.ts
+++ b/tests/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandStart/1.0.0/index.test.ts
@@ -28,8 +28,18 @@ describe('ffmpegCommandStart Plugin', () => {
       expect(result.variables.ffmpegCommand).toBeDefined();
       expect(result.variables.ffmpegCommand.init).toBe(true);
       expect(result.variables.ffmpegCommand.container).toBe('mp4');
+      expect(result.variables.ffmpegCommand.mapAllStreams).toBe(true);
       expect(result.variables.ffmpegCommand.shouldProcess).toBe(false);
       expect(result.variables.ffmpegCommand.hardwareDecoding).toBe(false);
+    });
+
+    it('should allow generated stream mapping to be disabled', () => {
+      baseArgs.inputs.mapAllStreams = false;
+
+      const result = plugin(baseArgs);
+
+      expect(result.variables.ffmpegCommand.mapAllStreams).toBe(false);
+      expect(result.variables.ffmpegCommand.streams).toHaveLength(2);
     });
 
     it('should initialize ffmpeg command structure with audio file', () => {


### PR DESCRIPTION
## Summary

- Add a default-enabled `Map All Streams` switch to the FFmpeg Begin Command flow plugin.
- Skip Tdarr-generated per-stream mapping and copy arguments when the switch is disabled.
- Preserve existing behavior for saved flows and add regression coverage.

## Why

Begin Command currently maps every input stream before Custom Arguments appends user-provided mappings. Since FFmpeg treats repeated `-map` options cumulatively, custom mappings can duplicate streams in the output.

This option lets Custom Arguments fully control stream mapping while retaining the Begin Command and Execute workflow.

## User impact

Existing flows are unchanged because generated stream mapping remains enabled by default. Users who disable it must provide complete mapping and codec arguments through Custom Arguments.

## Tests

- `tsc`
- Targeted ESLint checks
- `jest tests/FlowPlugins/CommunityFlowPlugins/ffmpegCommand --runInBand` (328 tests)

Closes HaveAGitGat/Tdarr#1401
