### PR TITLE
fix: include exit code and output tail in ffmpegCommandExecute's thrown error

### DIFF
--- a/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandExecute/1.0.0/index.js
+++ b/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandExecute/1.0.0/index.js
@@ -115,7 +115,7 @@ var shouldAddCopyCodec = function (outputArgs) { return (outputArgs.length === 0
     || (!hasCodecOutputArg(outputArgs) && hasOnlyCopyCompatibleOutputArgs(outputArgs))); };
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 var plugin = function (args) { return __awaiter(void 0, void 0, void 0, function () {
-    var lib, cliArgs, _a, shouldProcess, streams, inputArgs, _loop_1, i, idx, outputFilePath, spawnArgs, cli, res;
+    var lib, cliArgs, _a, shouldProcess, streams, inputArgs, _loop_1, i, idx, outputFilePath, spawnArgs, cli, res, outputTail;
     return __generator(this, function (_b) {
         switch (_b.label) {
             case 0:
@@ -207,8 +207,15 @@ var plugin = function (args) { return __awaiter(void 0, void 0, void 0, function
             case 1:
                 res = _b.sent();
                 if (res.cliExitCode !== 0) {
-                    args.jobLog('Running FFmpeg failed');
-                    throw new Error('FFmpeg failed');
+                    outputTail = (res.errorLogFull || [])
+                        .join('')
+                        .split('\n')
+                        .map(function (line) { return line.trim(); })
+                        .filter(function (line) { return line !== ''; })
+                        .slice(-20)
+                        .join('\n');
+                    args.jobLog("Running FFmpeg failed with exit code ".concat(res.cliExitCode));
+                    throw new Error("FFmpeg failed with exit code ".concat(res.cliExitCode).concat(outputTail ? ":\n".concat(outputTail) : ''));
                 }
                 args.logOutcome('tSuc');
                 // eslint-disable-next-line no-param-reassign

--- a/FlowPluginsTs/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandExecute/1.0.0/index.ts
+++ b/FlowPluginsTs/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandExecute/1.0.0/index.ts
@@ -208,8 +208,24 @@ const plugin = async (args: IpluginInputArgs): Promise<IpluginOutputArgs> => {
   const res = await cli.runCli();
 
   if (res.cliExitCode !== 0) {
-    args.jobLog('Running FFmpeg failed');
-    throw new Error('FFmpeg failed');
+    // The full output is already captured in res.errorLogFull and logged via
+    // jobLog inside runCli, but the thrown error itself previously carried no
+    // detail - meaning the exit code and actual ffmpeg output weren't visible
+    // at the point of failure without separately searching the job log for it.
+    // Include a tail of the real output directly in the error so it's visible
+    // wherever this exception surfaces (e.g. in the job report's stack trace).
+    const outputTail = (res.errorLogFull || [])
+      .join('')
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line !== '')
+      .slice(-20)
+      .join('\n');
+
+    args.jobLog(`Running FFmpeg failed with exit code ${res.cliExitCode}`);
+    throw new Error(
+      `FFmpeg failed with exit code ${res.cliExitCode}${outputTail ? `:\n${outputTail}` : ''}`,
+    );
   }
 
   args.logOutcome('tSuc');

--- a/tests/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandExecute/1.0.0/index.test.ts
+++ b/tests/FlowPlugins/CommunityFlowPlugins/ffmpegCommand/ffmpegCommandExecute/1.0.0/index.test.ts
@@ -405,15 +405,30 @@ describe('ffmpegCommandExecute Plugin', () => {
       await expect(plugin(baseArgs)).rejects.toThrow(expectedError);
     });
 
-    it('should throw error when CLI fails', async () => {
+    it('should throw error with exit code and output tail when CLI fails', async () => {
       // Mock the CLI to return failure
       const { CLI } = require('../../../../../../FlowPluginsTs/FlowHelpers/1.0.0/cliUtils');
       CLI.mockImplementation(() => ({
-        runCli: jest.fn().mockResolvedValue({ cliExitCode: 1 }),
+        runCli: jest.fn().mockResolvedValue({
+          cliExitCode: 1,
+          errorLogFull: ['Unknown encoder ', "'hevc_bogus'\n", 'Conversion failed!\n'],
+        }),
       }));
 
-      await expect(plugin(baseArgs)).rejects.toThrow('FFmpeg failed');
-      expect(baseArgs.jobLog).toHaveBeenCalledWith('Running FFmpeg failed');
+      await expect(plugin(baseArgs)).rejects.toThrow(
+        "FFmpeg failed with exit code 1:\nUnknown encoder 'hevc_bogus'\nConversion failed!",
+      );
+      expect(baseArgs.jobLog).toHaveBeenCalledWith('Running FFmpeg failed with exit code 1');
+    });
+
+    it('should throw error with just the exit code when no output was captured', async () => {
+      const { CLI } = require('../../../../../../FlowPluginsTs/FlowHelpers/1.0.0/cliUtils');
+      CLI.mockImplementation(() => ({
+        runCli: jest.fn().mockResolvedValue({ cliExitCode: 1, errorLogFull: [] }),
+      }));
+
+      await expect(plugin(baseArgs)).rejects.toThrow('FFmpeg failed with exit code 1');
+      await expect(plugin(baseArgs)).rejects.not.toThrow(/:\n/);
     });
   });
 


### PR DESCRIPTION
Fixes #588.

## The gap
`ffmpegCommandExecute`'s `cli.runCli()` already returns `cliExitCode` and `errorLogFull` (the captured ffmpeg stdout/stderr), but on failure the plugin discarded both and just threw a bare `new Error('FFmpeg failed')`. That's the string that ends up in the job's failure banner/report — the thing most visible when a job actually fails.

## Note on scope vs. the original issue
The issue's original framing was "doesn't print out any information for someone to debug it" / "it might even log the full log today, but I can't figure out where the config is." That config does exist — the "Log full FFmpeg/HandBrake output" toggle (`args.logFullCliOutput`, plumbed into `CLI`). Reading `cliUtils.ts`'s `runCli()`:
- with it **on**, every stdout/stderr chunk is logged live via `jobLog` as ffmpeg runs
- with it **off** (default), nothing streams live, but the last 1000 captured output chunks get dumped into the job log in one shot right after the process exits

So the full output does land in the job log either way — that part of the original report is a bit stale. But the reporter's own follow-up comment confirms the actual, still-live problem precisely: *"The logs that tdarr gave me from this flow plugin did not help me actually debug this."* That's because the **thrown `Error`** — the thing that actually surfaces in the job's failure report/notification — carried none of that detail, regardless of the logging toggle.

## The fix
On failure, the thrown error now includes the exit code and a trailing tail (last 20 non-empty lines) of the actual captured ffmpeg output, e.g.:

```
FFmpeg failed with exit code 1:
Unknown encoder 'hevc_bogus'
Conversion failed!
```

instead of just `FFmpeg failed`. `jobLog` also gets the exit code for consistency. No behavior change when there's no captured output (falls back to just the exit code).

## Testing
- Updated the existing "should throw error when CLI fails" test to cover the new message content, and added a case for when no output was captured.
- `tsc`, `eslint`, and the full `jest` suite (98 suites / 1618 tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)