### PR TITLE
cleanup: undo plugin timer changes

### DIFF
--- a/Community/Tdarr_Plugin_e5c3_CnT_Keep_Preferred_Audio.js
+++ b/Community/Tdarr_Plugin_e5c3_CnT_Keep_Preferred_Audio.js
@@ -44,17 +44,9 @@ const details = () => {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-const plugin = async (file, librarySettings, inputs, otherArguments) => {
+const plugin = (file, librarySettings, inputs, otherArguments) => {
   
-  const lib = require('../methods/lib')(); const fs = require("fs");
-  const appendSpecialAudio = async (filePath, sourceName) => {
-    try {
-      await fs.promises.appendFile(filePath, `${sourceName}\n`);
-      console.log(`added to txt: ` + sourceName);
-    } catch (err) {
-      console.log(`could not add to txt: ` + err);
-    }
-  };
+  const lib = require('../methods/lib')(); const exec = require("child_process").exec; const fs = require("fs");
   // eslint-disable-next-line @typescript-eslint/no-unused-vars,no-param-reassign
   inputs = lib.loadDefaultValues(inputs, details);
   if (inputs.languages == "" || typeof inputs.special == "undefined") {
@@ -116,19 +108,30 @@ const plugin = async (file, librarySettings, inputs, otherArguments) => {
         ) {
           for (l = 0; l < length; l++) {
             if (file.ffProbeData.streams[i].tags.language == special[l]) {
-              const specialAudioPath =
-                otherArguments.homePath +
-                `/Tdarr/special_audio_${special[l]}.txt`;
-              if (!fs.existsSync(specialAudioPath)) {
+              if (
+                !fs.existsSync(
+                  otherArguments.homePath +
+                    `/Tdarr/special_audio_${special[l]}.txt`
+                )
+              ) {
                 //create txt file if it doesn't exist yet
-                await appendSpecialAudio(specialAudioPath, sourcename);
+                exec(
+                  `echo "${sourcename}" >> ${otherArguments.homePath}/Tdarr/special_audio_${special[l]}.txt`
+                ); //first file will be added and file is created
+                console.log(`added to txt: ` + sourcename);
               } else {
                 specialcheck = fs
-                  .readFileSync(specialAudioPath)
+                  .readFileSync(
+                    otherArguments.homePath +
+                      `/Tdarr/special_audio_${special[l]}.txt`
+                  )
                   .toString(); //create string from existing file
                 if (!specialcheck.includes(sourcename)) {
                   //only add the filename if it wasn't added already
-                  await appendSpecialAudio(specialAudioPath, sourcename);
+                  exec(
+                    `echo "${sourcename}" >> ${otherArguments.homePath}/Tdarr/special_audio_${special[l]}.txt`
+                  );
+                  console.log(`added to txt: ` + sourcename);
                 }
               }
 

--- a/FlowPlugins/CommunityFlowPlugins/automations/detectNonTdarrNvenc/1.0.0/index.js
+++ b/FlowPlugins/CommunityFlowPlugins/automations/detectNonTdarrNvenc/1.0.0/index.js
@@ -42,94 +42,75 @@ var automationUtils_1 = require("../../../../FlowHelpers/1.0.0/automationUtils")
 // Sets ffmpeg/HandBrake process priority (cross-platform).
 var setTdarrProcessPriority = function (priority, platform, 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-childProcess, jobLog) { return __awaiter(void 0, void 0, void 0, function () {
-    var cmdFFmpeg, cmdHandBrake, priorityClass, niceVal, runPriorityCommand, err_1;
-    return __generator(this, function (_a) {
-        switch (_a.label) {
-            case 0:
-                _a.trys.push([0, 2, , 3]);
-                cmdFFmpeg = '';
-                cmdHandBrake = '';
-                if (platform === 'win32') {
+childProcess, jobLog) {
+    try {
+        var cmdFFmpeg = '';
+        var cmdHandBrake = '';
+        if (platform === 'win32') {
+            var priorityClass = 'Normal';
+            switch (priority) {
+                case 'high':
+                    priorityClass = 'High';
+                    break;
+                case 'above normal':
+                    priorityClass = 'AboveNormal';
+                    break;
+                case 'normal':
                     priorityClass = 'Normal';
-                    switch (priority) {
-                        case 'high':
-                            priorityClass = 'High';
-                            break;
-                        case 'above normal':
-                            priorityClass = 'AboveNormal';
-                            break;
-                        case 'normal':
-                            priorityClass = 'Normal';
-                            break;
-                        case 'below normal':
-                            priorityClass = 'BelowNormal';
-                            break;
-                        case 'low':
-                            priorityClass = 'Idle';
-                            break;
-                        default:
-                            priorityClass = 'Normal';
-                            break;
-                    }
-                    // eslint-disable-next-line max-len
-                    cmdFFmpeg = "powershell -Command \"if (Get-Process -Name 'ffmpeg' -ErrorAction SilentlyContinue) { Get-Process -Name 'ffmpeg' | ForEach-Object { $_.PriorityClass = '".concat(priorityClass, "' } }\"");
-                    // eslint-disable-next-line max-len
-                    cmdHandBrake = "powershell -Command \"if (Get-Process -Name 'HandBrakeCLI' -ErrorAction SilentlyContinue) { Get-Process -Name 'HandBrakeCLI' | ForEach-Object { $_.PriorityClass = '".concat(priorityClass, "' } }\"");
-                }
-                else {
-                    niceVal = 0;
-                    switch (priority) {
-                        case 'high':
-                            niceVal = -15;
-                            break;
-                        case 'above normal':
-                            niceVal = -10;
-                            break;
-                        case 'normal':
-                            niceVal = 0;
-                            break;
-                        case 'below normal':
-                            niceVal = 10;
-                            break;
-                        case 'low':
-                            niceVal = 19;
-                            break;
-                        default:
-                            niceVal = 0;
-                            break;
-                    }
-                    cmdFFmpeg = "for p in $(pgrep ^ffmpeg$ || true); do renice -n ".concat(niceVal, " -p $p; done");
-                    cmdHandBrake = "for p in $(pgrep ^HandBrakeCLI$ || true); do renice -n ".concat(niceVal, " -p $p; done");
-                }
-                runPriorityCommand = function (command, processName) { return (new Promise(function (resolve) {
-                    try {
-                        childProcess.exec(command, { windowsHide: true }, function (err) {
-                            if (err)
-                                jobLog("Error setting ".concat(processName, " priority: ").concat(err));
-                            resolve();
-                        });
-                    }
-                    catch (err) {
-                        jobLog("Error setting ".concat(processName, " priority: ").concat(err));
-                        resolve();
-                    }
-                })); };
-                return [4 /*yield*/, Promise.all([
-                        runPriorityCommand(cmdFFmpeg, 'ffmpeg'),
-                        runPriorityCommand(cmdHandBrake, 'HandBrake'),
-                    ])];
-            case 1:
-                _a.sent();
-                return [3 /*break*/, 3];
-            case 2:
-                err_1 = _a.sent();
-                jobLog("Error setting process priority: ".concat(err_1));
-                return [3 /*break*/, 3];
-            case 3: return [2 /*return*/];
+                    break;
+                case 'below normal':
+                    priorityClass = 'BelowNormal';
+                    break;
+                case 'low':
+                    priorityClass = 'Idle';
+                    break;
+                default:
+                    priorityClass = 'Normal';
+                    break;
+            }
+            // eslint-disable-next-line max-len
+            cmdFFmpeg = "powershell -Command \"if (Get-Process -Name 'ffmpeg' -ErrorAction SilentlyContinue) { Get-Process -Name 'ffmpeg' | ForEach-Object { $_.PriorityClass = '".concat(priorityClass, "' } }\"");
+            // eslint-disable-next-line max-len
+            cmdHandBrake = "powershell -Command \"if (Get-Process -Name 'HandBrakeCLI' -ErrorAction SilentlyContinue) { Get-Process -Name 'HandBrakeCLI' | ForEach-Object { $_.PriorityClass = '".concat(priorityClass, "' } }\"");
         }
-    });
-}); };
+        else {
+            var niceVal = 0;
+            switch (priority) {
+                case 'high':
+                    niceVal = -15;
+                    break;
+                case 'above normal':
+                    niceVal = -10;
+                    break;
+                case 'normal':
+                    niceVal = 0;
+                    break;
+                case 'below normal':
+                    niceVal = 10;
+                    break;
+                case 'low':
+                    niceVal = 19;
+                    break;
+                default:
+                    niceVal = 0;
+                    break;
+            }
+            cmdFFmpeg = "for p in $(pgrep ^ffmpeg$ || true); do renice -n ".concat(niceVal, " -p $p; done");
+            cmdHandBrake = "for p in $(pgrep ^HandBrakeCLI$ || true); do renice -n ".concat(niceVal, " -p $p; done");
+        }
+        childProcess.exec(cmdFFmpeg, { windowsHide: true }, function (err) {
+            if (err)
+                jobLog("Error setting ffmpeg priority: ".concat(err));
+        });
+        childProcess.exec(cmdHandBrake, { windowsHide: true }, function (err) {
+            if (err)
+                jobLog("Error setting HandBrake priority: ".concat(err));
+        });
+    }
+    catch (err) {
+        jobLog("Error setting process priority: ".concat(err));
+    }
+};
 var details = function () { return ({
     name: 'Set GPU Node to Low Priority When Non-Tdarr NVENC Detected',
     description: 'Polls nvidia-smi for non-Tdarr NVENC encoder processes.'
@@ -267,25 +248,19 @@ var plugin = function (args) { return __awaiter(void 0, void 0, void 0, function
                                 case 0:
                                     nvencPids = getNonTdarrNvencPids(childProcess, firstCheck || firstPoll, args.jobLog);
                                     hasNonTdarrNvenc = nvencPids.length > 0;
-                                    if (!(hasNonTdarrNvenc && !isLowered)) return [3 /*break*/, 2];
-                                    args.jobLog("Non-Tdarr NVENC detected (PIDs: ".concat(nvencPids.join(', '), "), setting priority to ").concat(lowPriority));
-                                    return [4 /*yield*/, setTdarrProcessPriority(lowPriority, args.platform, childProcess, args.jobLog)];
-                                case 1:
-                                    _a.sent();
-                                    isLowered = true;
-                                    return [3 /*break*/, 4];
-                                case 2:
-                                    if (!(!hasNonTdarrNvenc && isLowered)) return [3 /*break*/, 4];
-                                    args.jobLog("No non-Tdarr NVENC processes, restoring priority to ".concat(normalPriority));
-                                    return [4 /*yield*/, setTdarrProcessPriority(normalPriority, args.platform, childProcess, args.jobLog)];
-                                case 3:
-                                    _a.sent();
-                                    isLowered = false;
-                                    _a.label = 4;
-                                case 4:
+                                    if (hasNonTdarrNvenc && !isLowered) {
+                                        args.jobLog("Non-Tdarr NVENC detected (PIDs: ".concat(nvencPids.join(', '), "), setting priority to ").concat(lowPriority));
+                                        setTdarrProcessPriority(lowPriority, args.platform, childProcess, args.jobLog);
+                                        isLowered = true;
+                                    }
+                                    else if (!hasNonTdarrNvenc && isLowered) {
+                                        args.jobLog("No non-Tdarr NVENC processes, restoring priority to ".concat(normalPriority));
+                                        setTdarrProcessPriority(normalPriority, args.platform, childProcess, args.jobLog);
+                                        isLowered = false;
+                                    }
                                     firstCheck = false;
                                     return [4 /*yield*/, (0, automationUtils_1.checkOtherWorkersRunning)(args, firstPoll)];
-                                case 5:
+                                case 1:
                                     othersRunning = _a.sent();
                                     if (othersRunning === 'error')
                                         return [2 /*return*/, 'error'];
@@ -295,17 +270,16 @@ var plugin = function (args) { return __awaiter(void 0, void 0, void 0, function
                     }); }, "No other workers running (confirmed ".concat(confirmCount, " times), stopping NVENC priority monitor"))];
             case 1:
                 _a.sent();
-                if (!isLowered) return [3 /*break*/, 3];
-                args.jobLog("Restoring priority to ".concat(normalPriority, " on exit"));
-                return [4 /*yield*/, setTdarrProcessPriority(normalPriority, args.platform, childProcess, args.jobLog)];
-            case 2:
-                _a.sent();
-                _a.label = 3;
-            case 3: return [2 /*return*/, {
-                    outputFileObj: args.inputFileObj,
-                    outputNumber: 1,
-                    variables: args.variables,
-                }];
+                // Restore priority on exit if it was lowered
+                if (isLowered) {
+                    args.jobLog("Restoring priority to ".concat(normalPriority, " on exit"));
+                    setTdarrProcessPriority(normalPriority, args.platform, childProcess, args.jobLog);
+                }
+                return [2 /*return*/, {
+                        outputFileObj: args.inputFileObj,
+                        outputNumber: 1,
+                        variables: args.variables,
+                    }];
         }
     });
 }); };

--- a/FlowPlugins/CommunityFlowPlugins/automations/preventSleepWhileEncoding/1.0.0/index.js
+++ b/FlowPlugins/CommunityFlowPlugins/automations/preventSleepWhileEncoding/1.0.0/index.js
@@ -73,57 +73,11 @@ var details = function () { return ({
     ],
 }); };
 exports.details = details;
-// Killing a child only requests termination. Wait for exit/close, but keep
-// cleanup best-effort and bounded if the child never reports either event.
-var stopSleepPreventionProcess = function (
+// Spawns a platform-specific process that prevents system sleep.
+// Returns a cleanup function to stop it.
+var startSleepPrevention = function (platform, childProcess, 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-proc) { return __awaiter(void 0, void 0, void 0, function () {
-    return __generator(this, function (_a) {
-        switch (_a.label) {
-            case 0:
-                if (!proc || proc.exitCode !== null || typeof proc.once !== 'function') {
-                    try {
-                        if (proc)
-                            proc.kill();
-                    }
-                    catch (err) {
-                        // cleanup best-effort
-                    }
-                    return [2 /*return*/];
-                }
-                return [4 /*yield*/, new Promise(function (resolve) {
-                        var settled = false;
-                        var timeout;
-                        var finish = function () {
-                            var _a, _b, _c;
-                            if (settled)
-                                return;
-                            settled = true;
-                            clearTimeout(timeout);
-                            (_a = proc.removeListener) === null || _a === void 0 ? void 0 : _a.call(proc, 'exit', finish);
-                            (_b = proc.removeListener) === null || _b === void 0 ? void 0 : _b.call(proc, 'close', finish);
-                            (_c = proc.removeListener) === null || _c === void 0 ? void 0 : _c.call(proc, 'error', finish);
-                            resolve();
-                        };
-                        proc.once('exit', finish);
-                        proc.once('close', finish);
-                        proc.once('error', finish);
-                        timeout = setTimeout(finish, 5000);
-                        try {
-                            if (proc.kill() === false)
-                                finish();
-                        }
-                        catch (err) {
-                            finish();
-                        }
-                    })];
-            case 1:
-                _a.sent();
-                return [2 /*return*/];
-        }
-    });
-}); };
-var startSleepPrevention = function (platform, childProcess, jobLog) {
+jobLog) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     var proc = null;
     try {
@@ -142,28 +96,25 @@ var startSleepPrevention = function (platform, childProcess, jobLog) {
             proc = childProcess.spawn('powershell', ['-NoProfile', '-Command', psScript], { stdio: 'ignore', windowsHide: true, detached: false });
             jobLog('Sleep prevention active (Windows SetThreadExecutionState, refreshing)');
             var winProc_1 = proc;
-            return function () { return __awaiter(void 0, void 0, void 0, function () {
-                var clearCmd;
-                return __generator(this, function (_a) {
-                    switch (_a.label) {
-                        case 0: return [4 /*yield*/, stopSleepPreventionProcess(winProc_1)];
-                        case 1:
-                            _a.sent();
-                            // Reset execution state via a separate PowerShell call as best-effort
-                            try {
-                                clearCmd = 'powershell -NoProfile -Command "Add-Type -MemberDefinition '
-                                    + '\'[DllImport(\\"kernel32.dll\\")] public static extern uint SetThreadExecutionState(uint f);\' '
-                                    + '-Name SleepUtilClr -Namespace Win32; '
-                                    + '[Win32.SleepUtilClr]::SetThreadExecutionState(2147483648)"';
-                                childProcess.execSync(clearCmd, { timeout: 10000, windowsHide: true });
-                            }
-                            catch (err) {
-                                // cleanup best-effort
-                            }
-                            return [2 /*return*/];
-                    }
-                });
-            }); };
+            return function () {
+                try {
+                    winProc_1.kill();
+                }
+                catch (err) {
+                    // cleanup best-effort
+                }
+                // Reset execution state via a separate PowerShell call as best-effort
+                try {
+                    var clearCmd = 'powershell -NoProfile -Command "Add-Type -MemberDefinition '
+                        + '\'[DllImport(\\"kernel32.dll\\")] public static extern uint SetThreadExecutionState(uint f);\' '
+                        + '-Name SleepUtilClr -Namespace Win32; '
+                        + '[Win32.SleepUtilClr]::SetThreadExecutionState(2147483648)"';
+                    childProcess.execSync(clearCmd, { timeout: 10000, windowsHide: true });
+                }
+                catch (err) {
+                    // cleanup best-effort
+                }
+            };
         }
         if (platform === 'darwin') {
             // caffeinate -i prevents idle sleep, runs until killed
@@ -173,7 +124,14 @@ var startSleepPrevention = function (platform, childProcess, jobLog) {
             });
             jobLog('Sleep prevention active (caffeinate)');
             var cafProc_1 = proc;
-            return function () { return stopSleepPreventionProcess(cafProc_1); };
+            return function () {
+                try {
+                    cafProc_1.kill();
+                }
+                catch (err) {
+                    // cleanup best-effort
+                }
+            };
         }
         // Linux: use systemd-inhibit if available
         proc = childProcess.spawn('systemd-inhibit', ['--what=idle:sleep', '--who=Tdarr', '--why=Encoding in progress', 'sleep', 'infinity'], { stdio: 'ignore', detached: false });
@@ -185,25 +143,23 @@ var startSleepPrevention = function (platform, childProcess, jobLog) {
         });
         jobLog('Sleep prevention active (systemd-inhibit)');
         var inhProc_1 = proc;
-        return function () { return __awaiter(void 0, void 0, void 0, function () {
-            return __generator(this, function (_a) {
-                switch (_a.label) {
-                    case 0:
-                        if (!!inhibitFailed_1) return [3 /*break*/, 2];
-                        return [4 /*yield*/, stopSleepPreventionProcess(inhProc_1)];
-                    case 1:
-                        _a.sent();
-                        _a.label = 2;
-                    case 2: return [2 /*return*/];
+        return function () {
+            if (!inhibitFailed_1) {
+                try {
+                    inhProc_1.kill();
                 }
-            });
-        }); };
+                catch (err) {
+                    // cleanup best-effort
+                }
+            }
+        };
     }
     catch (err) {
         jobLog("Could not start sleep prevention: ".concat(err));
     }
     // No-op cleanup if nothing was started
-    return function () { return Promise.resolve(); };
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    return function () { };
 };
 var plugin = function (args) { return __awaiter(void 0, void 0, void 0, function () {
     var lib, childProcess, pollInterval, stopSleepPrevention, confirmCount;
@@ -220,7 +176,7 @@ var plugin = function (args) { return __awaiter(void 0, void 0, void 0, function
                 confirmCount = 3;
                 _a.label = 1;
             case 1:
-                _a.trys.push([1, , 3, 5]);
+                _a.trys.push([1, , 3, 4]);
                 return [4 /*yield*/, (0, automationUtils_1.pollUntilConfirmed)(args, pollInterval, confirmCount, function (firstCheck) { return __awaiter(void 0, void 0, void 0, function () {
                         var othersRunning;
                         return __generator(this, function (_a) {
@@ -236,12 +192,11 @@ var plugin = function (args) { return __awaiter(void 0, void 0, void 0, function
                     }); }, "No other workers running (confirmed ".concat(confirmCount, " times), stopping sleep prevention"))];
             case 2:
                 _a.sent();
-                return [3 /*break*/, 5];
-            case 3: return [4 /*yield*/, stopSleepPrevention()];
-            case 4:
-                _a.sent();
+                return [3 /*break*/, 4];
+            case 3:
+                stopSleepPrevention();
                 return [7 /*endfinally*/];
-            case 5: return [2 /*return*/, {
+            case 4: return [2 /*return*/, {
                     outputFileObj: args.inputFileObj,
                     outputNumber: 1,
                     variables: args.variables,

--- a/FlowPlugins/CommunityFlowPlugins/tools/waitTimeout/1.0.0/index.js
+++ b/FlowPlugins/CommunityFlowPlugins/tools/waitTimeout/1.0.0/index.js
@@ -87,7 +87,7 @@ var details = function () { return ({
 exports.details = details;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 var plugin = function (args) { return __awaiter(void 0, void 0, void 0, function () {
-    var lib, _a, amount, unit, amountNum, multiplier, waitTime, finished, loggingTimeout, logWait;
+    var lib, _a, amount, unit, amountNum, multiplier, waitTime, finished, logWait;
     return __generator(this, function (_b) {
         switch (_b.label) {
             case 0:
@@ -116,27 +116,19 @@ var plugin = function (args) { return __awaiter(void 0, void 0, void 0, function
                 logWait = function () {
                     if (!finished) {
                         args.jobLog('Waiting...');
-                        loggingTimeout = setTimeout(logWait, 5000);
+                        setTimeout(logWait, 5000);
                     }
                 };
                 logWait();
-                _b.label = 1;
-            case 1:
-                _b.trys.push([1, , 3, 4]);
                 return [4 /*yield*/, new Promise(function (resolve) { return setTimeout(resolve, waitTime); })];
-            case 2:
+            case 1:
                 _b.sent();
-                return [3 /*break*/, 4];
-            case 3:
                 finished = true;
-                if (loggingTimeout)
-                    clearTimeout(loggingTimeout);
-                return [7 /*endfinally*/];
-            case 4: return [2 /*return*/, {
-                    outputFileObj: args.inputFileObj,
-                    outputNumber: 1,
-                    variables: args.variables,
-                }];
+                return [2 /*return*/, {
+                        outputFileObj: args.inputFileObj,
+                        outputNumber: 1,
+                        variables: args.variables,
+                    }];
         }
     });
 }); };

--- a/FlowPluginsTs/CommunityFlowPlugins/automations/detectNonTdarrNvenc/1.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/automations/detectNonTdarrNvenc/1.0.0/index.ts
@@ -11,13 +11,13 @@ import {
 /* eslint no-plusplus: ["error", { "allowForLoopAfterthoughts": true }] */
 
 // Sets ffmpeg/HandBrake process priority (cross-platform).
-const setTdarrProcessPriority = async (
+const setTdarrProcessPriority = (
   priority: 'low' | 'below normal' | 'normal' | 'above normal' | 'high',
   platform: string,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   childProcess: any,
   jobLog: (text: string) => void,
-): Promise<void> => {
+): void => {
   try {
     let cmdFFmpeg = '';
     let cmdHandBrake = '';
@@ -76,24 +76,12 @@ const setTdarrProcessPriority = async (
       cmdHandBrake = `for p in $(pgrep ^HandBrakeCLI$ || true); do renice -n ${niceVal} -p $p; done`;
     }
 
-    const runPriorityCommand = (command: string, processName: string): Promise<void> => (
-      new Promise((resolve) => {
-        try {
-          childProcess.exec(command, { windowsHide: true }, (err: unknown) => {
-            if (err) jobLog(`Error setting ${processName} priority: ${err}`);
-            resolve();
-          });
-        } catch (err) {
-          jobLog(`Error setting ${processName} priority: ${err}`);
-          resolve();
-        }
-      })
-    );
-
-    await Promise.all([
-      runPriorityCommand(cmdFFmpeg, 'ffmpeg'),
-      runPriorityCommand(cmdHandBrake, 'HandBrake'),
-    ]);
+    childProcess.exec(cmdFFmpeg, { windowsHide: true }, (err: unknown) => {
+      if (err) jobLog(`Error setting ffmpeg priority: ${err}`);
+    });
+    childProcess.exec(cmdHandBrake, { windowsHide: true }, (err: unknown) => {
+      if (err) jobLog(`Error setting HandBrake priority: ${err}`);
+    });
   } catch (err) {
     jobLog(`Error setting process priority: ${err}`);
   }
@@ -257,11 +245,11 @@ const plugin = async (args: IpluginInputArgs): Promise<IpluginOutputArgs> => {
 
       if (hasNonTdarrNvenc && !isLowered) {
         args.jobLog(`Non-Tdarr NVENC detected (PIDs: ${nvencPids.join(', ')}), setting priority to ${lowPriority}`);
-        await setTdarrProcessPriority(lowPriority, args.platform, childProcess, args.jobLog);
+        setTdarrProcessPriority(lowPriority, args.platform, childProcess, args.jobLog);
         isLowered = true;
       } else if (!hasNonTdarrNvenc && isLowered) {
         args.jobLog(`No non-Tdarr NVENC processes, restoring priority to ${normalPriority}`);
-        await setTdarrProcessPriority(normalPriority, args.platform, childProcess, args.jobLog);
+        setTdarrProcessPriority(normalPriority, args.platform, childProcess, args.jobLog);
         isLowered = false;
       }
 
@@ -278,7 +266,7 @@ const plugin = async (args: IpluginInputArgs): Promise<IpluginOutputArgs> => {
   // Restore priority on exit if it was lowered
   if (isLowered) {
     args.jobLog(`Restoring priority to ${normalPriority} on exit`);
-    await setTdarrProcessPriority(normalPriority, args.platform, childProcess, args.jobLog);
+    setTdarrProcessPriority(normalPriority, args.platform, childProcess, args.jobLog);
   }
 
   return {

--- a/FlowPluginsTs/CommunityFlowPlugins/automations/preventSleepWhileEncoding/1.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/automations/preventSleepWhileEncoding/1.0.0/index.ts
@@ -44,58 +44,17 @@ const details = (): IpluginDetails => ({
   ],
 });
 
-// Killing a child only requests termination. Wait for exit/close, but keep
-// cleanup best-effort and bounded if the child never reports either event.
-const stopSleepPreventionProcess = async (
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  proc: any,
-): Promise<void> => {
-  if (!proc || proc.exitCode !== null || typeof proc.once !== 'function') {
-    try {
-      if (proc) proc.kill();
-    } catch (err) {
-      // cleanup best-effort
-    }
-    return;
-  }
-
-  await new Promise<void>((resolve) => {
-    let settled = false;
-    let timeout: ReturnType<typeof setTimeout>;
-    const finish = (): void => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timeout);
-      proc.removeListener?.('exit', finish);
-      proc.removeListener?.('close', finish);
-      proc.removeListener?.('error', finish);
-      resolve();
-    };
-
-    proc.once('exit', finish);
-    proc.once('close', finish);
-    proc.once('error', finish);
-    timeout = setTimeout(finish, 5000);
-
-    try {
-      if (proc.kill() === false) finish();
-    } catch (err) {
-      finish();
-    }
-  });
-};
-
 // Spawns a platform-specific process that prevents system sleep.
 // Returns a cleanup function to stop it.
-type StopSleepPrevention = () => Promise<void>;
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type ChildProcessApi = any;
-
 const startSleepPrevention = (
   platform: string,
-  childProcess: ChildProcessApi,
+  childProcess: // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   jobLog: (text: string) => void,
-): StopSleepPrevention => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): (() => void
+) => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let proc: any = null;
 
@@ -120,8 +79,12 @@ const startSleepPrevention = (
       jobLog('Sleep prevention active (Windows SetThreadExecutionState, refreshing)');
 
       const winProc = proc;
-      return async () => {
-        await stopSleepPreventionProcess(winProc);
+      return () => {
+        try {
+          winProc.kill();
+        } catch (err) {
+          // cleanup best-effort
+        }
         // Reset execution state via a separate PowerShell call as best-effort
         try {
           const clearCmd = 'powershell -NoProfile -Command "Add-Type -MemberDefinition '
@@ -144,7 +107,13 @@ const startSleepPrevention = (
       jobLog('Sleep prevention active (caffeinate)');
 
       const cafProc = proc;
-      return () => stopSleepPreventionProcess(cafProc);
+      return () => {
+        try {
+          cafProc.kill();
+        } catch (err) {
+          // cleanup best-effort
+        }
+      };
     }
 
     // Linux: use systemd-inhibit if available
@@ -162,9 +131,13 @@ const startSleepPrevention = (
     jobLog('Sleep prevention active (systemd-inhibit)');
 
     const inhProc = proc;
-    return async () => {
+    return () => {
       if (!inhibitFailed) {
-        await stopSleepPreventionProcess(inhProc);
+        try {
+          inhProc.kill();
+        } catch (err) {
+          // cleanup best-effort
+        }
       }
     };
   } catch (err) {
@@ -172,7 +145,8 @@ const startSleepPrevention = (
   }
 
   // No-op cleanup if nothing was started
-  return () => Promise.resolve();
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  return () => {};
 };
 
 const plugin = async (args: IpluginInputArgs): Promise<IpluginOutputArgs> => {
@@ -201,7 +175,7 @@ const plugin = async (args: IpluginInputArgs): Promise<IpluginOutputArgs> => {
       `No other workers running (confirmed ${confirmCount} times), stopping sleep prevention`,
     );
   } finally {
-    await stopSleepPrevention();
+    stopSleepPrevention();
   }
 
   return {

--- a/FlowPluginsTs/CommunityFlowPlugins/tools/waitTimeout/1.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/tools/waitTimeout/1.0.0/index.ts
@@ -82,23 +82,19 @@ const plugin = async (args: IpluginInputArgs): Promise<IpluginOutputArgs> => {
   args.jobLog(`Waiting for ${waitTime} milliseconds`);
 
   let finished = false;
-  let loggingTimeout: ReturnType<typeof setTimeout> | undefined;
 
   const logWait = () => {
     if (!finished) {
       args.jobLog('Waiting...');
-      loggingTimeout = setTimeout(logWait, 5000);
+      setTimeout(logWait, 5000);
     }
   };
 
   logWait();
 
-  try {
-    await new Promise((resolve) => setTimeout(resolve, waitTime));
-  } finally {
-    finished = true;
-    if (loggingTimeout) clearTimeout(loggingTimeout);
-  }
+  await new Promise((resolve) => setTimeout(resolve, waitTime));
+
+  finished = true;
 
   return {
     outputFileObj: args.inputFileObj,

--- a/tests/Community/Tdarr_Plugin_e5c3_CnT_Keep_Preferred_Audio.js
+++ b/tests/Community/Tdarr_Plugin_e5c3_CnT_Keep_Preferred_Audio.js
@@ -1,12 +1,6 @@
 /* eslint max-len: 0 */
 const _ = require('lodash');
 const run = require('../helpers/run');
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
-
-const specialLogHome = fs.mkdtempSync(path.join(os.tmpdir(), 'tdarr-cnt-audio-'));
-fs.mkdirSync(path.join(specialLogHome, 'Tdarr'));
 
 const tests = [
   {
@@ -93,27 +87,6 @@ const tests = [
         + 'Found wanted eng: 5\n'
         + 'Found unwanted audio\n'
         + 'It will be removed\n',
-    },
-  },
-  {
-    input: {
-      file: _.cloneDeep(require('../sampleData/media/sampleH264_2.json')),
-      librarySettings: {},
-      inputs: {
-        languages: 'eng',
-        special: 'eng',
-        container: 'mp4',
-      },
-      otherArguments: {
-        homePath: specialLogHome,
-      },
-    },
-    output: 'h264\n',
-    outputModify: () => {
-      const logPath = path.join(specialLogHome, 'Tdarr', 'special_audio_eng.txt');
-      const text = fs.readFileSync(logPath, 'utf8');
-      fs.rmSync(specialLogHome, { recursive: true, force: true });
-      return text;
     },
   },
 ];

--- a/tests/FlowPlugins/CommunityFlowPlugins/automations/detectNonTdarrNvenc/1.0.0/index.test.ts
+++ b/tests/FlowPlugins/CommunityFlowPlugins/automations/detectNonTdarrNvenc/1.0.0/index.test.ts
@@ -50,14 +50,7 @@ describe('detectNonTdarrNvenc Plugin', () => {
     jest.useFakeTimers({ doNotFake: ['setImmediate'] });
     mockAxiosGet = jest.fn();
     mockExecFileSync.mockReset();
-    mockExec.mockReset().mockImplementation((
-      _command: string,
-      _options: unknown,
-      callback: (err: unknown) => void,
-    ) => {
-      callback(null);
-      return {};
-    });
+    mockExec.mockReset();
 
     baseArgs = {
       inputs: {
@@ -257,41 +250,6 @@ describe('detectNonTdarrNvenc Plugin', () => {
     expect(baseArgs.jobLog).toHaveBeenCalledWith(
       expect.stringContaining('Restoring priority to normal on exit'),
     );
-  });
-
-  it('should not resolve until final priority commands complete', async () => {
-    mockNoOtherWorkers();
-    mockExecFileSync.mockReturnValue(pmonWithNvenc);
-    const callbacks: Array<(err: unknown) => void> = [];
-    mockExec.mockImplementation((
-      _command: string,
-      _options: unknown,
-      callback: (err: unknown) => void,
-    ) => {
-      callbacks.push(callback);
-      return {};
-    });
-
-    let resolved = false;
-    const pluginPromise = plugin(baseArgs).then((result) => {
-      resolved = true;
-      return result;
-    });
-    await flush();
-    await advanceOnePoll();
-
-    expect(callbacks.length).toBe(2);
-    expect(resolved).toBe(false);
-    callbacks.splice(0).forEach((callback) => callback(null));
-    await flush();
-    for (let i = 0; i < 2; i += 1) {
-      await advanceOnePoll(); // eslint-disable-line no-await-in-loop
-    }
-    expect(callbacks.length).toBe(2);
-    expect(resolved).toBe(false);
-    callbacks.splice(0).forEach((callback) => callback(null));
-    await pluginPromise;
-    expect(resolved).toBe(true);
   });
 
   describe('Priority on Windows', () => {

--- a/tests/FlowPlugins/CommunityFlowPlugins/automations/preventSleepWhileEncoding/1.0.0/index.test.ts
+++ b/tests/FlowPlugins/CommunityFlowPlugins/automations/preventSleepWhileEncoding/1.0.0/index.test.ts
@@ -1,4 +1,3 @@
-import { EventEmitter } from 'events';
 import { plugin, details } from
   '../../../../../../FlowPluginsTs/CommunityFlowPlugins/automations/preventSleepWhileEncoding/1.0.0/index';
 import { IpluginInputArgs } from '../../../../../../FlowPluginsTs/FlowHelpers/1.0.0/interfaces/interfaces';
@@ -170,65 +169,6 @@ describe('preventSleepWhileEncoding Plugin', () => {
   });
 
   describe('Sleep Prevention', () => {
-    it('should wait for child exit after kill before resolving', async () => {
-      mockAxiosGet.mockResolvedValue({
-        data: { 123: { workers: { w1: { job: { jobId: 'my-job-1' } } } } },
-      });
-      const child = new EventEmitter() as EventEmitter & {
-        exitCode: number | null;
-        kill: jest.Mock;
-      };
-      child.exitCode = null;
-      child.kill = jest.fn(() => true);
-      mockSpawn.mockReturnValue(child);
-
-      let resolved = false;
-      const pluginPromise = plugin(baseArgs).then((result) => {
-        resolved = true;
-        return result;
-      });
-      await flush();
-      for (let i = 0; i < 3; i += 1) {
-        await advanceOnePoll(); // eslint-disable-line no-await-in-loop
-      }
-
-      expect(child.kill).toHaveBeenCalled();
-      expect(resolved).toBe(false);
-      child.emit('close', 0);
-      await pluginPromise;
-      expect(resolved).toBe(true);
-    });
-
-    it('should bound cleanup when the child never reports exit', async () => {
-      mockAxiosGet.mockResolvedValue({
-        data: { 123: { workers: { w1: { job: { jobId: 'my-job-1' } } } } },
-      });
-      const child = new EventEmitter() as EventEmitter & {
-        exitCode: number | null;
-        kill: jest.Mock;
-      };
-      child.exitCode = null;
-      child.kill = jest.fn(() => true);
-      mockSpawn.mockReturnValue(child);
-
-      let resolved = false;
-      const pluginPromise = plugin(baseArgs).then((result) => {
-        resolved = true;
-        return result;
-      });
-      await flush();
-      for (let i = 0; i < 3; i += 1) {
-        await advanceOnePoll(); // eslint-disable-line no-await-in-loop
-      }
-
-      jest.advanceTimersByTime(4999);
-      await flush();
-      expect(resolved).toBe(false);
-      jest.advanceTimersByTime(1);
-      await pluginPromise;
-      expect(resolved).toBe(true);
-    });
-
     it('should start systemd-inhibit on linux', async () => {
       mockAxiosGet.mockResolvedValue({
         data: { 123: { workers: { w1: { job: { jobId: 'my-job-1' } } } } },

--- a/tests/FlowPlugins/CommunityFlowPlugins/tools/waitTimeout/1.0.0/index.test.ts
+++ b/tests/FlowPlugins/CommunityFlowPlugins/tools/waitTimeout/1.0.0/index.test.ts
@@ -136,7 +136,6 @@ describe('waitTimeout Plugin', () => {
       // Complete the wait
       jest.advanceTimersByTime(3000);
       await pluginPromise;
-      expect(jest.getTimerCount()).toBe(0);
 
       // Clear previous calls
       (baseArgs.jobLog as jest.Mock).mockClear();


### PR DESCRIPTION
## Summary

- Restores the previous timer and child-process behavior in the affected plugins.
- Restores the corresponding generated flow-plugin output and tests.

## Why

The runner completion behavior is handled by the application runtime, so plugin-specific timer changes are not needed.

## Validation

- Focused flow-plugin tests: 3 suites and 32 tests passed.
- Classic plugin test suite passed.