### PR TITLE
fix: add missing h264_vaapi entry to hardware encoder list

### DIFF
--- a/FlowPluginsTs/FlowHelpers/1.0.0/hardwareUtils.ts
+++ b/FlowPluginsTs/FlowHelpers/1.0.0/hardwareUtils.ts
@@ -311,6 +311,13 @@ export const getEncoder = async ({
         filter: '',
       },
       {
+        encoder: 'h264_vaapi',
+        inputArgs: vaapiInputArgs,
+        outputArgs: [],
+        enabled: false,
+        filter: vaapiFilter,
+      },
+      {
         encoder: 'h264_rkmpp',
         enabled: false,
         inputArgs: [


### PR DESCRIPTION
## Problem

The `h264` encoder block in `getEncoder()` (`FlowPluginsTs/FlowHelpers/1.0.0/hardwareUtils.ts`) is missing a `h264_vaapi` entry, even though `hevc_vaapi` and `av1_vaapi` are both present and correctly configured for their respective codec blocks.

As a result, Tdarr Node's automatic hardware encoder detection never tests `h264_vaapi`. The encoder always falls back to `libx264` software encoding, even on systems where `h264_vaapi` works correctly via ffmpeg. In the encoder capability list shown in the Tdarr UI, this shows up as `h264_vaapi-true-false` (ffmpeg has the capability compiled in, but Tdarr's functional test never runs against it, so it's never marked as working).

## Fix

Added the missing `h264_vaapi` entry to the `h264` encoder block, following the exact same pattern already used for `hevc_vaapi` and `av1_vaapi` (reusing the existing `vaapiInputArgs` / `vaapiFilter` variables).

## Testing

Verified on an Intel Sandy Bridge (2nd Gen Core, HD Graphics 2000/3000) system running the legacy `i965` VAAPI driver:

- Before the fix: `h264_vaapi-true-false` in the encoder test output, Tdarr always falls back to `libx264`.
- After the fix: `h264_vaapi-true-true`, Tdarr correctly detects and enables `h264_vaapi` for transcoding jobs.

Confirmed the underlying ffmpeg command Tdarr generates for this encoder (`-hwaccel vaapi -hwaccel_device /dev/dri/renderD128 -hwaccel_output_format vaapi -vf format=nv12,hwupload -c:v h264_vaapi`) runs successfully outside of Tdarr as well, ruling out a hardware/driver issue — the entry was simply missing from the encoder list.

Ran `npm run lint:fix`, `npm run checkPlugins`, and `npm run test` locally — all pass with no new warnings or errors introduced by this change.