### PR TITLE
fix: VAAPI encoding fails with Hardware Decoding disabled (encoderProperties.filter never applied)

### DIFF
--- a/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandSetVideoEncoder/1.0.0/index.js
+++ b/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandSetVideoEncoder/1.0.0/index.js
@@ -213,10 +213,10 @@ var details = function () { return ({
 exports.details = details;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 var plugin = function (args) { return __awaiter(void 0, void 0, void 0, function () {
-    var lib, hardwareDecoding, hardwareType, i, stream, targetCodec, _a, ffmpegPresetEnabled, ffmpegQualityEnabled, ffmpegPreset, ffmpegQuality, forceEncoding, hardwarEncoding, encoderProperties, presetToUse, nvencPresetMap, amfPresetMap;
-    var _b, _c;
-    return __generator(this, function (_d) {
-        switch (_d.label) {
+    var lib, hardwareDecoding, hardwareType, i, stream, targetCodec, _a, ffmpegPresetEnabled, ffmpegQualityEnabled, ffmpegPreset, ffmpegQuality, forceEncoding, hardwarEncoding, encoderProperties, presetToUse, nvencPresetMap, amfPresetMap, deviceIdx, device;
+    var _b, _c, _d;
+    return __generator(this, function (_e) {
+        switch (_e.label) {
             case 0:
                 lib = require('../../../../../methods/lib')();
                 // eslint-disable-next-line @typescript-eslint/no-unused-vars,no-param-reassign
@@ -226,7 +226,7 @@ var plugin = function (args) { return __awaiter(void 0, void 0, void 0, function
                 hardwareType = String(args.inputs.hardwareType);
                 args.variables.ffmpegCommand.hardwareDecoding = hardwareDecoding;
                 i = 0;
-                _d.label = 1;
+                _e.label = 1;
             case 1:
                 if (!(i < args.variables.ffmpegCommand.streams.length)) return [3 /*break*/, 4];
                 stream = args.variables.ffmpegCommand.streams[i];
@@ -247,7 +247,7 @@ var plugin = function (args) { return __awaiter(void 0, void 0, void 0, function
                         args: args,
                     })];
             case 2:
-                encoderProperties = _d.sent();
+                encoderProperties = _e.sent();
                 stream.outputArgs.push('-c:{outputIndex}', encoderProperties.encoder);
                 if (ffmpegQualityEnabled) {
                     if (encoderProperties.isGpu) {
@@ -311,10 +311,18 @@ var plugin = function (args) { return __awaiter(void 0, void 0, void 0, function
                 if (hardwareDecoding) {
                     (_b = stream.inputArgs).push.apply(_b, encoderProperties.inputArgs);
                 }
-                if (encoderProperties.outputArgs) {
-                    (_c = stream.outputArgs).push.apply(_c, encoderProperties.outputArgs);
+                else if (encoderProperties.filter) {
+                    deviceIdx = encoderProperties.inputArgs.indexOf('-hwaccel_device');
+                    device = deviceIdx !== -1 ? encoderProperties.inputArgs[deviceIdx + 1] : undefined;
+                    if (device) {
+                        stream.inputArgs.push('-vaapi_device', device);
+                    }
+                    (_c = stream.outputArgs).push.apply(_c, encoderProperties.filter.split(' '));
                 }
-                _d.label = 3;
+                if (encoderProperties.outputArgs) {
+                    (_d = stream.outputArgs).push.apply(_d, encoderProperties.outputArgs);
+                }
+                _e.label = 3;
             case 3:
                 i += 1;
                 return [3 /*break*/, 1];

--- a/FlowPluginsTs/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandSetVideoEncoder/1.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandSetVideoEncoder/1.0.0/index.ts
@@ -276,6 +276,20 @@ const plugin = async (args: IpluginInputArgs): Promise<IpluginOutputArgs> => {
 
         if (hardwareDecoding) {
           stream.inputArgs.push(...encoderProperties.inputArgs);
+        } else if (encoderProperties.filter) {
+          // Hardware encoding without hardware decoding (e.g. VAAPI encode-only):
+          // encoderProperties.inputArgs is skipped above since it forces hwaccel
+          // decode, but the encoder still needs a device context for its filter
+          // (hwupload etc.) to target. Reuse the device path hardwareUtils already
+          // resolved into inputArgs (via -hwaccel_device) and establish it
+          // standalone with -vaapi_device, which - unlike -hwaccel_device - creates
+          // a usable device reference without requiring -hwaccel.
+          const deviceIdx = encoderProperties.inputArgs.indexOf('-hwaccel_device');
+          const device = deviceIdx !== -1 ? encoderProperties.inputArgs[deviceIdx + 1] : undefined;
+          if (device) {
+            stream.inputArgs.push('-vaapi_device', device);
+          }
+          stream.outputArgs.push(...encoderProperties.filter.split(' '));
         }
 
         if (encoderProperties.outputArgs) {

--- a/FlowPluginsTs/FlowHelpers/1.0.0/hardwareUtils.ts
+++ b/FlowPluginsTs/FlowHelpers/1.0.0/hardwareUtils.ts
@@ -192,6 +192,7 @@ export interface IgetEncoder {
   outputArgs: string[],
   isGpu: boolean,
   enabledDevices: IgpuEncoder[],
+  filter?: string,
 }
 
 export const getEncoder = async ({

--- a/tests/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandSetVideoEncoder/1.0.0/index.test.ts
+++ b/tests/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandSetVideoEncoder/1.0.0/index.test.ts
@@ -253,6 +253,73 @@ describe('ffmpegCommandSetVideoEncoder Plugin', () => {
         args: baseArgs,
       });
     });
+
+    it('should establish a standalone VAAPI device and apply the upload filter '
+      + 'when hardware decoding is disabled but the encoder needs a filter', async () => {
+      baseArgs.inputs.hardwareType = 'vaapi';
+      baseArgs.inputs.hardwareDecoding = false;
+      mockGetEncoder.mockResolvedValue({
+        encoder: 'hevc_vaapi',
+        inputArgs: ['-hwaccel', 'vaapi', '-hwaccel_device', '/dev/dri/renderD128', '-hwaccel_output_format', 'vaapi'],
+        outputArgs: [],
+        isGpu: true,
+        enabledDevices: [],
+        filter: '-vf format=nv12,hwupload',
+      });
+
+      const result = await plugin(baseArgs);
+
+      const videoStream = result.variables.ffmpegCommand.streams[0];
+      // Should NOT include the full hwaccel-decode args (that would force hardware
+      // decode, contradicting hardwareDecoding=false) - only a standalone device ref.
+      expect(videoStream.inputArgs).toEqual(['-vaapi_device', '/dev/dri/renderD128']);
+      // The filter that getEncoder() computes but the plugin previously never
+      // applied should now reach outputArgs, split into separate tokens.
+      expect(videoStream.outputArgs).toContain('-vf');
+      expect(videoStream.outputArgs).toContain('format=nv12,hwupload');
+    });
+
+    it('should not add a device or filter when hardware decoding is disabled '
+      + 'and the encoder has no filter (e.g. NVENC)', async () => {
+      baseArgs.inputs.hardwareType = 'nvenc';
+      baseArgs.inputs.hardwareDecoding = false;
+      mockGetEncoder.mockResolvedValue({
+        encoder: 'hevc_nvenc',
+        inputArgs: ['-hwaccel', 'cuda'],
+        outputArgs: [],
+        isGpu: true,
+        enabledDevices: [],
+        filter: '',
+      });
+
+      const result = await plugin(baseArgs);
+
+      const videoStream = result.variables.ffmpegCommand.streams[0];
+      expect(videoStream.inputArgs).toHaveLength(0);
+      expect(videoStream.outputArgs).not.toContain('-vf');
+    });
+
+    it('should not apply the filter when hardware decoding is enabled '
+      + '(hwaccel_output_format already produces the right frame format)', async () => {
+      baseArgs.inputs.hardwareType = 'vaapi';
+      baseArgs.inputs.hardwareDecoding = true;
+      mockGetEncoder.mockResolvedValue({
+        encoder: 'hevc_vaapi',
+        inputArgs: ['-hwaccel', 'vaapi', '-hwaccel_device', '/dev/dri/renderD128', '-hwaccel_output_format', 'vaapi'],
+        outputArgs: [],
+        isGpu: true,
+        enabledDevices: [],
+        filter: '-vf format=nv12,hwupload',
+      });
+
+      const result = await plugin(baseArgs);
+
+      const videoStream = result.variables.ffmpegCommand.streams[0];
+      expect(videoStream.inputArgs).toEqual([
+        '-hwaccel', 'vaapi', '-hwaccel_device', '/dev/dri/renderD128', '-hwaccel_output_format', 'vaapi',
+      ]);
+      expect(videoStream.outputArgs).not.toContain('-vf');
+    });
   });
 
   describe('Quality and Preset Settings', () => {


### PR DESCRIPTION
Fixes #1022.

`getEncoder()` computes a `filter` (`-vf format=nv12,hwupload`) for the VAAPI encoder entry, but `ffmpegCommandSetVideoEncoder` never reads or applies it — it's dead code. This is harmless with `Hardware Decoding: true`, since `-hwaccel_output_format vaapi` already produces correctly-formatted hardware-surface frames and no filter is needed (confirmed working as-is). But with `Hardware Decoding: false`, `inputArgs` (which carries all the `-hwaccel`/`-hwaccel_device`/`-hwaccel_output_format` setup) is also skipped, gated behind the same check — so the real generated command ends up with **no VAAPI device declared anywhere**, and encoding fails immediately.

## Fix

Establishes a standalone device via `-vaapi_device` (reusing the device path `hardwareUtils` already resolves into `inputArgs`, since `-hwaccel_device` alone — without `-hwaccel` — doesn't create a usable device reference) and applies the filter, but only on the `Hardware Decoding: false` path. The `true` path is untouched.

## Verification

- Real hardware repro/fix, not just unit tests — see #1022 for the full job-report evidence (actual spawned commands and ffmpeg stderr, pulled via `/api/v2/job-reports/:jobId`) showing the broken command before this change and a successful `Transcode success` job after applying the equivalent fix manually.
- `tsc` compiles clean, `eslint` clean.
- All existing tests pass (35/35), plus 3 new tests covering: the fixed `Hardware Decoding: false` + VAAPI case, that non-VAAPI encoders without a `filter` are unaffected, and a regression check that `Hardware Decoding: true` behavior is unchanged.