### PR TITLE
Add Roku safe 4K SDR and HDR10 plugins

### DIFF
--- a/Community/Tdarr_Plugin_STV1_Roku_Safe_4K_SDR_MP4.js
+++ b/Community/Tdarr_Plugin_STV1_Roku_Safe_4K_SDR_MP4.js
@@ -1,0 +1,284 @@
+/* eslint max-len: 0 */
+
+const details = () => ({
+  id: 'Tdarr_Plugin_STV1_Roku_Safe_4K_SDR_MP4',
+  Stage: 'Pre-processing',
+  Name: 'Roku Safe 4K SDR MP4',
+  Type: 'Video',
+  Operation: 'Transcode',
+  Description: 'Conservatively standardize 4K SDR media to the locally validated Roku/Jellyfin-safe shape: MP4/HVC1, HEVC Main 8-bit SDR, AAC stereo fallback, optional AC3 5.1 when the source supports it. HDR/Main10/Dolby Vision/HLG files are skipped.',
+  Version: '1.0.0',
+  Tags: 'pre-processing,ffmpeg,video,4k,roku,mp4,hevc,sdr',
+  Inputs: [
+    {
+      name: 'video_encoder',
+      type: 'string',
+      defaultValue: 'hevc_qsv',
+      inputUI: {
+        type: 'dropdown',
+        options: [
+          'hevc_qsv',
+          'libx265',
+        ],
+      },
+      tooltip: 'FFmpeg HEVC encoder to use when video re-encode is needed. Supported values: hevc_qsv or libx265.',
+    },
+    {
+      name: 'target_video_bitrate_kbps',
+      type: 'string',
+      defaultValue: '20000',
+      inputUI: { type: 'text' },
+      tooltip: 'Target video bitrate in kbps when video re-encode is needed. Video is copied when already HEVC Main 8-bit SDR at or below max_video_bitrate_kbps.',
+    },
+    {
+      name: 'max_video_bitrate_kbps',
+      type: 'string',
+      defaultValue: '25000',
+      inputUI: { type: 'text' },
+      tooltip: 'Above this bitrate, eligible 4K SDR video is re-encoded instead of copied.',
+    },
+    {
+      name: 'allow_unknown_bitrate',
+      type: 'string',
+      defaultValue: 'no',
+      inputUI: {
+        type: 'dropdown',
+        options: [
+          'no',
+          'yes',
+        ],
+      },
+      tooltip: 'Set to yes to allow copying already-compatible HEVC SDR video when bitrate is unknown. Default no is safer for Roku direct play.',
+    },
+    {
+      name: 'aac_bitrate_kbps',
+      type: 'string',
+      defaultValue: '192',
+      inputUI: { type: 'text' },
+      tooltip: 'AAC stereo fallback bitrate.',
+    },
+    {
+      name: 'ac3_bitrate_kbps',
+      type: 'string',
+      defaultValue: '640',
+      inputUI: { type: 'text' },
+      tooltip: 'AC3 5.1 bitrate when the source has a 6+ channel audio stream.',
+    },
+  ],
+});
+
+const get = (obj, path, fallback = undefined) => path
+  .split('.')
+  .reduce((acc, key) => (acc && acc[key] !== undefined ? acc[key] : undefined), obj) ?? fallback;
+
+const lower = (value) => String(value || '').toLowerCase();
+
+const toInt = (value, fallback) => {
+  const parsed = parseInt(value, 10);
+  return Number.isFinite(parsed) ? parsed : fallback;
+};
+
+const yes = (value) => ['1', 'true', 'yes', 'y'].includes(lower(value));
+
+const streamLang = (stream) => lower(get(stream, 'tags.language', 'und'));
+
+const isPreferredLanguage = (stream) => {
+  const lang = streamLang(stream);
+  return lang === 'eng' || lang === 'und' || lang === '';
+};
+
+const is4k = (video) => (video.width || 0) >= 3840 || (video.height || 0) >= 2160;
+
+const isHdrOrTenBit = (video) => {
+  const profile = lower(video.profile);
+  const pixFmt = lower(video.pix_fmt);
+  const colorTransfer = lower(video.color_transfer);
+  const colorPrimaries = lower(video.color_primaries);
+  const colorSpace = lower(video.color_space);
+
+  const sideData = JSON.stringify(video.side_data_list || '').toLowerCase();
+
+  return profile.includes('main 10')
+    || profile.includes('main10')
+    || pixFmt.includes('10')
+    || pixFmt.includes('p010')
+    || colorTransfer === 'smpte2084'
+    || colorTransfer === 'arib-std-b67'
+    || colorPrimaries === 'bt2020'
+    || colorSpace === 'bt2020nc'
+    || sideData.includes('dovi')
+    || sideData.includes('dolby vision');
+};
+
+const pathHasHdrMarkers = (file) => {
+  const text = lower(`${file.file || ''} ${file.fileNameWithoutExtension || ''} ${file.originalFile || ''}`);
+  return /(^|[ ._\-[({])(?:hdr|hdr10|hdr10\+|hdr10plus|hdr10p|dv|dovi|dolby[ ._-]?vision|hlg)(?=$|[ ._\-\])}])/.test(text);
+};
+
+const isSdr = (file, video) => !isHdrOrTenBit(video) && !pathHasHdrMarkers(file);
+
+const bitrateKbps = (file, video) => {
+  const streamBitrate = parseInt(video.bit_rate || 0, 10);
+  if (streamBitrate > 0) {
+    return Math.round(streamBitrate / 1000);
+  }
+
+  const formatBitrate = parseInt(get(file, 'ffProbeData.format.bit_rate', 0), 10);
+  if (formatBitrate > 0) {
+    return Math.round(formatBitrate / 1000);
+  }
+
+  const tdarrBitrate = parseInt(file.bit_rate || 0, 10);
+  if (tdarrBitrate > 0) {
+    return Math.round(tdarrBitrate / 1000);
+  }
+
+  return 0;
+};
+
+const findBestAudio = (streams, requireSixPlus) => {
+  const audio = streams
+    .map((stream, index) => ({ stream, index }))
+    .filter(({ stream }) => lower(stream.codec_type) === 'audio')
+    .filter(({ stream }) => isPreferredLanguage(stream));
+
+  const candidates = requireSixPlus
+    ? audio.filter(({ stream }) => (stream.channels || 0) >= 6)
+    : audio;
+
+  const sorted = candidates.sort((a, b) => (b.stream.channels || 0) - (a.stream.channels || 0));
+  return sorted.length > 0 ? sorted[0] : null;
+};
+
+const hasSafeAudio = (streams) => {
+  const audio = streams.filter((stream) => lower(stream.codec_type) === 'audio');
+  const hasAacStereo = audio.some((stream) => lower(stream.codec_name) === 'aac' && stream.channels === 2);
+  const hasSixPlusSource = audio.some((stream) => (stream.channels || 0) >= 6);
+  const hasAc3Six = audio.some((stream) => lower(stream.codec_name) === 'ac3' && (stream.channels || 0) >= 6);
+  const onlySafeCodecs = audio.every((stream) => ['aac', 'ac3'].includes(lower(stream.codec_name)));
+
+  return hasAacStereo && onlySafeCodecs && (!hasSixPlusSource || hasAc3Six);
+};
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const plugin = (file, librarySettings, inputs, otherArguments) => {
+  const lib = require('../methods/lib')();
+  // eslint-disable-next-line no-param-reassign
+  inputs = lib.loadDefaultValues(inputs, details);
+
+  const response = {
+    container: '.mp4',
+    processFile: false,
+    preset: '',
+    handBrakeMode: false,
+    FFmpegMode: true,
+    reQueueAfter: true,
+    infoLog: '',
+  };
+
+  if (file.fileMedium !== 'video') {
+    response.infoLog += 'Not a video file. Skipping. \n';
+    return response;
+  }
+
+  const streams = get(file, 'ffProbeData.streams', []);
+  const video = streams.find((stream) => lower(stream.codec_type) === 'video'
+    && !['mjpeg', 'png'].includes(lower(stream.codec_name)));
+
+  if (!video) {
+    response.infoLog += 'No primary video stream found. Skipping. \n';
+    return response;
+  }
+
+  if (!is4k(video)) {
+    response.infoLog += `Not 4K (${video.width || '?'}x${video.height || '?'}). Skipping. \n`;
+    return response;
+  }
+
+  if (!isSdr(file, video)) {
+    response.infoLog += '4K file is HDR, Main10, HLG, Dolby Vision, or BT.2020. Skipping for Roku-safe SDR rule. \n';
+    return response;
+  }
+
+  const videoEncoder = lower(inputs.video_encoder || 'hevc_qsv');
+  const targetVideoBitrate = toInt(inputs.target_video_bitrate_kbps, 20000);
+  const maxVideoBitrate = toInt(inputs.max_video_bitrate_kbps, 25000);
+  const allowUnknownBitrate = yes(inputs.allow_unknown_bitrate);
+  const aacBitrate = toInt(inputs.aac_bitrate_kbps, 192);
+  const ac3Bitrate = toInt(inputs.ac3_bitrate_kbps, 640);
+
+  if (!['hevc_qsv', 'libx265'].includes(videoEncoder)) {
+    response.infoLog += `Unsupported video_encoder '${inputs.video_encoder}'. Use hevc_qsv or libx265. Skipping. \n`;
+    return response;
+  }
+
+  const currentVideoBitrate = bitrateKbps(file, video);
+  const container = lower(file.container || get(file, 'ffProbeData.format.format_name', ''));
+  const videoCodec = lower(video.codec_name);
+  const videoProfile = lower(video.profile);
+
+  const mp4Container = container.includes('mp4') || container.includes('mov') || container.includes('m4a');
+  const safeVideoCodec = videoCodec === 'hevc' && (videoProfile === '' || videoProfile.includes('main')) && !videoProfile.includes('10');
+  const copyVideo = safeVideoCodec
+    && ((currentVideoBitrate > 0 && currentVideoBitrate <= maxVideoBitrate) || allowUnknownBitrate);
+  const safeAudio = hasSafeAudio(streams);
+
+  if (safeVideoCodec && currentVideoBitrate === 0 && !allowUnknownBitrate) {
+    response.infoLog += 'Video bitrate is unknown. Skipping copy-only SDR path by default. \n';
+    return response;
+  }
+
+  if (mp4Container && copyVideo && safeAudio) {
+    response.infoLog += 'Already matches Roku-safe 4K SDR MP4 rule. Skipping. \n';
+    return response;
+  }
+
+  const bestAudio = findBestAudio(streams, false);
+  if (!bestAudio) {
+    response.infoLog += 'No preferred-language audio stream found. Skipping. \n';
+    return response;
+  }
+
+  const bestSixAudio = findBestAudio(streams, true);
+  const audioMaps = [`-map 0:${bestAudio.index}`];
+  const audioOptions = [
+    `-c:a:0 aac -ac:a:0 2 -b:a:0 ${aacBitrate}k`,
+  ];
+
+  if (bestSixAudio) {
+    audioMaps.push(`-map 0:${bestSixAudio.index}`);
+    audioOptions.push(`-c:a:1 ac3 -ac:a:1 6 -b:a:1 ${ac3Bitrate}k`);
+  }
+
+  let videoOptions = '-map 0:v:0 -c:v copy -tag:v hvc1';
+  if (!copyVideo) {
+    const maxrate = Math.max(targetVideoBitrate, maxVideoBitrate);
+    const bufsize = Math.max(maxrate * 2, 40000);
+    if (videoEncoder === 'hevc_qsv') {
+      videoOptions = '-map 0:v:0 -c:v hevc_qsv -load_plugin hevc_hw -profile:v main '
+        + `-b:v ${targetVideoBitrate}k -maxrate ${maxrate}k -bufsize ${bufsize}k -tag:v hvc1`;
+    } else {
+      videoOptions = '-map 0:v:0 -c:v libx265 -preset medium -pix_fmt yuv420p -profile:v main '
+        + `-b:v ${targetVideoBitrate}k -maxrate ${maxrate}k -bufsize ${bufsize}k -tag:v hvc1`;
+    }
+  }
+
+  response.preset = `, -map_metadata -1 -map_chapters -1 ${videoOptions} `
+    + `${audioMaps.join(' ')} -sn -dn ${audioOptions.join(' ')} `
+    + '-movflags +faststart -avoid_negative_ts make_zero ';
+
+  response.processFile = true;
+  response.infoLog += 'Applying Roku-safe 4K SDR MP4 rule. ';
+  response.infoLog += copyVideo
+    ? `Copying HEVC Main SDR video at ${currentVideoBitrate || 'unknown'} kbps. `
+    : `Encoding video to HEVC Main SDR with ${videoEncoder} at ${targetVideoBitrate} kbps. `;
+  response.infoLog += bestSixAudio
+    ? 'Creating AAC stereo fallback and AC3 5.1 tracks. '
+    : 'Creating AAC stereo fallback only; no 6+ channel source audio found. ';
+  response.infoLog += 'Subtitles omitted in first validated Roku-safe rule. ';
+
+  return response;
+};
+
+module.exports.details = details;
+module.exports.plugin = plugin;

