### PR TITLE
Add hardware decode inputArgs for av1_nvenc and av1_qsv

### DIFF
--- a/FlowPlugins/FlowHelpers/1.0.0/hardwareUtils.js
+++ b/FlowPlugins/FlowHelpers/1.0.0/hardwareUtils.js
@@ -355,7 +355,10 @@ var getEncoder = function (_a) { return __awaiter(void 0, [_a], void 0, function
                     {
                         encoder: 'av1_nvenc',
                         enabled: false,
-                        inputArgs: [],
+                        inputArgs: [
+                            '-hwaccel',
+                            'cuda',
+                        ],
                         outputArgs: [],
                         filter: '',
                     },
@@ -369,7 +372,12 @@ var getEncoder = function (_a) { return __awaiter(void 0, [_a], void 0, function
                     {
                         encoder: 'av1_qsv',
                         enabled: false,
-                        inputArgs: [],
+                        inputArgs: [
+                            '-hwaccel',
+                            'qsv',
+                            '-hwaccel_output_format',
+                            'qsv',
+                        ],
                         outputArgs: [],
                         filter: '',
                     },

--- a/FlowPluginsTs/FlowHelpers/1.0.0/hardwareUtils.ts
+++ b/FlowPluginsTs/FlowHelpers/1.0.0/hardwareUtils.ts
@@ -335,7 +335,10 @@ export const getEncoder = async ({
       {
         encoder: 'av1_nvenc',
         enabled: false,
-        inputArgs: [],
+        inputArgs: [
+          '-hwaccel',
+          'cuda',
+        ],
         outputArgs: [],
         filter: '',
       },
@@ -349,7 +352,12 @@ export const getEncoder = async ({
       {
         encoder: 'av1_qsv',
         enabled: false,
-        inputArgs: [],
+        inputArgs: [
+          '-hwaccel',
+          'qsv',
+          '-hwaccel_output_format',
+          'qsv',
+        ],
         outputArgs: [],
         filter: '',
       },


### PR DESCRIPTION
Fixes #1017

`hevc_nvenc`/`h264_nvenc` and `hevc_qsv`/`h264_qsv` inject `-hwaccel` input args so the source is hardware-decoded, but the AV1 entries shipped with empty `inputArgs`. As a result, any AV1 hardware-encode flow software-decodes the source (CPU pinned at 100%) while NVDEC/QSV sit idle.

This gives `av1_nvenc` and `av1_qsv` the same inputArgs as their HEVC/H.264 counterparts:
- `av1_nvenc`: `-hwaccel cuda`
- `av1_qsv`: `-hwaccel qsv -hwaccel_output_format qsv`

The compiled `FlowPlugins/FlowHelpers/1.0.0/hardwareUtils.js` was regenerated with `npx tsc`; repo tests pass (`node ./tests/runTests.js` → "No errors encountered!").

Verified on RTX 4090 (driver 610.57.04, Tdarr 2.86.01): adding `-hwaccel cuda` to an AV1 flow drops CPU decode usage to near zero.