### PR TITLE
fix: detect WMA codec variants

### DIFF
--- a/FlowPlugins/CommunityFlowPlugins/audio/checkAudioCodec/1.0.0/index.js
+++ b/FlowPlugins/CommunityFlowPlugins/audio/checkAudioCodec/1.0.0/index.js
@@ -124,8 +124,10 @@ var plugin = function (args) {
     var hasCodec = false;
     if (args.inputFileObj.ffProbeData.streams) {
         args.inputFileObj.ffProbeData.streams.forEach(function (stream, index) {
-            var _a, _b, _c;
-            if (stream.codec_type === 'audio' && stream.codec_name === args.inputs.codec) {
+            var _a, _b, _c, _d;
+            var codecMatches = stream.codec_name === args.inputs.codec
+                || (args.inputs.codec === 'wma' && ((_a = stream.codec_name) === null || _a === void 0 ? void 0 : _a.startsWith('wma')));
+            if (stream.codec_type === 'audio' && codecMatches) {
                 if (!checkBitrate) {
                     args.jobLog("File has codec: ".concat(args.inputs.codec));
                     hasCodec = true;
@@ -137,7 +139,7 @@ var plugin = function (args) {
                             + " ".concat(ffprobeBitrate, " between ").concat(greaterThan, " and ").concat(lessThan));
                         hasCodec = true;
                     }
-                    var mediaInfoBitrate = Number(((_c = (_b = (_a = args.inputFileObj.mediaInfo) === null || _a === void 0 ? void 0 : _a.track) === null || _b === void 0 ? void 0 : _b[index + 1]) === null || _c === void 0 ? void 0 : _c.BitRate) || 0);
+                    var mediaInfoBitrate = Number(((_d = (_c = (_b = args.inputFileObj.mediaInfo) === null || _b === void 0 ? void 0 : _b.track) === null || _c === void 0 ? void 0 : _c[index + 1]) === null || _d === void 0 ? void 0 : _d.BitRate) || 0);
                     if (mediaInfoBitrate > greaterThan && mediaInfoBitrate < lessThan) {
                         args.jobLog("File has codec: ".concat(args.inputs.codec, " with bitrate")
                             + " ".concat(mediaInfoBitrate, " between ").concat(greaterThan, " and ").concat(lessThan));

--- a/FlowPluginsTs/CommunityFlowPlugins/audio/checkAudioCodec/1.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/audio/checkAudioCodec/1.0.0/index.ts
@@ -132,7 +132,10 @@ const plugin = (args:IpluginInputArgs):IpluginOutputArgs => {
 
   if (args.inputFileObj.ffProbeData.streams) {
     args.inputFileObj.ffProbeData.streams.forEach((stream, index) => {
-      if (stream.codec_type === 'audio' && stream.codec_name === args.inputs.codec) {
+      const codecMatches = stream.codec_name === args.inputs.codec
+        || (args.inputs.codec === 'wma' && stream.codec_name?.startsWith('wma'));
+
+      if (stream.codec_type === 'audio' && codecMatches) {
         if (!checkBitrate) {
           args.jobLog(`File has codec: ${args.inputs.codec}`);
           hasCodec = true;

--- a/tests/FlowPlugins/CommunityFlowPlugins/audio/checkAudioCodec/1.0.0/index.test.ts
+++ b/tests/FlowPlugins/CommunityFlowPlugins/audio/checkAudioCodec/1.0.0/index.test.ts
@@ -43,6 +43,21 @@ describe('checkAudioCodec Plugin', () => {
       expect(baseArgs.jobLog).toHaveBeenCalledWith('File has codec: mp3');
     });
 
+    it.each([
+      'wmav1',
+      'wmav2',
+    ])('should detect %s as WMA', (codec) => {
+      baseArgs.inputs.codec = 'wma';
+      if (baseArgs.inputFileObj.ffProbeData.streams?.[1]) {
+        baseArgs.inputFileObj.ffProbeData.streams[1].codec_name = codec;
+      }
+
+      const result = plugin(baseArgs);
+
+      expect(result.outputNumber).toBe(1);
+      expect(baseArgs.jobLog).toHaveBeenCalledWith('File has codec: wma');
+    });
+
     it('should reject non-matching codec', () => {
       baseArgs.inputs.codec = 'mp3'; // Looking for MP3 in AAC file
 


### PR DESCRIPTION
## Summary

- Treat the `wma` selection as the WMA codec family, including ffprobe names such as `wmav1` and `wmav2`.
- Preserve exact codec matching for every other selection.
- Add regression coverage for WMA v1 and WMA v2 detection.
- Update the generated JavaScript plugin.

## Root cause

The plugin exposes a generic `wma` selection, but ffprobe reports the specific WMA variant. The previous exact comparison treated `wmav2` and `wma` as different codecs and incorrectly routed matching files to output 2.

## Impact

Files with WMA audio now route to output 1 when `wma` is selected. Other codec checks are unchanged.