--- a/Community/Tdarr_Plugin_STV2_Roku_Safe_4K_HDR10_MP4.js
+++ b/Community/Tdarr_Plugin_STV2_Roku_Safe_4K_HDR10_MP4.js
@@ -1,0 +1,281 @@
+/* eslint max-len: 0 */
+
+const details = () => ({
+  id: 'Tdarr_Plugin_STV2_Roku_Safe_4K_HDR10_MP4',
+  Stage: 'Pre-processing',
+  Name: 'Roku Safe 4K HDR10 MP4',
+  Type: 'Video',
+  Operation: 'Transcode',
+  Description: 'Conservatively standardize validated 4K HDR10 media for Roku/Jellyfin direct play: MP4/HVC1, copied HEVC Main10 HDR10 video, AAC stereo fallback, optional AC3 5.1 when the source supports it. Dolby Vision, HDR10+, HLG, non-HEVC video, and high/unknown bitrate sources are skipped by default.',
+  Version: '1.0.0',
+  Tags: 'pre-processing,ffmpeg,video,4k,roku,mp4,hevc,hdr,hdr10',
+  Inputs: [
+    {
+      name: 'max_video_bitrate_kbps',
+      type: 'string',
+      defaultValue: '25000',
+      inputUI: { type: 'text' },
+      tooltip: 'Maximum video bitrate in kbps for copy-only HDR10 processing. Higher bitrate or unknown bitrate files are skipped in v1.',
+    },
+    {
+      name: 'allow_unknown_bitrate',
+      type: 'string',
+      defaultValue: 'no',
+      inputUI: {
+        type: 'dropdown',
+        options: [
+          'no',
+          'yes',
+        ],
+      },
+      tooltip: 'Set to yes to allow copy-only processing when ffprobe/Tdarr does not expose a video or format bitrate. Default no is safer for Roku direct play.',
+    },
+    {
+      name: 'aac_bitrate_kbps',
+      type: 'string',
+      defaultValue: '192',
+      inputUI: { type: 'text' },
+      tooltip: 'AAC stereo fallback bitrate.',
+    },
+    {
+      name: 'ac3_bitrate_kbps',
+      type: 'string',
+      defaultValue: '640',
+      inputUI: { type: 'text' },
+      tooltip: 'AC3 5.1 bitrate when the source has a 6+ channel audio stream.',
+    },
+  ],
+});
+
+const get = (obj, path, fallback = undefined) => path
+  .split('.')
+  .reduce((acc, key) => (acc && acc[key] !== undefined ? acc[key] : undefined), obj) ?? fallback;
+
+const lower = (value) => String(value || '').toLowerCase();
+
+const toInt = (value, fallback) => {
+  const parsed = parseInt(value, 10);
+  return Number.isFinite(parsed) ? parsed : fallback;
+};
+
+const yes = (value) => ['1', 'true', 'yes', 'y'].includes(lower(value));
+
+const streamLang = (stream) => lower(get(stream, 'tags.language', 'und'));
+
+const isPreferredLanguage = (stream) => {
+  const lang = streamLang(stream);
+  return lang === 'eng' || lang === 'und' || lang === '';
+};
+
+const is4k = (video) => (video.width || 0) >= 3840 || (video.height || 0) >= 2160;
+
+const textForPathRules = (file) => lower(`${file.file || ''} ${file.fileNameWithoutExtension || ''} ${file.originalFile || ''}`);
+
+const pathHasUnsupportedHdrMarkers = (file) => {
+  const text = textForPathRules(file);
+  return /(^|[ ._\-[({])(?:dv|dovi|dolby[ ._-]?vision|hdr10\+|hdr10plus|hdr10p|hlg)(?=$|[ ._\-\])}])/.test(text);
+};
+
+const pathHasHdr10Marker = (file) => {
+  const text = textForPathRules(file);
+  return /(^|[ ._\-[({])hdr10(?=$|[ ._\-\])}])/.test(text)
+    || /(^|[ ._\-[({])hdr(?=$|[ ._\-\])}])/.test(text);
+};
+
+const pathHasTenBitMarker = (file) => {
+  const text = textForPathRules(file);
+  return /(^|[ ._\-[({])(?:10bit|10-bit|main10|main[ ._-]?10)(?=$|[ ._\-\])}])/.test(text);
+};
+
+const sideDataText = (video) => JSON.stringify(video.side_data_list || '').toLowerCase();
+
+const hasUnsupportedHdrSideData = (video) => {
+  const sideData = sideDataText(video);
+  return sideData.includes('dovi')
+    || sideData.includes('dolby vision')
+    || sideData.includes('hdr10+')
+    || sideData.includes('smpte 2094')
+    || sideData.includes('dynamic hdr');
+};
+
+const hasUnsupportedHdrMetadata = (video) => lower(video.color_transfer) === 'arib-std-b67'
+  || hasUnsupportedHdrSideData(video);
+
+const isHdr10 = (file, video) => {
+  const profile = lower(video.profile);
+  const pixFmt = lower(video.pix_fmt);
+  const colorTransfer = lower(video.color_transfer);
+  const colorPrimaries = lower(video.color_primaries);
+  const colorSpace = lower(video.color_space);
+
+  const main10 = profile.includes('main 10')
+    || profile.includes('main10')
+    || pixFmt.includes('10')
+    || pixFmt.includes('p010');
+
+  const pq = colorTransfer === 'smpte2084';
+  const bt2020 = colorPrimaries === 'bt2020' || colorSpace === 'bt2020nc';
+  const streamMetadataComplete = colorTransfer !== '' || colorPrimaries !== '' || colorSpace !== '' || pixFmt !== '';
+  const explicitPathFallback = !streamMetadataComplete && pathHasHdr10Marker(file) && pathHasTenBitMarker(file);
+
+  return (main10 || explicitPathFallback)
+    && ((pq && bt2020) || explicitPathFallback)
+    && !pathHasUnsupportedHdrMarkers(file)
+    && !hasUnsupportedHdrMetadata(video);
+};
+
+const bitrateKbps = (file, video) => {
+  const streamBitrate = parseInt(video.bit_rate || 0, 10);
+  if (streamBitrate > 0) {
+    return Math.round(streamBitrate / 1000);
+  }
+
+  const formatBitrate = parseInt(get(file, 'ffProbeData.format.bit_rate', 0), 10);
+  if (formatBitrate > 0) {
+    return Math.round(formatBitrate / 1000);
+  }
+
+  const tdarrBitrate = parseInt(file.bit_rate || 0, 10);
+  if (tdarrBitrate > 0) {
+    return Math.round(tdarrBitrate / 1000);
+  }
+
+  return 0;
+};
+
+const findBestAudio = (streams, requireSixPlus) => {
+  const audio = streams
+    .map((stream, index) => ({ stream, index }))
+    .filter(({ stream }) => lower(stream.codec_type) === 'audio')
+    .filter(({ stream }) => isPreferredLanguage(stream));
+
+  const candidates = requireSixPlus
+    ? audio.filter(({ stream }) => (stream.channels || 0) >= 6)
+    : audio;
+
+  const sorted = candidates.sort((a, b) => (b.stream.channels || 0) - (a.stream.channels || 0));
+  return sorted.length > 0 ? sorted[0] : null;
+};
+
+const hasSafeAudio = (streams) => {
+  const audio = streams.filter((stream) => lower(stream.codec_type) === 'audio');
+  const hasAacStereo = audio.some((stream) => lower(stream.codec_name) === 'aac' && stream.channels === 2);
+  const hasSixPlusSource = audio.some((stream) => (stream.channels || 0) >= 6);
+  const hasAc3Six = audio.some((stream) => lower(stream.codec_name) === 'ac3' && (stream.channels || 0) >= 6);
+  const onlySafeCodecs = audio.every((stream) => ['aac', 'ac3'].includes(lower(stream.codec_name)));
+
+  return hasAacStereo && onlySafeCodecs && (!hasSixPlusSource || hasAc3Six);
+};
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const plugin = (file, librarySettings, inputs, otherArguments) => {
+  const lib = require('../methods/lib')();
+  // eslint-disable-next-line no-param-reassign
+  inputs = lib.loadDefaultValues(inputs, details);
+
+  const response = {
+    container: '.mp4',
+    processFile: false,
+    preset: '',
+    handBrakeMode: false,
+    FFmpegMode: true,
+    reQueueAfter: true,
+    infoLog: '',
+  };
+
+  if (file.fileMedium !== 'video') {
+    response.infoLog += 'Not a video file. Skipping. \n';
+    return response;
+  }
+
+  const streams = get(file, 'ffProbeData.streams', []);
+  const video = streams.find((stream) => lower(stream.codec_type) === 'video'
+    && !['mjpeg', 'png'].includes(lower(stream.codec_name)));
+
+  if (!video) {
+    response.infoLog += 'No primary video stream found. Skipping. \n';
+    return response;
+  }
+
+  if (!is4k(video)) {
+    response.infoLog += `Not 4K (${video.width || '?'}x${video.height || '?'}). Skipping. \n`;
+    return response;
+  }
+
+  if (lower(video.codec_name) !== 'hevc') {
+    response.infoLog += '4K HDR10 rule is copy-only for HEVC video in v1. Skipping non-HEVC source. \n';
+    return response;
+  }
+
+  if (pathHasUnsupportedHdrMarkers(file) || hasUnsupportedHdrMetadata(video)) {
+    response.infoLog += 'Dolby Vision, HDR10+, HLG, or dynamic HDR marker detected. Skipping conservative HDR10-only rule. \n';
+    return response;
+  }
+
+  if (!isHdr10(file, video)) {
+    response.infoLog += pathHasHdr10Marker(file)
+      ? 'Path suggests HDR10, but stream metadata is incomplete for BT.2020/PQ Main10. Skipping rather than guessing. \n'
+      : 'Not a validated HDR10 Main10 BT.2020/PQ source. Skipping. \n';
+    return response;
+  }
+
+  const maxVideoBitrate = toInt(inputs.max_video_bitrate_kbps, 25000);
+  const allowUnknownBitrate = yes(inputs.allow_unknown_bitrate);
+  const aacBitrate = toInt(inputs.aac_bitrate_kbps, 192);
+  const ac3Bitrate = toInt(inputs.ac3_bitrate_kbps, 640);
+
+  const currentVideoBitrate = bitrateKbps(file, video);
+  if (currentVideoBitrate === 0 && !allowUnknownBitrate) {
+    response.infoLog += 'Video bitrate is unknown. Skipping by default for Roku-safe HDR10 rule. \n';
+    return response;
+  }
+
+  if (currentVideoBitrate > maxVideoBitrate) {
+    response.infoLog += `HDR10 video bitrate ${currentVideoBitrate} kbps exceeds max ${maxVideoBitrate} kbps. Skipping copy-only v1 rule. \n`;
+    return response;
+  }
+
+  const container = lower(file.container || get(file, 'ffProbeData.format.format_name', ''));
+  const mp4Container = container.includes('mp4') || container.includes('mov') || container.includes('m4a');
+  const safeAudio = hasSafeAudio(streams);
+
+  if (mp4Container && safeAudio) {
+    response.infoLog += 'Already matches Roku-safe 4K HDR10 MP4 rule. Skipping. \n';
+    return response;
+  }
+
+  const bestAudio = findBestAudio(streams, false);
+  if (!bestAudio) {
+    response.infoLog += 'No preferred-language audio stream found. Skipping. \n';
+    return response;
+  }
+
+  const bestSixAudio = findBestAudio(streams, true);
+  const audioMaps = [`-map 0:${bestAudio.index}`];
+  const audioOptions = [
+    `-c:a:0 aac -ac:a:0 2 -b:a:0 ${aacBitrate}k`,
+  ];
+
+  if (bestSixAudio) {
+    audioMaps.push(`-map 0:${bestSixAudio.index}`);
+    audioOptions.push(`-c:a:1 ac3 -ac:a:1 6 -b:a:1 ${ac3Bitrate}k`);
+  }
+
+  response.preset = ', -map_metadata -1 -map_chapters -1 '
+    + '-map 0:v:0 -c:v copy -tag:v hvc1 '
+    + `${audioMaps.join(' ')} -sn -dn ${audioOptions.join(' ')} `
+    + '-movflags +faststart -avoid_negative_ts make_zero ';
+
+  response.processFile = true;
+  response.infoLog += 'Applying Roku-safe 4K HDR10 MP4 rule. ';
+  response.infoLog += `Copying HEVC Main10 HDR10 video at ${currentVideoBitrate || 'unknown'} kbps. `;
+  response.infoLog += bestSixAudio
+    ? 'Creating AAC stereo fallback and AC3 5.1 tracks. '
+    : 'Creating AAC stereo fallback only; no 6+ channel source audio found. ';
+  response.infoLog += 'Subtitles omitted in first validated Roku-safe HDR10 rule. ';
+
+  return response;
+};
+
+module.exports.details = details;
+module.exports.plugin = plugin;

