### PR TITLE
fix: drop WebVTT subtitle streams instead of crashing in Migz1FFMPEG and Migz3CleanAudio

### DIFF
--- a/Community/Tdarr_Plugin_MC93_Migz1FFMPEG.js
+++ b/Community/Tdarr_Plugin_MC93_Migz1FFMPEG.js
@@ -243,6 +243,10 @@ const plugin = (file, librarySettings, inputs, otherArguments) => {
                           .toLowerCase() === 'eia_608'
                         || file.ffProbeData.streams[i].codec_name
                           .toLowerCase() === 'timed_id3'
+                        // ffmpeg cannot mux S_TEXT/WEBVTT into mkv ("Unknown/unsupported AVCodecID
+                        // S_TEXT/WEBVTT"), so -c:s copy fails outright. Drop it instead.
+                        || file.ffProbeData.streams[i].codec_name
+                          .toLowerCase() === 'webvtt'
           ) {
             extraArguments += `-map -0:${i} `;
           }
@@ -263,6 +267,9 @@ const plugin = (file, librarySettings, inputs, otherArguments) => {
                           .toLowerCase() === 'subrip'
                         || file.ffProbeData.streams[i].codec_name
                           .toLowerCase() === 'timed_id3'
+                        // ffmpeg cannot mux S_TEXT/WEBVTT into mp4 either - same failure as the mkv branch.
+                        || file.ffProbeData.streams[i].codec_name
+                          .toLowerCase() === 'webvtt'
           ) {
             extraArguments += `-map -0:${i} `;
           }

--- a/Community/Tdarr_Plugin_MC93_Migz3CleanAudio.js
+++ b/Community/Tdarr_Plugin_MC93_Migz3CleanAudio.js
@@ -176,6 +176,23 @@ const plugin = (file, librarySettings, inputs, otherArguments) => {
       ffmpegCommandInsert += `-map -0:a:${audioIdx} `;
       convert = true;
     }
+
+    // Catch error here incase codec_type/codec_name metadata is completely missing.
+    try {
+      // ffmpeg cannot mux S_TEXT/WEBVTT subtitles ("Unknown/unsupported AVCodecID S_TEXT/WEBVTT"),
+      // so the "-c copy" this plugin uses whenever it needs to touch the file for another reason
+      // would fail outright if one is present. Drop it rather than crash. Only relevant once
+      // "convert" is already true for another reason - if nothing else needs changing, this
+      // plugin doesn't touch the file at all, so a WebVTT stream alone won't trigger this branch.
+      if (
+        file.ffProbeData.streams[i].codec_type.toLowerCase() === 'subtitle'
+        && file.ffProbeData.streams[i].codec_name.toLowerCase() === 'webvtt'
+      ) {
+        ffmpegCommandInsert += `-map -0:${i} `;
+      }
+    } catch (err) {
+      // Error
+    }
     // Check if inputs.tag_language has something entered
     // (Entered means user actually wants something to happen, empty would disable this)
     // AND checks that stream is audio.

--- a/tests/Community/Tdarr_Plugin_MC93_Migz1FFMPEG.js
+++ b/tests/Community/Tdarr_Plugin_MC93_Migz1FFMPEG.js
@@ -276,4 +276,81 @@ const tests = [
   },
 ];
 
