### PR TITLE
fix: update ensured audio stream metadata

### DIFF
--- a/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandEnsureAudioStream/1.0.0/index.js
+++ b/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandEnsureAudioStream/1.0.0/index.js
@@ -1,4 +1,15 @@
 "use strict";
+var __assign = (this && this.__assign) || function () {
+    __assign = Object.assign || function(t) {
+        for (var s, i = 1, n = arguments.length; i < n; i++) {
+            s = arguments[i];
+            for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+                t[p] = s[p];
+        }
+        return t;
+    };
+    return __assign.apply(this, arguments);
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.plugin = exports.details = void 0;
 var fileUtils_1 = require("../../../../FlowHelpers/1.0.0/fileUtils");
@@ -151,12 +162,58 @@ var getHighest = function (first, second) {
     }
     return second;
 };
+var audioCodecNames = {
+    dca: 'dts',
+    libopus: 'opus',
+    libmp3lame: 'mp3',
+};
+var audioTrackTitles = {
+    libopus: 'Opus',
+    truehd: 'TrueHD',
+};
+var channelTitles = {
+    1: '1.0',
+    2: '2.0',
+    6: '5.1',
+    8: '7.1',
+};
+var channelLayouts = {
+    1: 'mono',
+    2: 'stereo',
+    6: '5.1',
+    8: '7.1',
+};
+var getAudioCodecName = function (audioEncoder) { return audioCodecNames[audioEncoder] || audioEncoder; };
+var getTrackTitle = function (audioEncoder, channels) { return ("".concat(audioTrackTitles[audioEncoder] || getAudioCodecName(audioEncoder).toUpperCase())
+    + " ".concat(channelTitles[channels] || "".concat(channels, " channels"))); };
+var codecTitlePrefix = new RegExp('^(?:dts(?:-?hd)?|e-?ac-?3|ac-?3|aac|dca|flac|opus|mp2|mp3|truehd)'
+    + '(?:\\s+(?:hd|ma|hra|master audio|atmos))*'
+    + '(?:\\s+\\d(?:\\.\\d)?(?:\\s*channels?)?)?(?=$|\\s)', 'i');
+var getOutputTrackTitle = function (sourceTitle, audioEncoder, channels) {
+    var trackTitle = getTrackTitle(audioEncoder, channels);
+    var trimmedTitle = sourceTitle === null || sourceTitle === void 0 ? void 0 : sourceTitle.trim();
+    if (!trimmedTitle) {
+        return trackTitle;
+    }
+    return trimmedTitle.replace(codecTitlePrefix, trackTitle).trim();
+};
+var parseRate = function (rate) {
+    var normalizedRate = rate.trim().toLowerCase();
+    var rateMatch = normalizedRate.match(/^(\d+(?:\.\d+)?)(k?)$/);
+    if (!rateMatch) {
+        return undefined;
+    }
+    var multiplier = rateMatch[2] === 'k' ? 1000 : 1;
+    return Math.round(Number(rateMatch[1]) * multiplier);
+};
 var attemptMakeStream = function (_a) {
-    var args = _a.args, langTag = _a.langTag, streams = _a.streams, audioCodec = _a.audioCodec, audioEncoder = _a.audioEncoder, wantedChannelCount = _a.wantedChannelCount;
+    var _b;
+    var args = _a.args, langTag = _a.langTag, streams = _a.streams, audioEncoder = _a.audioEncoder, wantedChannelCount = _a.wantedChannelCount;
     var enableBitrate = Boolean(args.inputs.enableBitrate);
     var bitrate = String(args.inputs.bitrate);
     var enableSamplerate = Boolean(args.inputs.enableSamplerate);
     var samplerate = String(args.inputs.samplerate);
+    var audioCodecName = getAudioCodecName(audioEncoder);
     var langMatch = function (stream) {
         var _a;
         return ((langTag === 'und'
@@ -164,13 +221,7 @@ var attemptMakeStream = function (_a) {
             || (((_a = stream === null || stream === void 0 ? void 0 : stream.tags) === null || _a === void 0 ? void 0 : _a.language) && stream.tags.language.toLowerCase().includes(langTag)));
     };
     // filter streams to only include audio streams with the specified lang tag
-    var streamsWithLangTag = streams.filter(function (stream) {
-        if (stream.codec_type === 'audio'
-            && langMatch(stream)) {
-            return true;
-        }
-        return false;
-    });
+    var streamsWithLangTag = streams.filter(function (stream) { return stream.codec_type === 'audio' && langMatch(stream); });
     if (streamsWithLangTag.length === 0) {
         args.jobLog("No streams with language tag ".concat(langTag, " found. Skipping \n"));
         return false;
@@ -189,16 +240,11 @@ var attemptMakeStream = function (_a) {
         args.jobLog("The wanted channel count ".concat(wantedChannelCount, " is higher than the")
             + " highest available channel count (".concat(streamWithHighestChannel.channels, "). \n"));
     }
-    var hasStreamAlready = streams.filter(function (stream) {
-        if (stream.codec_type === 'audio'
-            && langMatch(stream)
-            && stream.codec_name === audioCodec
-            && stream.channels === targetChannels) {
-            return true;
-        }
-        return false;
-    });
-    if (hasStreamAlready.length > 0) {
+    var hasStreamAlready = streams.some(function (stream) { return (stream.codec_type === 'audio'
+        && langMatch(stream)
+        && stream.codec_name === audioCodecName
+        && stream.channels === targetChannels); });
+    if (hasStreamAlready) {
         args.jobLog("File already has ".concat(langTag, " stream in ").concat(audioEncoder, ", ").concat(targetChannels, " channels \n"));
         return true;
     }
@@ -207,16 +253,35 @@ var attemptMakeStream = function (_a) {
     streamCopy.removed = false;
     streamCopy.index = streams.length;
     // Keep planned stream metadata aligned for subsequent command plugins.
-    streamCopy.codec_name = audioCodec;
+    var trackTitle = getOutputTrackTitle((_b = streamCopy.tags) === null || _b === void 0 ? void 0 : _b.title, audioEncoder, targetChannels);
+    streamCopy.codec_name = audioCodecName;
     streamCopy.channels = targetChannels;
+    if (channelLayouts[targetChannels]) {
+        streamCopy.channel_layout = channelLayouts[targetChannels];
+    }
+    else {
+        delete streamCopy.channel_layout;
+    }
+    streamCopy.tags = __assign(__assign({}, (streamCopy.tags || {})), { title: trackTitle });
+    delete streamCopy.codec_long_name;
+    delete streamCopy.profile;
     streamCopy.outputArgs.push('-c:{outputIndex}', audioEncoder);
     streamCopy.outputArgs.push('-ac', "".concat(targetChannels));
+    streamCopy.outputArgs.push('-metadata:s:a:{outputTypeIndex}', "title=".concat(trackTitle));
     if (enableBitrate) {
         var ffType = (0, fileUtils_1.getFfType)(streamCopy.codec_type);
         streamCopy.outputArgs.push("-b:".concat(ffType, ":{outputTypeIndex}"), "".concat(bitrate));
+        var parsedBitrate = parseRate(bitrate);
+        if (parsedBitrate !== undefined) {
+            streamCopy.bit_rate = parsedBitrate;
+        }
     }
     if (enableSamplerate) {
         streamCopy.outputArgs.push('-ar', "".concat(samplerate));
+        var parsedSamplerate = parseRate(samplerate);
+        if (parsedSamplerate !== undefined) {
+            streamCopy.sample_rate = String(parsedSamplerate);
+        }
     }
     // eslint-disable-next-line no-param-reassign
     args.variables.ffmpegCommand.shouldProcess = true;
@@ -233,21 +298,10 @@ var plugin = function (args) {
     var langTag = String(args.inputs.language).toLowerCase();
     var wantedChannelCount = Number(args.inputs.channels);
     var streams = args.variables.ffmpegCommand.streams;
-    var audioCodec = audioEncoder;
-    if (audioEncoder === 'dca') {
-        audioCodec = 'dts';
-    }
-    if (audioEncoder === 'libmp3lame') {
-        audioCodec = 'mp3';
-    }
-    if (audioEncoder === 'libopus') {
-        audioCodec = 'opus';
-    }
     var addedOrExists = attemptMakeStream({
         args: args,
         langTag: langTag,
         streams: streams,
-        audioCodec: audioCodec,
         audioEncoder: audioEncoder,
         wantedChannelCount: wantedChannelCount,
     });
@@ -256,7 +310,6 @@ var plugin = function (args) {
             args: args,
             langTag: 'und',
             streams: streams,
-            audioCodec: audioCodec,
             audioEncoder: audioEncoder,
             wantedChannelCount: wantedChannelCount,
         });

--- a/FlowPluginsTs/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandEnsureAudioStream/1.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandEnsureAudioStream/1.0.0/index.ts
@@ -163,18 +163,77 @@ const getHighest = (first: IffmpegCommandStream, second: IffmpegCommandStream) =
   return second;
 };
 
+const audioCodecNames: Record<string, string> = {
+  dca: 'dts',
+  libopus: 'opus',
+  libmp3lame: 'mp3',
+};
+
+const audioTrackTitles: Record<string, string> = {
+  libopus: 'Opus',
+  truehd: 'TrueHD',
+};
+
+const channelTitles: Record<number, string> = {
+  1: '1.0',
+  2: '2.0',
+  6: '5.1',
+  8: '7.1',
+};
+
+const channelLayouts: Record<number, string> = {
+  1: 'mono',
+  2: 'stereo',
+  6: '5.1',
+  8: '7.1',
+};
+
+const getAudioCodecName = (audioEncoder: string): string => audioCodecNames[audioEncoder] || audioEncoder;
+const getTrackTitle = (audioEncoder: string, channels: number): string => (
+  `${audioTrackTitles[audioEncoder] || getAudioCodecName(audioEncoder).toUpperCase()}`
+  + ` ${channelTitles[channels] || `${channels} channels`}`
+);
+
+const codecTitlePrefix = new RegExp(
+  '^(?:dts(?:-?hd)?|e-?ac-?3|ac-?3|aac|dca|flac|opus|mp2|mp3|truehd)'
+  + '(?:\\s+(?:hd|ma|hra|master audio|atmos))*'
+  + '(?:\\s+\\d(?:\\.\\d)?(?:\\s*channels?)?)?(?=$|\\s)',
+  'i',
+);
+
+const getOutputTrackTitle = (sourceTitle: string | undefined, audioEncoder: string, channels: number): string => {
+  const trackTitle = getTrackTitle(audioEncoder, channels);
+  const trimmedTitle = sourceTitle?.trim();
+
+  if (!trimmedTitle) {
+    return trackTitle;
+  }
+
+  return trimmedTitle.replace(codecTitlePrefix, trackTitle).trim();
+};
+
+const parseRate = (rate: string): number | undefined => {
+  const normalizedRate = rate.trim().toLowerCase();
+  const rateMatch = normalizedRate.match(/^(\d+(?:\.\d+)?)(k?)$/);
+
+  if (!rateMatch) {
+    return undefined;
+  }
+
+  const multiplier = rateMatch[2] === 'k' ? 1000 : 1;
+  return Math.round(Number(rateMatch[1]) * multiplier);
+};
+
 const attemptMakeStream = ({
   args,
   langTag,
   streams,
-  audioCodec,
   audioEncoder,
   wantedChannelCount,
 }: {
   args: IpluginInputArgs,
   langTag: string
   streams: IffmpegCommandStream[],
-  audioCodec: string,
   audioEncoder: string,
   wantedChannelCount: number,
 }): boolean => {
@@ -182,6 +241,7 @@ const attemptMakeStream = ({
   const bitrate = String(args.inputs.bitrate);
   const enableSamplerate = Boolean(args.inputs.enableSamplerate);
   const samplerate = String(args.inputs.samplerate);
+  const audioCodecName = getAudioCodecName(audioEncoder);
 
   const langMatch = (stream: IffmpegCommandStream) => (
     (langTag === 'und'
@@ -191,16 +251,7 @@ const attemptMakeStream = ({
   );
 
   // filter streams to only include audio streams with the specified lang tag
-  const streamsWithLangTag = streams.filter((stream) => {
-    if (
-      stream.codec_type === 'audio'
-        && langMatch(stream)
-    ) {
-      return true;
-    }
-
-    return false;
-  });
+  const streamsWithLangTag = streams.filter((stream) => stream.codec_type === 'audio' && langMatch(stream));
 
   if (streamsWithLangTag.length === 0) {
     args.jobLog(`No streams with language tag ${langTag} found. Skipping \n`);
@@ -222,20 +273,14 @@ const attemptMakeStream = ({
       + ` highest available channel count (${streamWithHighestChannel.channels}). \n`);
   }
 
-  const hasStreamAlready = streams.filter((stream) => {
-    if (
-      stream.codec_type === 'audio'
-      && langMatch(stream)
-      && stream.codec_name === audioCodec
-      && stream.channels === targetChannels
-    ) {
-      return true;
-    }
+  const hasStreamAlready = streams.some((stream) => (
+    stream.codec_type === 'audio'
+    && langMatch(stream)
+    && stream.codec_name === audioCodecName
+    && stream.channels === targetChannels
+  ));
 
-    return false;
-  });
-
-  if (hasStreamAlready.length > 0) {
+  if (hasStreamAlready) {
     args.jobLog(`File already has ${langTag} stream in ${audioEncoder}, ${targetChannels} channels \n`);
     return true;
   }
@@ -246,18 +291,39 @@ const attemptMakeStream = ({
   streamCopy.removed = false;
   streamCopy.index = streams.length;
   // Keep planned stream metadata aligned for subsequent command plugins.
-  streamCopy.codec_name = audioCodec;
+  const trackTitle = getOutputTrackTitle(streamCopy.tags?.title, audioEncoder, targetChannels);
+  streamCopy.codec_name = audioCodecName;
   streamCopy.channels = targetChannels;
+  if (channelLayouts[targetChannels]) {
+    streamCopy.channel_layout = channelLayouts[targetChannels];
+  } else {
+    delete streamCopy.channel_layout;
+  }
+  streamCopy.tags = {
+    ...(streamCopy.tags || {}),
+    title: trackTitle,
+  };
+  delete streamCopy.codec_long_name;
+  delete streamCopy.profile;
   streamCopy.outputArgs.push('-c:{outputIndex}', audioEncoder);
   streamCopy.outputArgs.push('-ac', `${targetChannels}`);
+  streamCopy.outputArgs.push('-metadata:s:a:{outputTypeIndex}', `title=${trackTitle}`);
 
   if (enableBitrate) {
     const ffType = getFfType(streamCopy.codec_type);
     streamCopy.outputArgs.push(`-b:${ffType}:{outputTypeIndex}`, `${bitrate}`);
+    const parsedBitrate = parseRate(bitrate);
+    if (parsedBitrate !== undefined) {
+      streamCopy.bit_rate = parsedBitrate;
+    }
   }
 
   if (enableSamplerate) {
     streamCopy.outputArgs.push('-ar', `${samplerate}`);
+    const parsedSamplerate = parseRate(samplerate);
+    if (parsedSamplerate !== undefined) {
+      streamCopy.sample_rate = String(parsedSamplerate);
+    }
   }
 
   // eslint-disable-next-line no-param-reassign
@@ -282,25 +348,10 @@ const plugin = (args: IpluginInputArgs): IpluginOutputArgs => {
 
   const { streams } = args.variables.ffmpegCommand;
 
-  let audioCodec = audioEncoder;
-
-  if (audioEncoder === 'dca') {
-    audioCodec = 'dts';
-  }
-
-  if (audioEncoder === 'libmp3lame') {
-    audioCodec = 'mp3';
-  }
-
-  if (audioEncoder === 'libopus') {
-    audioCodec = 'opus';
-  }
-
   const addedOrExists = attemptMakeStream({
     args,
     langTag,
     streams,
-    audioCodec,
     audioEncoder,
     wantedChannelCount,
   });
@@ -310,7 +361,6 @@ const plugin = (args: IpluginInputArgs): IpluginOutputArgs => {
       args,
       langTag: 'und',
       streams,
-      audioCodec,
       audioEncoder,
       wantedChannelCount,
     });

--- a/tests/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandEnsureAudioStream/1.0.0/index.test.ts
+++ b/tests/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandEnsureAudioStream/1.0.0/index.test.ts
@@ -2,43 +2,121 @@ import { plugin } from
   '../../../../../../FlowPluginsTs/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandEnsureAudioStream/1.0.0/index';
 import { plugin as removeStreamByPropertyPlugin } from
   '../../../../../../FlowPluginsTs/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandRemoveStreamByProperty/1.0.0/index';
+import { plugin as executePlugin } from
+  '../../../../../../FlowPluginsTs/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandExecute/1.0.0/index';
 import { IpluginInputArgs } from '../../../../../../FlowPluginsTs/FlowHelpers/1.0.0/interfaces/interfaces';
+import getConfigVars from '../../../../configVars';
 
 const sampleH264 = require('../../../../../sampleData/media/sampleH264_1.json');
+
+jest.mock('../../../../../../FlowPluginsTs/FlowHelpers/1.0.0/cliUtils', () => ({
+  CLI: jest.fn().mockImplementation(() => ({
+    runCli: jest.fn().mockResolvedValue({ cliExitCode: 0 }),
+  })),
+}));
 
 describe('ffmpegCommandEnsureAudioStream Plugin', () => {
   let baseArgs: IpluginInputArgs;
 
-  beforeEach(() => {
-    baseArgs = {
-      inputs: {
-        audioEncoder: 'aac',
-        language: 'en',
-        channels: '2',
-        enableBitrate: 'false',
-        bitrate: '128k',
-        enableSamplerate: 'false',
-        samplerate: '48k',
+  const makeBaseArgs = (): IpluginInputArgs => ({
+    inputs: {
+      audioEncoder: 'aac',
+      language: 'en',
+      channels: '2',
+      enableBitrate: 'false',
+      bitrate: '128k',
+      enableSamplerate: 'false',
+      samplerate: '48k',
+    },
+    variables: {
+      ffmpegCommand: {
+        init: true,
+        inputFiles: [],
+        shouldProcess: false,
+        streams: JSON.parse(JSON.stringify(sampleH264.ffProbeData.streams.map(
+          (stream: Record<string, unknown>, index: number) => ({
+            ...stream,
+            removed: false,
+            outputArgs: [],
+            inputArgs: [],
+            mapArgs: ['-map', `0:${index}`],
+            index,
+          }),
+        ))),
+        container: 'mkv',
+        hardwareDecoding: false,
+        overallInputArguments: [],
+        overallOuputArguments: [],
       },
-      variables: {
-        ffmpegCommand: {
-          init: true,
-          shouldProcess: false,
-          streams: JSON.parse(JSON.stringify(sampleH264.ffProbeData.streams.map(
-            (stream: Record<string, unknown>, index: number) => ({
-              ...stream,
-              removed: false,
-              outputArgs: [],
-              inputArgs: [],
-              index,
-            }),
-          ))),
-        },
-      } as IpluginInputArgs['variables'],
-      inputFileObj: JSON.parse(JSON.stringify(sampleH264)),
-      jobLog: jest.fn(),
-    } as Partial<IpluginInputArgs> as IpluginInputArgs;
+      flowFailed: false,
+      user: {},
+    } as IpluginInputArgs['variables'],
+    inputFileObj: JSON.parse(JSON.stringify(sampleH264)),
+    jobLog: jest.fn(),
+    workDir: '/tmp/work',
+    ffmpegPath: '/usr/bin/ffmpeg',
+    updateWorker: jest.fn(),
+    logOutcome: jest.fn(),
+    logFullCliOutput: false,
+    deps: {
+      fsextra: {
+        ensureDirSync: jest.fn(),
+      },
+    },
+    configVars: getConfigVars(),
+  } as unknown as IpluginInputArgs);
+
+  beforeEach(() => {
+    baseArgs = makeBaseArgs();
   });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const configureDtsSourceAudio = (args: IpluginInputArgs, channels = 6) => {
+    const sourceAudioStream = args.variables.ffmpegCommand.streams[1];
+    sourceAudioStream.codec_name = 'dts';
+    sourceAudioStream.codec_long_name = 'DCA (DTS Coherent Acoustics)';
+    sourceAudioStream.profile = 'DTS-HD MA';
+    sourceAudioStream.channels = channels;
+    sourceAudioStream.channel_layout = channels === 6 ? '5.1(side)' : `${channels} channels`;
+    sourceAudioStream.tags = {
+      language: 'eng',
+      title: 'DTS-HD MA 5.1',
+    };
+
+    return sourceAudioStream;
+  };
+
+  const setEnsureEac3Inputs = (args: IpluginInputArgs, channels = '2') => Object.assign(args.inputs, {
+    audioEncoder: 'eac3',
+    language: 'eng',
+    channels,
+  });
+
+  const addEac3FromDts = (args: IpluginInputArgs, channels = '2') => {
+    const sourceAudioStream = configureDtsSourceAudio(args);
+    setEnsureEac3Inputs(args, channels);
+    plugin(args);
+
+    return {
+      sourceAudioStream,
+      plannedStream: args.variables.ffmpegCommand.streams[2],
+    };
+  };
+
+  const removeDtsByProperty = (args: IpluginInputArgs, propertyToCheck = 'codec_name') => {
+    removeStreamByPropertyPlugin({
+      ...args,
+      inputs: {
+        codecType: 'audio',
+        propertyToCheck,
+        valuesToRemove: 'dts',
+        condition: 'includes',
+      },
+    });
+  };
 
   describe('Basic Audio Stream Addition', () => {
     it('should add AAC stereo stream when not present', () => {
@@ -362,31 +440,106 @@ describe('ffmpegCommandEnsureAudioStream Plugin', () => {
     });
   });
 
-  it('should keep a planned EAC3 stream when a downstream plugin removes DTS streams', () => {
-    const { streams } = baseArgs.variables.ffmpegCommand;
-    const sourceAudioStream = streams[1];
-    sourceAudioStream.codec_name = 'dts';
-    sourceAudioStream.tags = { language: 'eng' };
-    baseArgs.inputs.audioEncoder = 'eac3';
-    baseArgs.inputs.language = 'eng';
-    baseArgs.inputs.channels = '2';
+  it('should set a matching track title on a planned encoded audio stream', () => {
+    const { plannedStream } = addEac3FromDts(baseArgs, '6');
+
+    expect(plannedStream.tags?.title).toBe('EAC3 5.1');
+    expect(plannedStream.codec_long_name).toBeUndefined();
+    expect(plannedStream.profile).toBeUndefined();
+    expect(plannedStream.channel_layout).toBe('5.1');
+    expect(plannedStream.outputArgs).toEqual(expect.arrayContaining([
+      '-metadata:s:a:{outputTypeIndex}',
+      'title=EAC3 5.1',
+    ]));
+  });
+
+  it('should preserve semantic source track titles on planned encoded audio streams', () => {
+    [
+      ['Commentary', 'Commentary'],
+      ['DTS-HD MA 5.1 Commentary', 'EAC3 5.1 Commentary'],
+    ].forEach(([sourceTitle, expectedTitle]) => {
+      const args = makeBaseArgs();
+      const sourceAudioStream = configureDtsSourceAudio(args);
+      sourceAudioStream.tags = {
+        language: 'eng',
+        title: sourceTitle,
+      };
+      setEnsureEac3Inputs(args, '6');
+
+      plugin(args);
+      const plannedStream = args.variables.ffmpegCommand.streams[2];
+
+      expect(plannedStream.tags?.title).toBe(expectedTitle);
+      expect(plannedStream.outputArgs).toEqual(expect.arrayContaining([
+        '-metadata:s:a:{outputTypeIndex}',
+        `title=${expectedTitle}`,
+      ]));
+    });
+  });
+
+  it('should update planned bitrate and samplerate metadata when those options are enabled', () => {
+    configureDtsSourceAudio(baseArgs);
+    setEnsureEac3Inputs(baseArgs);
+    baseArgs.inputs.enableBitrate = 'true';
+    baseArgs.inputs.bitrate = '256k';
+    baseArgs.inputs.enableSamplerate = 'true';
+    baseArgs.inputs.samplerate = '44100';
 
     plugin(baseArgs);
-    const plannedStream = streams[2];
+    const plannedStream = baseArgs.variables.ffmpegCommand.streams[2];
 
-    baseArgs.inputs = {
-      codecType: 'audio',
-      propertyToCheck: 'codec_name',
-      valuesToRemove: 'dts',
-      condition: 'includes',
-    };
-    removeStreamByPropertyPlugin(baseArgs);
+    expect(plannedStream.bit_rate).toBe(256000);
+    expect(plannedStream.sample_rate).toBe('44100');
+  });
+
+  it('should keep a planned EAC3 stream when a downstream plugin removes DTS streams', () => {
+    const { sourceAudioStream, plannedStream } = addEac3FromDts(baseArgs);
+    removeDtsByProperty(baseArgs);
 
     expect(sourceAudioStream.removed).toBe(true);
     expect(plannedStream).toMatchObject({
       codec_name: 'eac3',
       channels: 2,
       removed: false,
+      tags: {
+        title: 'EAC3 2.0',
+      },
     });
+    expect(plannedStream.codec_long_name).toBeUndefined();
+    expect(plannedStream.profile).toBeUndefined();
+    expect(plannedStream.outputArgs).toEqual(expect.arrayContaining([
+      '-metadata:s:a:{outputTypeIndex}',
+      'title=EAC3 2.0',
+    ]));
+  });
+
+  it('should not remove a planned EAC3 stream when downstream checks stale DTS fields', () => {
+    ['codec_long_name', 'profile', 'tags.title'].forEach((propertyToCheck) => {
+      const args = makeBaseArgs();
+      const { sourceAudioStream, plannedStream } = addEac3FromDts(args);
+      removeDtsByProperty(args, propertyToCheck);
+
+      expect(sourceAudioStream.removed).toBe(true);
+      expect(plannedStream.removed).toBe(false);
+    });
+  });
+
+  it('should expand the planned audio title metadata to the final output audio index', async () => {
+    addEac3FromDts(baseArgs, '6');
+    removeDtsByProperty(baseArgs);
+
+    baseArgs.inputs = {};
+    await executePlugin(baseArgs);
+
+    const { CLI } = require('../../../../../../FlowPluginsTs/FlowHelpers/1.0.0/cliUtils');
+    const [cliOptions] = CLI.mock.calls[0];
+    const { spawnArgs } = cliOptions;
+
+    expect(spawnArgs).toEqual(expect.arrayContaining([
+      '-c:1',
+      'eac3',
+      '-metadata:s:a:0',
+      'title=EAC3 5.1',
+    ]));
   });
 });


### PR DESCRIPTION
## Summary

- Update Ensure Audio Stream planned audio metadata after cloning the source stream.
- Write FFmpeg audio title metadata such as `EAC3 5.1`.
- Preserve semantic title text such as `Commentary` while replacing stale codec title prefixes.
- Add regression coverage for same-section Remove Stream By Property and Execute output index expansion.

## Why

Ensure Audio Stream cloned the source DTS stream before updating enough planned stream metadata. Downstream plugins could still match stale DTS fields and remove the planned EAC3 stream. The encoded file could also keep the original DTS track title.