--- a/tests/Community/Tdarr_Plugin_STV1_Roku_Safe_4K_SDR_MP4.js
+++ b/tests/Community/Tdarr_Plugin_STV1_Roku_Safe_4K_SDR_MP4.js
@@ -1,0 +1,196 @@
+/* eslint max-len: 0 */
+const run = require('../helpers/run');
+
+const baseFile = {
+  fileMedium: 'video',
+  container: 'mkv',
+  file: '/media/movie-4k-sdr.mkv',
+  bit_rate: 12000000,
+  ffProbeData: {
+    streams: [
+      {
+        codec_type: 'video',
+        codec_name: 'hevc',
+        profile: 'Main',
+        width: 3840,
+        height: 2160,
+        bit_rate: '11000000',
+      },
+      {
+        codec_type: 'audio',
+        codec_name: 'eac3',
+        channels: 6,
+        tags: { language: 'eng' },
+      },
+    ],
+    format: {},
+  },
+};
+
+const tests = [
+  {
+    input: {
+      file: baseFile,
+      librarySettings: {},
+      inputs: {},
+      otherArguments: {},
+    },
+    output: {
+      container: '.mp4',
+      processFile: true,
+      preset: ', -map_metadata -1 -map_chapters -1 -map 0:v:0 -c:v copy -tag:v hvc1 -map 0:1 -map 0:1 -sn -dn -c:a:0 aac -ac:a:0 2 -b:a:0 192k -c:a:1 ac3 -ac:a:1 6 -b:a:1 640k -movflags +faststart -avoid_negative_ts make_zero ',
+      handBrakeMode: false,
+      FFmpegMode: true,
+      reQueueAfter: true,
+      infoLog: 'Applying Roku-safe 4K SDR MP4 rule. Copying HEVC Main SDR video at 11000 kbps. Creating AAC stereo fallback and AC3 5.1 tracks. Subtitles omitted in first validated Roku-safe rule. ',
+    },
+  },
+  {
+    input: {
+      file: {
+        ...baseFile,
+        file: '/media/movie-4k-hdr10.mkv',
+        ffProbeData: {
+          streams: [
+            {
+              codec_type: 'video',
+              codec_name: 'hevc',
+              profile: 'Main 10',
+              width: 3840,
+              height: 2160,
+              pix_fmt: 'yuv420p10le',
+              color_transfer: 'smpte2084',
+              color_primaries: 'bt2020',
+            },
+          ],
+        },
+      },
+      librarySettings: {},
+      inputs: {},
+      otherArguments: {},
+    },
+    output: {
+      container: '.mp4',
+      processFile: false,
+      preset: '',
+      handBrakeMode: false,
+      FFmpegMode: true,
+      reQueueAfter: true,
+      infoLog: '4K file is HDR, Main10, HLG, Dolby Vision, or BT.2020. Skipping for Roku-safe SDR rule. \n',
+    },
+  },
+  {
+    input: {
+      file: {
+        ...baseFile,
+        bit_rate: 0,
+        ffProbeData: {
+          streams: [
+            {
+              codec_type: 'video',
+              codec_name: 'hevc',
+              profile: 'Main',
+              width: 3840,
+              height: 2160,
+            },
+          ],
+          format: {},
+        },
+      },
+      librarySettings: {},
+      inputs: {},
+      otherArguments: {},
+    },
+    output: {
+      container: '.mp4',
+      processFile: false,
+      preset: '',
+      handBrakeMode: false,
+      FFmpegMode: true,
+      reQueueAfter: true,
+      infoLog: 'Video bitrate is unknown. Skipping copy-only SDR path by default. \n',
+    },
+  },
+  {
+    input: {
+      file: {
+        ...baseFile,
+        file: '/media/movie-4k-sdr-h264.mkv',
+        ffProbeData: {
+          streams: [
+            {
+              codec_type: 'video',
+              codec_name: 'h264',
+              profile: 'High',
+              width: 3840,
+              height: 2160,
+              bit_rate: '30000000',
+            },
+            {
+              codec_type: 'audio',
+              codec_name: 'aac',
+              channels: 2,
+              tags: { language: 'eng' },
+            },
+          ],
+          format: {},
+        },
+      },
+      librarySettings: {},
+      inputs: {
+        video_encoder: 'libx265',
+      },
+      otherArguments: {},
+    },
+    output: {
+      container: '.mp4',
+      processFile: true,
+      preset: ', -map_metadata -1 -map_chapters -1 -map 0:v:0 -c:v libx265 -preset medium -pix_fmt yuv420p -profile:v main -b:v 20000k -maxrate 25000k -bufsize 50000k -tag:v hvc1 -map 0:1 -sn -dn -c:a:0 aac -ac:a:0 2 -b:a:0 192k -movflags +faststart -avoid_negative_ts make_zero ',
+      handBrakeMode: false,
+      FFmpegMode: true,
+      reQueueAfter: true,
+      infoLog: 'Applying Roku-safe 4K SDR MP4 rule. Encoding video to HEVC Main SDR with libx265 at 20000 kbps. Creating AAC stereo fallback only; no 6+ channel source audio found. Subtitles omitted in first validated Roku-safe rule. ',
+    },
+  },
+  {
+    input: {
+      file: baseFile,
+      librarySettings: {},
+      inputs: {
+        video_encoder: 'vp9',
+      },
+      otherArguments: {},
+    },
+    output: {
+      container: '.mp4',
+      processFile: false,
+      preset: '',
+      handBrakeMode: false,
+      FFmpegMode: true,
+      reQueueAfter: true,
+      infoLog: "Unsupported video_encoder 'vp9'. Use hevc_qsv or libx265. Skipping. \n",
+    },
+  },
+  {
+    input: {
+      file: {
+        ...baseFile,
+        file: '/media/movie.2160p.HDR10+.10bit.HEVC.mkv',
+      },
+      librarySettings: {},
+      inputs: {},
+      otherArguments: {},
+    },
+    output: {
+      container: '.mp4',
+      processFile: false,
+      preset: '',
+      handBrakeMode: false,
+      FFmpegMode: true,
+      reQueueAfter: true,
+      infoLog: '4K file is HDR, Main10, HLG, Dolby Vision, or BT.2020. Skipping for Roku-safe SDR rule. \n',
+    },
+  },
+];
+
+void run(tests);