+// https://github.com/HaveAGitGat/Tdarr_Plugins/issues/703
+// A WebVTT subtitle stream (Matroska CodecID S_TEXT/WEBVTT, reported by ffprobe as codec_name
+// "webvtt") makes ffmpeg fail outright with "Unknown/unsupported AVCodecID S_TEXT/WEBVTT" when
+// copied as-is. force_conform should drop it, same as it already does for mov_text/eia_608/etc.
+const webvttSubtitleStream = {
+  index: 2,
+  codec_name: 'webvtt',
+  codec_long_name: 'WebVTT subtitle',
+  codec_type: 'subtitle',
+  codec_tag_string: '[0][0][0][0]',
+  codec_tag: '0x0000',
+  r_frame_rate: '0/0',
+  avg_frame_rate: '0/0',
+  time_base: '1/1000',
+  tags: {
+    language: 'eng',
+  },
+};
+
+const sampleH264WithWebvttSubtitle = _.cloneDeep(require('../sampleData/media/sampleH264_1.json'));
+
+sampleH264WithWebvttSubtitle.ffProbeData.streams.push(webvttSubtitleStream);
+
+tests.push(
+  {
+    input: {
+      file: _.cloneDeep(sampleH264WithWebvttSubtitle),
+      librarySettings: {},
+      inputs: {
+        force_conform: 'true',
+      },
+      otherArguments: {},
+    },
+    output: {
+      processFile: true,
+      preset: '-hwaccel cuda -hwaccel_output_format cuda, -map 0 -c:v hevc_nvenc -cq:v 19 -b:v 758k -minrate 530k -maxrate 985k -bufsize 1517k -spatial_aq:v 1 -rc-lookahead:v 32 -c:a copy -c:s copy -max_muxing_queue_size 9999 -map -0:d -map -0:2 ',
+      handBrakeMode: false,
+      FFmpegMode: true,
+      reQueueAfter: true,
+      infoLog: 'Container for output selected as mkv. \n'
+        + 'Current bitrate = 1517 \n'
+        + 'Bitrate settings: \n'
+        + 'Target = 758 \n'
+        + 'Minimum = 530 \n'
+        + 'Maximum = 985 \n'
+        + 'File is not hevc or vp9. Transcoding. \n',
+      container: '.mkv',
+    },
+  },
+  {
+    input: {
+      file: _.cloneDeep(sampleH264WithWebvttSubtitle),
+      librarySettings: {},
+      inputs: {
+        container: 'mp4',
+        force_conform: 'true',
+      },
+      otherArguments: {},
+    },
+    output: {
+      processFile: true,
+      preset: '-hwaccel cuda -hwaccel_output_format cuda, -map 0 -c:v hevc_nvenc -cq:v 19 -b:v 758k -minrate 530k -maxrate 985k -bufsize 1517k -spatial_aq:v 1 -rc-lookahead:v 32 -c:a copy -c:s copy -max_muxing_queue_size 9999 -map -0:2 ',
+      handBrakeMode: false,
+      FFmpegMode: true,
+      reQueueAfter: true,
+      infoLog: 'Container for output selected as mp4. \n'
+        + 'Current bitrate = 1517 \n'
+        + 'Bitrate settings: \n'
+        + 'Target = 758 \n'
+        + 'Minimum = 530 \n'
+        + 'Maximum = 985 \n'
+        + 'File is not hevc or vp9. Transcoding. \n',
+      container: '.mp4',
+    },
+  },
+);
+
 void run(tests);

--- a/tests/Community/Tdarr_Plugin_MC93_Migz3CleanAudio.js
+++ b/tests/Community/Tdarr_Plugin_MC93_Migz3CleanAudio.js
@@ -95,4 +95,69 @@ const tests = [
   },
 ];
 
