### PR TITLE
fix: handle MKVPropEdit warning exit code

### DIFF
--- a/FlowPlugins/CommunityFlowPlugins/tools/runMkvPropEdit/1.0.0/index.js
+++ b/FlowPlugins/CommunityFlowPlugins/tools/runMkvPropEdit/1.0.0/index.js
@@ -88,7 +88,10 @@ var plugin = function (args) { return __awaiter(void 0, void 0, void 0, function
                 return [4 /*yield*/, cli.runCli()];
             case 1:
                 res = _a.sent();
-                if (res.cliExitCode !== 0) {
+                if (res.cliExitCode === 1 && !cli.cancelled) {
+                    args.jobLog('MKVPropEdit completed with warnings');
+                }
+                else if (res.cliExitCode !== 0) {
                     args.jobLog('Running MKVPropEdit failed');
                     throw new Error('Running MKVPropEdit failed');
                 }

--- a/FlowPlugins/FlowHelpers/1.0.0/cliUtils.js
+++ b/FlowPlugins/FlowHelpers/1.0.0/cliUtils.js
@@ -374,7 +374,7 @@ var CLI = /** @class */ (function () {
                                         // eslint-disable-next-line no-console
                                         console.log("Error executing binary: ".concat(_this.config.cli));
                                         _this.config.jobLog("Error executing binary: ".concat(_this.config.cli));
-                                        resolve(1);
+                                        resolve(-1);
                                     });
                                     // thread.stdout.pipe(process.stdout);
                                     // thread.stderr.pipe(process.stderr);
@@ -392,7 +392,7 @@ var CLI = /** @class */ (function () {
                                     // eslint-disable-next-line no-console
                                     console.log("Error executing binary: ".concat(_this.config.cli, ": ").concat(err));
                                     _this.config.jobLog("Error executing binary: ".concat(_this.config.cli, ": ").concat(err));
-                                    resolve(1);
+                                    resolve(-1);
                                 }
                             })];
                     case 1:

--- a/FlowPluginsTs/CommunityFlowPlugins/tools/runMkvPropEdit/1.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/tools/runMkvPropEdit/1.0.0/index.ts
@@ -53,7 +53,9 @@ const plugin = async (args:IpluginInputArgs):Promise<IpluginOutputArgs> => {
 
   const res = await cli.runCli();
 
-  if (res.cliExitCode !== 0) {
+  if (res.cliExitCode === 1 && !cli.cancelled) {
+    args.jobLog('MKVPropEdit completed with warnings');
+  } else if (res.cliExitCode !== 0) {
     args.jobLog('Running MKVPropEdit failed');
     throw new Error('Running MKVPropEdit failed');
   }

--- a/FlowPluginsTs/FlowHelpers/1.0.0/cliUtils.ts
+++ b/FlowPluginsTs/FlowHelpers/1.0.0/cliUtils.ts
@@ -422,7 +422,7 @@ class CLI {
           // eslint-disable-next-line no-console
           console.log(`Error executing binary: ${this.config.cli}`);
           this.config.jobLog(`Error executing binary: ${this.config.cli}`);
-          resolve(1);
+          resolve(-1);
         });
 
         // thread.stdout.pipe(process.stdout);
@@ -440,7 +440,7 @@ class CLI {
         // eslint-disable-next-line no-console
         console.log(`Error executing binary: ${this.config.cli}: ${err}`);
         this.config.jobLog(`Error executing binary: ${this.config.cli}: ${err}`);
-        resolve(1);
+        resolve(-1);
       }
     });
 

--- a/tests/Community/Tdarr_Plugin_e5c3_CnT_Keep_Preferred_Audio.js
+++ b/tests/Community/Tdarr_Plugin_e5c3_CnT_Keep_Preferred_Audio.js
@@ -1,9 +1,9 @@
 /* eslint max-len: 0 */
 const _ = require('lodash');
-const run = require('../helpers/run');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const run = require('../helpers/run');
 
 const specialLogHome = fs.mkdtempSync(path.join(os.tmpdir(), 'tdarr-cnt-audio-'));
 fs.mkdirSync(path.join(specialLogHome, 'Tdarr'));

--- a/tests/FlowPlugins/CommunityFlowPlugins/tools/runMkvPropEdit/1.0.0/index.test.ts
+++ b/tests/FlowPlugins/CommunityFlowPlugins/tools/runMkvPropEdit/1.0.0/index.test.ts
@@ -23,6 +23,7 @@ jest.mock('../../../../../../methods/lib', () => () => ({
 describe('runMkvPropEdit Plugin', () => {
   let baseArgs: IpluginInputArgs;
   let mockRunCli: jest.Mock;
+  let mockCancelled: boolean;
 
   beforeEach(() => {
     // Reset mocks
@@ -31,8 +32,10 @@ describe('runMkvPropEdit Plugin', () => {
     const { CLI } = require('../../../../../../FlowPluginsTs/FlowHelpers/1.0.0/cliUtils');
     const mockCLI = CLI as jest.MockedClass<typeof CLI>;
     mockRunCli = jest.fn().mockResolvedValue({ cliExitCode: 0 });
+    mockCancelled = false;
     mockCLI.mockImplementation(() => ({
       runCli: mockRunCli,
+      get cancelled() { return mockCancelled; },
     }));
 
     baseArgs = {
@@ -87,8 +90,22 @@ describe('runMkvPropEdit Plugin', () => {
   });
 
   describe('Error handling', () => {
-    it('should throw error when mkvpropedit returns non-zero exit code', async () => {
+    it('should continue when mkvpropedit completes with warnings', async () => {
       mockRunCli.mockResolvedValueOnce({ cliExitCode: 1 });
+
+      const result = await plugin(baseArgs);
+
+      expect(result.outputNumber).toBe(1);
+      expect(baseArgs.jobLog).toHaveBeenCalledWith('MKVPropEdit completed with warnings');
+    });
+
+    it.each([
+      ['mkvpropedit error', 2, false],
+      ['CLI execution error', -1, false],
+      ['cancellation', 1, true],
+    ])('should throw on %s', async (scenario, cliExitCode, cancelled) => {
+      mockCancelled = cancelled;
+      mockRunCli.mockResolvedValueOnce({ cliExitCode });
 
       await expect(plugin(baseArgs)).rejects.toThrow('Running MKVPropEdit failed');
       expect(baseArgs.jobLog).toHaveBeenCalledWith('Running MKVPropEdit failed');


### PR DESCRIPTION
## Summary

- Treat MKVPropEdit exit code `1` as a completed operation with warnings.
- Keep CLI launch failures, MKVPropEdit errors, and cancellations on the failure path.
- Add regression coverage and update the generated JavaScript.

## Root cause

The plugin treated every nonzero exit code as a failure, but MKVPropEdit uses exit code `1` when processing completes with warnings. The shared CLI helper also used `1` for launch failures, so those synthetic failures now use `-1` to keep the outcomes distinct.

## Impact

Flows continue when MKVPropEdit completes with warnings. Real errors and cancellations continue to fail as before.

Fixes #1011