--- a/tests/Community/Tdarr_Plugin_STV2_Roku_Safe_4K_HDR10_MP4.js
+++ b/tests/Community/Tdarr_Plugin_STV2_Roku_Safe_4K_HDR10_MP4.js
@@ -1,0 +1,197 @@
+/* eslint max-len: 0 */
+const run = require('../helpers/run');
+
+const hdr10File = {
+  fileMedium: 'video',
+  container: 'mkv',
+  file: '/media/The.Matrix.1999.2160p.Bluray.HDR10.10bit.x265.HEVC.mkv',
+  bit_rate: 9526301,
+  ffProbeData: {
+    streams: [
+      {
+        codec_type: 'video',
+        codec_name: 'hevc',
+        profile: '',
+        width: 3840,
+        height: 1600,
+      },
+      {
+        codec_type: 'audio',
+        codec_name: 'truehd',
+        channels: 8,
+        tags: { language: 'eng' },
+      },
+    ],
+    format: {},
+  },
+};
+
+const tests = [
+  {
+    input: {
+      file: hdr10File,
+      librarySettings: {},
+      inputs: {},
+      otherArguments: {},
+    },
+    output: {
+      container: '.mp4',
+      processFile: true,
+      preset: ', -map_metadata -1 -map_chapters -1 -map 0:v:0 -c:v copy -tag:v hvc1 -map 0:1 -map 0:1 -sn -dn -c:a:0 aac -ac:a:0 2 -b:a:0 192k -c:a:1 ac3 -ac:a:1 6 -b:a:1 640k -movflags +faststart -avoid_negative_ts make_zero ',
+      handBrakeMode: false,
+      FFmpegMode: true,
+      reQueueAfter: true,
+      infoLog: 'Applying Roku-safe 4K HDR10 MP4 rule. Copying HEVC Main10 HDR10 video at 9526 kbps. Creating AAC stereo fallback and AC3 5.1 tracks. Subtitles omitted in first validated Roku-safe HDR10 rule. ',
+    },
+  },
+  {
+    input: {
+      file: {
+        ...hdr10File,
+        file: '/media/movie.2160p.HDR10+.10bit.HEVC.mkv',
+      },
+      librarySettings: {},
+      inputs: {},
+      otherArguments: {},
+    },
+    output: {
+      container: '.mp4',
+      processFile: false,
+      preset: '',
+      handBrakeMode: false,
+      FFmpegMode: true,
+      reQueueAfter: true,
+      infoLog: 'Dolby Vision, HDR10+, HLG, or dynamic HDR marker detected. Skipping conservative HDR10-only rule. \n',
+    },
+  },
+  {
+    input: {
+      file: {
+        ...hdr10File,
+        file: '/media/movie.2160p.HDR.HEVC.mkv',
+      },
+      librarySettings: {},
+      inputs: {},
+      otherArguments: {},
+    },
+    output: {
+      container: '.mp4',
+      processFile: false,
+      preset: '',
+      handBrakeMode: false,
+      FFmpegMode: true,
+      reQueueAfter: true,
+      infoLog: 'Path suggests HDR10, but stream metadata is incomplete for BT.2020/PQ Main10. Skipping rather than guessing. \n',
+    },
+  },
+  {
+    input: {
+      file: {
+        ...hdr10File,
+        ffProbeData: {
+          streams: [
+            {
+              codec_type: 'video',
+              codec_name: 'hevc',
+              profile: 'Main 10',
+              width: 3840,
+              height: 1600,
+              pix_fmt: 'yuv420p10le',
+              color_transfer: 'smpte2084',
+              color_primaries: 'bt2020',
+              side_data_list: [
+                { side_data_type: 'DOVI configuration record' },
+              ],
+            },
+          ],
+          format: {},
+        },
+      },
+      librarySettings: {},
+      inputs: {},
+      otherArguments: {},
+    },
+    output: {
+      container: '.mp4',
+      processFile: false,
+      preset: '',
+      handBrakeMode: false,
+      FFmpegMode: true,
+      reQueueAfter: true,
+      infoLog: 'Dolby Vision, HDR10+, HLG, or dynamic HDR marker detected. Skipping conservative HDR10-only rule. \n',
+    },
+  },
+  {
+    input: {
+      file: {
+        ...hdr10File,
+        ffProbeData: {
+          streams: [
+            {
+              codec_type: 'video',
+              codec_name: 'hevc',
+              profile: 'Main 10',
+              width: 3840,
+              height: 1600,
+              pix_fmt: 'yuv420p10le',
+              color_transfer: 'smpte2084',
+              color_primaries: 'bt2020',
+              side_data_list: [
+                { side_data_type: 'HDR10+ metadata' },
+              ],
+            },
+          ],
+          format: {},
+        },
+      },
+      librarySettings: {},
+      inputs: {},
+      otherArguments: {},
+    },
+    output: {
+      container: '.mp4',
+      processFile: false,
+      preset: '',
+      handBrakeMode: false,
+      FFmpegMode: true,
+      reQueueAfter: true,
+      infoLog: 'Dolby Vision, HDR10+, HLG, or dynamic HDR marker detected. Skipping conservative HDR10-only rule. \n',
+    },
+  },
+  {
+    input: {
+      file: {
+        ...hdr10File,
+        ffProbeData: {
+          streams: [
+            {
+              codec_type: 'video',
+              codec_name: 'hevc',
+              profile: 'Main 10',
+              width: 3840,
+              height: 1600,
+              pix_fmt: 'yuv420p10le',
+              color_transfer: 'arib-std-b67',
+              color_primaries: 'bt2020',
+            },
+          ],
+          format: {},
+        },
+      },
+      librarySettings: {},
+      inputs: {},
+      otherArguments: {},
+    },
+    output: {
+      container: '.mp4',
+      processFile: false,
+      preset: '',
+      handBrakeMode: false,
+      FFmpegMode: true,
+      reQueueAfter: true,
+      infoLog: 'Dolby Vision, HDR10+, HLG, or dynamic HDR marker detected. Skipping conservative HDR10-only rule. \n',
+    },
+  },
+];
+
+void run(tests);