+// https://github.com/HaveAGitGat/Tdarr_Plugins/issues/619
+// A WebVTT subtitle stream (Matroska CodecID S_TEXT/WEBVTT, reported by ffprobe as codec_name
+// "webvtt") makes ffmpeg fail outright with "Unknown/unsupported AVCodecID S_TEXT/WEBVTT" when
+// swept up by this plugin's "-c copy". It should be dropped whenever the plugin already needs
+// to touch the file for another reason - same scenario as the existing "language: eng" test,
+// just with sample 2's subrip subtitle (stream 6) swapped for webvtt.
+tests.push(
+  {
+    input: {
+      file: (() => {
+        const file = _.cloneDeep(require('../sampleData/media/sampleH264_2.json'));
+        file.ffProbeData.streams[6].codec_name = 'webvtt';
+        return file;
+      })(),
+      librarySettings: {},
+      inputs: {
+        language: 'eng',
+      },
+      otherArguments: {},
+    },
+    output: {
+      processFile: true,
+      preset: ', -map 0 -map -0:a:3 -map -0:6  -c copy -max_muxing_queue_size 9999',
+      container: '.mkv',
+      handBrakeMode: false,
+      FFmpegMode: true,
+      reQueueAfter: true,
+      infoLog: '☒Audio stream 0:a:3 has unwanted language tag fre, removing. \n',
+    },
+  },
+  {
+    // Regression guard: a WebVTT subtitle alone, with nothing else for the plugin to change,
+    // should NOT trigger a conversion - this plugin only touches the file when it already has
+    // another reason to (audio language/commentary/tagging). sampleH264_1 has no audio issues
+    // under these inputs, so this should stay a no-op exactly like the first test in this file.
+    input: {
+      file: (() => {
+        const file = _.cloneDeep(require('../sampleData/media/sampleH264_1.json'));
+        file.ffProbeData.streams.push({
+          index: 2,
+          codec_name: 'webvtt',
+          codec_long_name: 'WebVTT subtitle',
+          codec_type: 'subtitle',
+          tags: {
+            language: 'eng',
+          },
+        });
+        return file;
+      })(),
+      librarySettings: {},
+      inputs: {},
+      otherArguments: {},
+    },
+    output: {
+      processFile: false,
+      preset: '',
+      container: '.mp4',
+      handBrakeMode: false,
+      FFmpegMode: true,
+      reQueueAfter: false,
+      infoLog: "☑File doesn't contain audio tracks which are unwanted or that require tagging.\n",
+    },
+  },
+);
+
 void run(tests);


### PR DESCRIPTION
Fixes #703. Fixes #619.

## The problem
ffmpeg cannot mux an `S_TEXT/WEBVTT` subtitle stream (ffprobe reports it as `codec_name: "webvtt"`) into mkv or mp4, and fails outright:

```
Unknown/unsupported AVCodecID S_TEXT/WEBVTT.
Subtitle codec 0 is not supported.
```

Both `Migz1FFMPEG` and `Migz3CleanAudio` do a blanket `-c:s copy`/`-c copy` whenever they decide to touch a file, so any source with a WebVTT subtitle track (common on some WEBDL releases) makes the job fail — confirmed against both issues' actual job logs, which show the identical ffmpeg error.

## Prior art in this repo
`Tdarr_Plugin_JB69_JBHEVCQSV_MinimalFile` already works around this exact problem by detecting `S_TEXT/WEBVTT` (via MediaInfo) and dropping the stream rather than copying it. This PR applies the same drop-don't-crash approach to the two plugins actually named in the bug reports, using ffprobe's `codec_name === 'webvtt'` instead (avoids requiring a MediaInfo scan, which neither plugin currently enables).

## The fix
- **Migz1FFMPEG**: added `webvtt` to the existing `force_conform` drop-lists (alongside `mov_text`/`eia_608`/`subrip`/`timed_id3`/`hdmv_pgs_subtitle`) for both the mkv and mp4 branches — same established pattern, just extended to cover this codec too.
- **Migz3CleanAudio**: drops any `webvtt` subtitle stream whenever the plugin has already decided to touch the file for an audio-related reason (language/commentary/tagging). This plugin has no `force_conform`-style toggle, so there's nowhere else to gate it — but it's still scoped tightly: a WebVTT stream on its own does **not** trigger a conversion, matching the plugin's existing minimal-intervention design (a file with no audio issues stays untouched, same as before).

## Testing
- New test cases for both plugins using a WebVTT subtitle stream, including a regression guard on `Migz3CleanAudio` confirming a WebVTT stream alone (no other audio changes needed) still leaves the file untouched.
- Full classic-plugin suite (`node ./tests/runTests.js`) passes with no errors.
- `eslint` clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)