### PR TITLE
test: cover WMA Pro codec detection

### DIFF
--- a/tests/FlowPlugins/CommunityFlowPlugins/audio/checkAudioCodec/1.0.0/index.test.ts
+++ b/tests/FlowPlugins/CommunityFlowPlugins/audio/checkAudioCodec/1.0.0/index.test.ts
@@ -46,6 +46,7 @@ describe('checkAudioCodec Plugin', () => {
     it.each([
       'wmav1',
       'wmav2',
+      'wmapro',
     ])('should detect %s as WMA', (codec) => {
       baseArgs.inputs.codec = 'wma';
       if (baseArgs.inputFileObj.ffProbeData.streams?.[1]) {


### PR DESCRIPTION
## Summary

- Add `wmapro` to WMA codec regression coverage.
- Confirm the generic `wma` selection recognizes FFmpeg's WMA Pro codec name.

## Why

FFmpeg reports WMA Pro audio streams as `wmapro`. The codec-family matcher already handles it, but the regression matrix only covered `wmav1` and `wmav2`.