### PR DESCRIPTION
## Summary

Adds two conservative Roku-safe 4K community plugins:

- `Tdarr_Plugin_STV1_Roku_Safe_4K_SDR_MP4`
- `Tdarr_Plugin_STV2_Roku_Safe_4K_HDR10_MP4`

These target Jellyfin/Roku direct-play friendly MP4/HVC1 output shapes for 4K SDR and validated HDR10 sources.

Credit: developed and locally validated by Team HH.

## Behavior

- SDR plugin handles 4K SDR / 8-bit sources, outputting MP4/HVC1 HEVC Main SDR with AAC stereo and optional AC3 5.1.
- SDR plugin supports `hevc_qsv` by default and `libx265` as a CPU fallback.
- HDR10 plugin handles validated 4K HEVC Main10 HDR10 sources only.
- HDR10 plugin is video-copy only in v1 to preserve HDR metadata and avoid unvalidated HDR re-encoding or tone mapping.
- Both plugins intentionally skip ambiguous or higher-risk cases by default.

## Explicit skips / non-goals

- Dolby Vision
- HDR10+
- HLG
- generic/dynamic HDR markers
- image subtitle handling or burn-in
- broad HDR tone mapping
- universal compatibility across every Roku model, display, receiver, and app combination

## Validation

Ran in a fresh upstream clone:

```bash
npm run checkPlugins
node tests/Community/Tdarr_Plugin_STV1_Roku_Safe_4K_SDR_MP4.js
node tests/Community/Tdarr_Plugin_STV2_Roku_Safe_4K_HDR10_MP4.js
npx eslint Community/Tdarr_Plugin_STV1_Roku_Safe_4K_SDR_MP4.js Community/Tdarr_Plugin_STV2_Roku_Safe_4K_HDR10_MP4.js tests/Community/Tdarr_Plugin_STV1_Roku_Safe_4K_SDR_MP4.js tests/Community/Tdarr_Plugin_STV2_Roku_Safe_4K_HDR10_MP4.js
npm test
```

All passed.

## Notes

The `STV1` / `STV2` IDs are intended as the submitted community plugin IDs. Happy to rename if the project prefers a different contributor prefix.
