### PR TITLE
feat: add FFmpeg and HandBrakeCLI to Run CLI

### DIFF
--- a/FlowPlugins/CommunityFlowPlugins/tools/runCli/1.0.0/index.js
+++ b/FlowPlugins/CommunityFlowPlugins/tools/runCli/1.0.0/index.js
@@ -112,6 +112,8 @@ var details = function () { return ({
             inputUI: {
                 type: 'dropdown',
                 options: [
+                    'ffmpeg',
+                    'handbrakecli',
                     'mkvmerge',
                     'mkvpropedit',
                 ],
@@ -275,8 +277,10 @@ var plugin = function (args) { return __awaiter(void 0, void 0, void 0, function
                     cliArguments = cliArguments.replace(/\${outputFilePath}/g, userOutputFilePath);
                 }
                 availableCli = {
-                    mkvpropedit: args.mkvpropeditPath,
+                    ffmpeg: args.ffmpegPath,
+                    handbrakecli: args.handbrakePath,
                     mkvmerge: 'mkvmerge',
+                    mkvpropedit: args.mkvpropeditPath,
                 };
                 if (useCustomCliPath) {
                     cliPath = customCliPath;

--- a/FlowPluginsTs/CommunityFlowPlugins/tools/runCli/1.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/tools/runCli/1.0.0/index.ts
@@ -86,6 +86,8 @@ const details = (): IpluginDetails => ({
       inputUI: {
         type: 'dropdown',
         options: [
+          'ffmpeg',
+          'handbrakecli',
           'mkvmerge',
           'mkvpropedit',
         ],
@@ -273,11 +275,11 @@ const plugin = async (args: IpluginInputArgs): Promise<IpluginOutputArgs> => {
     cliArguments = cliArguments.replace(/\${outputFilePath}/g, userOutputFilePath);
   }
 
-  const availableCli:{
-    [index: string]: string;
-  } = {
-    mkvpropedit: args.mkvpropeditPath,
+  const availableCli: Record<string, string> = {
+    ffmpeg: args.ffmpegPath,
+    handbrakecli: args.handbrakePath,
     mkvmerge: 'mkvmerge',
+    mkvpropedit: args.mkvpropeditPath,
   };
 
   if (useCustomCliPath) {

--- a/tests/FlowPlugins/CommunityFlowPlugins/tools/runCli/1.0.0/index.test.ts
+++ b/tests/FlowPlugins/CommunityFlowPlugins/tools/runCli/1.0.0/index.test.ts
@@ -1,4 +1,4 @@
-import { parseRunCliArguments, plugin } from
+import { details, parseRunCliArguments, plugin } from
   '../../../../../../FlowPluginsTs/CommunityFlowPlugins/tools/runCli/1.0.0/index';
 import { IpluginInputArgs } from '../../../../../../FlowPluginsTs/FlowHelpers/1.0.0/interfaces/interfaces';
 import { IFileObject } from '../../../../../../FlowPluginsTs/FlowHelpers/1.0.0/interfaces/synced/IFileObject';
@@ -65,6 +65,8 @@ describe('runCli Plugin', () => {
         configVars: getConfigVars(),
       },
       workDir: '/tmp/work',
+      ffmpegPath: '/usr/bin/ffmpeg',
+      handbrakePath: '/usr/bin/HandBrakeCLI',
       mkvpropeditPath: '/usr/bin/mkvpropedit',
       logFullCliOutput: false,
       updateWorker: jest.fn(),
@@ -72,6 +74,21 @@ describe('runCli Plugin', () => {
   });
 
   describe('Basic CLI Execution', () => {
+    it('should list the configured transcode CLIs in the dropdown', () => {
+      expect(details().inputs.find((input) => input.name === 'userCli')).toEqual(
+        expect.objectContaining({
+          inputUI: expect.objectContaining({
+            options: [
+              'ffmpeg',
+              'handbrakecli',
+              'mkvmerge',
+              'mkvpropedit',
+            ],
+          }),
+        }),
+      );
+    });
+
     it('should execute mkvmerge CLI successfully', async () => {
       const result = await plugin(baseArgs);
 
@@ -94,7 +111,33 @@ describe('runCli Plugin', () => {
       );
     });
 
+    it.each([
+      ['ffmpeg', 'ffmpegPath', '/opt/Tdarr Node/ffmpeg'],
+      ['handbrakecli', 'handbrakePath', '/usr/bin/HandBrakeCLI'],
+    ] as const)('should use the configured %s path', async (userCli, pathKey, configuredPath) => {
+      baseArgs.inputs.userCli = userCli;
+      baseArgs[pathKey] = configuredPath;
+
+      await plugin(baseArgs);
+
+      expect(mockCLI).toHaveBeenCalledWith(
+        expect.objectContaining({ cli: configuredPath }),
+      );
+    });
+
+    it('should reject FFmpeg when its configured path is empty', async () => {
+      baseArgs.inputs.userCli = 'ffmpeg';
+      baseArgs.ffmpegPath = '';
+
+      await expect(plugin(baseArgs)).rejects.toThrow(
+        'CLI ffmpeg not available to run in this plugin',
+      );
+      expect(mockCLI).not.toHaveBeenCalled();
+    });
+
     it('should use custom CLI path when specified', async () => {
+      baseArgs.inputs.userCli = 'ffmpeg';
+      baseArgs.ffmpegPath = '';
       baseArgs.inputs.useCustomCliPath = true;
       baseArgs.inputs.customCliPath = '/custom/path/mkvmerge';
 


### PR DESCRIPTION
## Summary

- Add `ffmpeg` and `handbrakecli` to the Run CLI dropdown.
- Resolve those selections through the executing Node's `args.ffmpegPath` and `args.handbrakePath`.
- Preserve custom CLI path precedence and reject an unavailable configured path before spawning.
- Add coverage for dropdown entries, configured path mapping, paths containing spaces, empty paths, and custom overrides.

## Why

Run CLI previously offered only `mkvmerge` and `mkvpropedit`. FFmpeg and HandBrakeCLI users had to enter a binary path manually instead of using the path configured for the Node executing the flow.

## Tests

- [x] `tsc -p tsconfig.json`
- [x] `eslint FlowPluginsTs/CommunityFlowPlugins/tools/runCli/1.0.0/index.ts tests/FlowPlugins/CommunityFlowPlugins/tools/runCli/1.0.0/index.test.ts`
- [x] `npm run test:flows -- tests/FlowPlugins/CommunityFlowPlugins/tools/runCli/1.0.0/index.test.ts --runInBand`
- [x] `git diff --check`
